### PR TITLE
[ChatStateLayer] MessageSearch and MessageSearchState

### DIFF
--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -200,8 +200,8 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
         resetMessagesObserver()
 
         messageUpdater.search(query: query, policy: .replace) { result in
-            if case let .success(payload) = result {
-                self.updateNextPageCursor(with: payload)
+            if case let .success(response) = result {
+                self.updateNextPageCursor(with: response.payload)
             }
 
             let error = result.error
@@ -236,8 +236,8 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
         }
 
         messageUpdater.search(query: updatedQuery) { result in
-            if case let .success(payload) = result {
-                self.updateNextPageCursor(with: payload)
+            if case let .success(response) = result {
+                self.updateNextPageCursor(with: response.payload)
             }
             self.callback { completion?(result.error) }
         }

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -280,3 +280,17 @@ extension ChatClient {
         MemberList(query: query, client: self)
     }
 }
+
+// MARK: - Factory Methods for Searching Messages
+
+@available(iOS 13.0, *)
+extension ChatClient {
+    /// Creates an instance of ``MessageSearch`` which represents an array of messages matching to the specified ``MessageSearchQuery``.
+    ///
+    /// Use ``MessageSearch`` as a data source for UIs representing message search.
+    ///
+    /// - Returns: An instance of ``MessageSearch`` which represents search actions and the search state.
+    public func makeMessageSearch() -> MessageSearch {
+        MessageSearch(client: self)
+    }
+}

--- a/Sources/StreamChat/StateLayer/MessageSearch.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearch.swift
@@ -56,7 +56,7 @@ public struct MessageSearch {
         query.filterHash = state.explicitFilterHash
         let result = try await messageUpdater.search(query: query, policy: .replace)
         await state.set(query: query, cursor: result.payload.next)
-        return result.messages
+        return result.models
     }
     
     /// Searches for more messages matching with the last search query.
@@ -70,14 +70,14 @@ public struct MessageSearch {
         let limit = (limit ?? query.pagination?.pageSize) ?? Int.messagesPageSize
         let pagination: Pagination = await {
             if !query.sort.isEmpty, let nextPageCursor = await state.value(forKeyPath: \.nextPageCursor) {
-                Pagination(pageSize: limit, cursor: nextPageCursor)
+                return Pagination(pageSize: limit, cursor: nextPageCursor)
             } else {
-                Pagination(pageSize: limit, offset: await state.value(forKeyPath: \.messages.count))
+                return Pagination(pageSize: limit, offset: await state.value(forKeyPath: \.messages.count))
             }
         }()
         let result = try await messageUpdater.search(query: query.withPagination(pagination), policy: .merge)
         await state.set(query: query, cursor: result.payload.next)
-        return result.messages
+        return result.models
     }
     
     // MARK: - Private

--- a/Sources/StreamChat/StateLayer/MessageSearch.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearch.swift
@@ -1,0 +1,113 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object which represents a list of ``ChatMessage`` for the specified search query.
+@available(iOS 13.0, *)
+public struct MessageSearch {
+    private let authenticationRepository: AuthenticationRepository
+    private let messageUpdater: MessageUpdater
+    
+    init(client: ChatClient, environment: Environment = .init()) {
+        authenticationRepository = client.authenticationRepository
+        messageUpdater = environment.messageUpdaterBuilder(
+            client.config.isLocalStorageEnabled,
+            client.messageRepository,
+            client.databaseContainer,
+            client.apiClient
+        )
+        state = environment.stateBuilder(client.databaseContainer)
+    }
+    
+    /// An observable object representing the current state of the search.
+    public let state: MessageSearchState
+    
+    /// Searches for messages with the specified full text search text and updates ``MessageSearchState.messages``.
+    ///
+    /// - Parameter text: A string to search for (which is a full text search).
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of paginated chat messages matching to the search term.
+    @discardableResult public func search(text: String) async throws -> [ChatMessage] {
+        // Clear results when there is no text
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, let query = state.query {
+            try await messageUpdater.clearSearchResults(for: query)
+        }
+        
+        let currentUserId = try currentUserId()
+        let query = MessageSearchQuery(
+            channelFilter: .containMembers(userIds: [currentUserId]),
+            messageFilter: .autocomplete(.text, text: text),
+            sort: [.init(key: .createdAt, isAscending: false)]
+        )
+        return try await search(query: query)
+    }
+    
+    /// Searches for messages with the specified query and updates ``MessageSearchState.messages``.
+    ///
+    /// - Parameter query: The search query specifying filters, sorting and pagination.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of paginated chat messages matching to the query.
+    @discardableResult public func search(query: MessageSearchQuery) async throws -> [ChatMessage] {
+        var query = query
+        query.filterHash = state.explicitFilterHash
+        let result = try await messageUpdater.search(query: query, policy: .replace)
+        await state.set(query: query, cursor: result.payload.next)
+        return result.messages
+    }
+    
+    /// Searches for more messages matching with the last search query.
+    ///
+    /// - Parameter limit: The limit for the page size. The default limit is 25.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: A next page of chat messages matching to the last query.
+    @discardableResult public func loadNextMessages(limit: Int? = nil) async throws -> [ChatMessage] {
+        guard let query = state.query else { throw ClientError("Call search() before calling for next page") }
+        let limit = (limit ?? query.pagination?.pageSize) ?? Int.messagesPageSize
+        let pagination: Pagination = await {
+            if !query.sort.isEmpty, let nextPageCursor = await state.value(forKeyPath: \.nextPageCursor) {
+                Pagination(pageSize: limit, cursor: nextPageCursor)
+            } else {
+                Pagination(pageSize: limit, offset: await state.value(forKeyPath: \.messages.count))
+            }
+        }()
+        let result = try await messageUpdater.search(query: query.withPagination(pagination), policy: .merge)
+        await state.set(query: query, cursor: result.payload.next)
+        return result.messages
+    }
+    
+    // MARK: - Private
+    
+    private func currentUserId() throws -> UserId {
+        guard let id = authenticationRepository.currentUserId else { throw ClientError.CurrentUserDoesNotExist() }
+        return id
+    }
+}
+
+@available(iOS 13.0, *)
+extension MessageSearch {
+    struct Environment {
+        var messageUpdaterBuilder: (
+            _ isLocalStorageEnabled: Bool,
+            _ messageRepository: MessageRepository,
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> MessageUpdater = MessageUpdater.init
+        
+        var stateBuilder: (
+            _ database: DatabaseContainer
+        ) -> MessageSearchState = MessageSearchState.init
+    }
+}
+
+private extension MessageSearchQuery {
+    func withPagination(_ pagination: Pagination) -> Self {
+        var result = self
+        result.pagination = pagination
+        return result
+    }
+}

--- a/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
@@ -1,0 +1,62 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+extension MessageSearchState {
+    final class Observer {
+        private let database: DatabaseContainer
+        private var messagesObserver: BackgroundListDatabaseObserver<ChatMessage, MessageDTO>?
+
+        init(database: DatabaseContainer) {
+            self.database = database
+        }
+        
+        deinit {
+            guard let query else { return }
+            database.write { $0.deleteQuery(query) }
+        }
+        
+        struct Handlers {
+            let messagesDidChange: (StreamCollection<ChatMessage>) async -> Void
+        }
+        
+        private var handlers: Handlers?
+        
+        func start(with handlers: Handlers) {
+            self.handlers = handlers
+        }
+        
+        var query: MessageSearchQuery? {
+            didSet {
+                reset(to: query)
+            }
+        }
+        
+        private func reset(to query: MessageSearchQuery?) {
+            if let query {
+                messagesObserver = BackgroundListDatabaseObserver(
+                    context: database.backgroundReadOnlyContext,
+                    fetchRequest: MessageDTO.messagesFetchRequest(for: query),
+                    itemCreator: { try $0.asModel() as ChatMessage },
+                    sorting: []
+                )
+                messagesObserver?.onDidChange = { [messagesObserver, handlers] _ in
+                    guard let handlers else { return }
+                    guard let items = messagesObserver?.items else { return }
+                    let collection = StreamCollection(items)
+                    Task { await handlers.messagesDidChange(collection) }
+                }
+                do {
+                    try messagesObserver?.startObserving()
+                } catch {
+                    log.error("Failed to start the message result observer for query (\(query) with error \(error)")
+                }
+            } else {
+                messagesObserver = nil
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/StateLayer/MessageSearchState.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearchState.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// Represents a list of message search results.
+@available(iOS 13.0, *)
+public final class MessageSearchState: ObservableObject {
+    private var cancellables = Set<AnyCancellable>()
+    private(set) var nextPageCursor: String?
+    private let observer: Observer
+    let explicitFilterHash = UUID().uuidString
+    
+    init(database: DatabaseContainer) {
+        observer = Observer(database: database)
+        observer.start(
+            with: .init(messagesDidChange: { [weak self] in await self?.setValue($0, for: \.messages) })
+        )
+        $query
+            .assign(to: \.query, on: observer)
+            .store(in: &cancellables)
+    }
+    
+    /// The message search query the messages match to.
+    @Published public private(set) var query: MessageSearchQuery?
+    
+    /// An array of search results for the specified query and pagination state.
+    @Published public private(set) var messages = StreamCollection<ChatMessage>([])
+    
+    // MARK: - Mutating the State
+    
+    @MainActor func value<Value>(forKeyPath keyPath: KeyPath<MessageSearchState, Value>) -> Value {
+        self[keyPath: keyPath]
+    }
+    
+    @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<MessageSearchState, Value>) {
+        self[keyPath: keyPath] = value
+    }
+    
+    @MainActor func set(query: MessageSearchQuery, cursor: String?) {
+        self.query = query
+        nextPageCursor = cursor
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -268,6 +268,12 @@
 		4F97F26B2BA83150001C4D66 /* UserListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2692BA83150001C4D66 /* UserListState.swift */; };
 		4F94B0E02BA1C4220045216B /* MemberListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F94B0DF2BA1C4220045216B /* MemberListState.swift */; };
 		4F94B0E12BA1C4220045216B /* MemberListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F94B0DF2BA1C4220045216B /* MemberListState.swift */; };
+		4F97F2742BA87C41001C4D66 /* MessageSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2732BA87C41001C4D66 /* MessageSearch.swift */; };
+		4F97F2752BA87C41001C4D66 /* MessageSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2732BA87C41001C4D66 /* MessageSearch.swift */; };
+		4F97F2772BA87E30001C4D66 /* MessageSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2762BA87E30001C4D66 /* MessageSearchState.swift */; };
+		4F97F2782BA87E30001C4D66 /* MessageSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2762BA87E30001C4D66 /* MessageSearchState.swift */; };
+		4F97F27A2BA88936001C4D66 /* MessageSearchState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */; };
+		4F97F27B2BA88936001C4D66 /* MessageSearchState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */; };
 		4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE512B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
@@ -2929,6 +2935,9 @@
 		4F97F2662BA83146001C4D66 /* UserList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList.swift; sourceTree = "<group>"; };
 		4F97F2692BA83150001C4D66 /* UserListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListState.swift; sourceTree = "<group>"; };
 		4F94B0DF2BA1C4220045216B /* MemberListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListState.swift; sourceTree = "<group>"; };
+		4F97F2732BA87C41001C4D66 /* MessageSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSearch.swift; sourceTree = "<group>"; };
+		4F97F2762BA87E30001C4D66 /* MessageSearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSearchState.swift; sourceTree = "<group>"; };
+		4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageSearchState+Observer.swift"; sourceTree = "<group>"; };
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
 		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
 		4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
@@ -4858,6 +4867,9 @@
 				4FFB5EA52BA0993000F0454F /* MemberState.swift */,
 				4F83FA452BA43DC3008BD8CD /* MemberList.swift */,
 				4F94B0DF2BA1C4220045216B /* MemberListState.swift */,
+				4F97F2732BA87C41001C4D66 /* MessageSearch.swift */,
+				4F97F2762BA87E30001C4D66 /* MessageSearchState.swift */,
+				4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
 				4F97F2662BA83146001C4D66 /* UserList.swift */,
@@ -10692,6 +10704,7 @@
 				C1FC2F952742579D0062530F /* WebSocketServer.swift in Sources */,
 				C1FC2F9C2742579D0062530F /* HTTPHandler.swift in Sources */,
 				C14A46532845043300EF498E /* ThreadSafeWeakCollection.swift in Sources */,
+				4F97F2742BA87C41001C4D66 /* MessageSearch.swift in Sources */,
 				792A4F472480107A00EAF71D /* Filter.swift in Sources */,
 				C1FC2F912742579D0062530F /* FoundationHTTPServerHandler.swift in Sources */,
 				22692C8F25D18097007C41D0 /* ChatMessageGiphyAttachment.swift in Sources */,
@@ -10845,6 +10858,7 @@
 				88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */,
 				79BF83F2248F8F60007611A1 /* Logger.swift in Sources */,
 				799C943B247D2FB9001F1104 /* MessageDTO.swift in Sources */,
+				4F97F27A2BA88936001C4D66 /* MessageSearchState+Observer.swift in Sources */,
 				40789D1729F6AC500018C2BB /* AudioPlaybackContextAccessor.swift in Sources */,
 				79D5CDD427EA1BE300BE7D8B /* MessageTranslationsPayload.swift in Sources */,
 				88D85D97252F168000AE1030 /* MemberController+SwiftUI.swift in Sources */,
@@ -10939,6 +10953,7 @@
 				C135A1CB28F45F6B0058EFB6 /* AuthenticationRepository.swift in Sources */,
 				CFE616BB28348AC500AE2ABF /* StreamTimer.swift in Sources */,
 				F65D9091250A5989000B8CEB /* WebSocketConnectEndpoint.swift in Sources */,
+				4F97F2772BA87E30001C4D66 /* MessageSearchState.swift in Sources */,
 				4A4E184728D06F260062378D /* Documentation.docc in Sources */,
 				842F9745277A09B10060A489 /* PinnedMessagesQuery.swift in Sources */,
 				DAE566EB24FFD26C00E39431 /* CurrentUserController+SwiftUI.swift in Sources */,
@@ -11439,6 +11454,7 @@
 				C121E816274544AD00023E4C /* EventType.swift in Sources */,
 				AD70DC3A2ADEC3C400CFC3B7 /* MessageModerationDetailsDTO.swift in Sources */,
 				C121E817274544AD00023E4C /* Event.swift in Sources */,
+				4F97F2752BA87C41001C4D66 /* MessageSearch.swift in Sources */,
 				4F97F2682BA83146001C4D66 /* UserList.swift in Sources */,
 				C121E818274544AD00023E4C /* EventPayload.swift in Sources */,
 				C121E819274544AD00023E4C /* EventDecoder.swift in Sources */,
@@ -11503,6 +11519,7 @@
 				C121E841274544AE00023E4C /* FileUploadPayload.swift in Sources */,
 				C121E842274544AE00023E4C /* MutedChannelPayload.swift in Sources */,
 				C121E843274544AE00023E4C /* RawJSON.swift in Sources */,
+				4F97F2782BA87E30001C4D66 /* MessageSearchState.swift in Sources */,
 				AD52A21A2804850700D0157E /* ChannelConfigDTO.swift in Sources */,
 				4F73F3992B91BD3000563CD9 /* MessageState.swift in Sources */,
 				40789D2229F6AC500018C2BB /* AppStateObserving.swift in Sources */,
@@ -11612,6 +11629,7 @@
 				C121E888274544AF00023E4C /* ChatMessageAttachment.swift in Sources */,
 				C121E889274544AF00023E4C /* ChatMessageAudioAttachment.swift in Sources */,
 				C121E88A274544AF00023E4C /* ChannelId.swift in Sources */,
+				4F97F27B2BA88936001C4D66 /* MessageSearchState+Observer.swift in Sources */,
 				C121E88B274544AF00023E4C /* ChannelRead.swift in Sources */,
 				40789D4329F6B3250018C2BB /* VoiceRecordingAttachmentPayload_Tests.swift in Sources */,
 				C121E88C274544AF00023E4C /* Channel.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -87,7 +87,7 @@ final class MessageUpdater_Mock: MessageUpdater {
 
     @Atomic var search_query: MessageSearchQuery?
     @Atomic var search_policy: UpdatePolicy?
-    @Atomic var search_completion: ((Result<MessageSearchResultsPayload, Error>) -> Void)?
+    @Atomic var search_completion: ((Result<MessageSearchResults, Error>) -> Void)?
 
     @Atomic var clearSearchResults_query: MessageSearchQuery?
     @Atomic var clearSearchResults_completion: ((Error?) -> Void)?
@@ -341,11 +341,11 @@ final class MessageUpdater_Mock: MessageUpdater {
         dispatchEphemeralMessageAction_action = action
         dispatchEphemeralMessageAction_completion = completion
     }
-
+    
     override func search(
         query: MessageSearchQuery,
         policy: UpdatePolicy = .merge,
-        completion: ((Result<MessageSearchResultsPayload, Error>) -> Void)? = nil
+        completion: ((Result<MessageSearchResults, Error>) -> Void)? = nil
     ) {
         search_query = query
         search_policy = policy
@@ -368,5 +368,15 @@ final class MessageUpdater_Mock: MessageUpdater {
         translate_messageId = messageId
         translate_language = language
         translate_completion = completion
+    }
+}
+
+extension MessageUpdater.MessageSearchResults {
+    static func empty() -> Self {
+        .make(api: [], next: nil, models: [])
+    }
+    
+    static func make(api apiMessages: [MessagePayload.Boxed], next: String?, models: [ChatMessage]) -> Self {
+        MessageUpdater.MessageSearchResults(payload: MessageSearchResultsPayload(results: apiMessages, next: next), models: models)
     }
 }

--- a/Tests/StreamChatTests/Controllers/SearchControllers/MessageSearchController/MessageSearchController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/MessageSearchController/MessageSearchController_Tests.swift
@@ -76,7 +76,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater?.search_completion = nil
 
@@ -132,7 +132,7 @@ final class MessageSearchController_Tests: XCTestCase {
         controller = nil
 
         // Simulate successful update
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater?.search_completion = nil
 
@@ -167,7 +167,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -191,7 +191,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -214,7 +214,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -242,7 +242,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate search call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -259,7 +259,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: newMessageId, searchQuery: controller.query, clearAll: true)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let newMessage = try XCTUnwrap(client.databaseContainer.viewContext.message(id: newMessageId)?.asModel())
 
@@ -299,7 +299,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: .unique, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         // Assert message is reported
         AssertAsync.willBeEqual(controller.messages.count, 1)
@@ -341,7 +341,7 @@ final class MessageSearchController_Tests: XCTestCase {
         controller = nil
 
         // Simulate successful update
-        env.messageUpdater!.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater!.search_completion?(.success(.empty()))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater!.search_completion = nil
 
@@ -376,7 +376,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -396,7 +396,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
         XCTAssertEqual(controller.messages, [message])
@@ -418,7 +418,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -446,7 +446,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate search call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 
@@ -463,7 +463,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: newMessageId, searchQuery: controller.query, clearAll: true)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let newMessage = try XCTUnwrap(client.databaseContainer.viewContext.message(id: newMessageId)?.asModel())
 
@@ -499,7 +499,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessages(ids: [messageId, olderMessageId], searchQuery: controller.query)
 
         // Simulate update call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
         let olderMessage = try XCTUnwrap(client.databaseContainer.viewContext.message(id: olderMessageId)?.asModel())
@@ -543,10 +543,12 @@ final class MessageSearchController_Tests: XCTestCase {
         controller.search(text: "test")
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [
-            MessagePayload.Boxed(message: .dummy(messageId: "123", authorUserId: "456"))
-        ], next: nil)))
-
+        env.messageUpdater?.search_completion?(.success(.make(
+            api: [MessagePayload.Boxed(message: .dummy(messageId: "123", authorUserId: "456"))],
+            next: nil,
+            models: [ChatMessage.mock(id: "123", author: ChatUser.mock(id: "456"))]
+        )))
+        
         // Call `loadNextMessages`
         controller.loadNextMessages { error in
             reportedError = error
@@ -581,7 +583,7 @@ final class MessageSearchController_Tests: XCTestCase {
         controller.loadNextMessages()
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let pagination = env.messageUpdater?.search_query?.pagination
 
@@ -600,7 +602,7 @@ final class MessageSearchController_Tests: XCTestCase {
         controller.loadNextMessages()
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let pagination = env.messageUpdater?.search_query?.pagination
 
@@ -630,7 +632,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: newMessageId, searchQuery: controller.query)
 
         // Simulate network call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: nil)))
+        env.messageUpdater?.search_completion?(.success(.empty()))
 
         let newMessage = try XCTUnwrap(client.databaseContainer.viewContext.message(id: newMessageId)?.asModel())
 
@@ -666,7 +668,7 @@ final class MessageSearchController_Tests: XCTestCase {
         try client.databaseContainer.createMessage(id: messageId, searchQuery: controller.query)
 
         // Simulate update call response
-        env.messageUpdater?.search_completion?(.success(MessageSearchResultsPayload(results: [], next: responseNextCursor)))
+        env.messageUpdater?.search_completion?(.success(.make(api: [], next: responseNextCursor, models: [])))
 
         let message = try XCTUnwrap(client.databaseContainer.viewContext.message(id: messageId)?.asModel())
 

--- a/Tests/StreamChatTests/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelMemberListUpdater_Tests.swift
@@ -46,8 +46,8 @@ final class ChannelMemberListUpdater_Tests: XCTestCase {
 
         // Simulate `load` call.
         var completionCalled = false
-        listUpdater.load(query) { error in
-            XCTAssertNil(error)
+        listUpdater.load(query) { result in
+            XCTAssertNil(result.error)
             completionCalled = true
         }
 
@@ -81,8 +81,8 @@ final class ChannelMemberListUpdater_Tests: XCTestCase {
     func test_load_happyPath_whenChannelDoesNotExistsLocally() {
         // Simulate `load` call.
         var completionCalled = false
-        listUpdater.load(query) { error in
-            XCTAssertNil(error)
+        listUpdater.load(query) { result in
+            XCTAssertNil(result.error)
             completionCalled = true
         }
 


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Represent functionality in the `ChatMessageSearchController` in the new state layer. 

### 📝 Summary

* Add `MessageSearch`
* Add `MessageSearchState`

### 🛠 Implementation

Keep the internal setup the same where CoreData drives results although it is not ideal (ideally we want to drive it with API request only but we not currently ready for it)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)