### PR TITLE
Fix markdown-formatter customization accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make it easier to customize `ComposerVC.updateContent()` [#3112](https://github.com/GetStream/stream-chat-swift/pull/3112)
 - Add support markdown font styling customization [#3101](https://github.com/GetStream/stream-chat-swift/pull/3101)
 
->>>>>>> c089224e1 (Add support markdown font styling customization)
 ### 🐞 Fixed
 - Fix support for markdown ordered list with all numbers [#3090](https://github.com/GetStream/stream-chat-swift/pull/3090)
 - Fix support for markdown italic and bold styles inside snake-styled text [#3094](https://github.com/GetStream/stream-chat-swift/pull/3094)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Validates file size limit per attachment type defined in Stream's Dashboard [#3105](https://github.com/GetStream/stream-chat-swift/pull/3105)
 - Make it easier to customize `ComposerVC.updateContent()` [#3112](https://github.com/GetStream/stream-chat-swift/pull/3112)
+- Add support markdown font styling customization [#3101](https://github.com/GetStream/stream-chat-swift/pull/3101)
+
+>>>>>>> c089224e1 (Add support markdown font styling customization)
 ### 🐞 Fixed
 - Fix support for markdown ordered list with all numbers [#3090](https://github.com/GetStream/stream-chat-swift/pull/3090)
 - Fix support for markdown italic and bold styles inside snake-styled text [#3094](https://github.com/GetStream/stream-chat-swift/pull/3094)

--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -63,12 +63,13 @@ extension StreamChatWrapper {
         
         // Customize MarkdownFormatter
         let defaultFormatter = DefaultMarkdownFormatter()
+        defaultFormatter.styles.bodyFont.color = .systemOrange
         defaultFormatter.styles.codeFont.color = .systemPurple
         defaultFormatter.styles.h1Font.color = .systemBlue
         defaultFormatter.styles.h2Font.color = .systemRed
         defaultFormatter.styles.h3Font.color = .systemYellow
         defaultFormatter.styles.h4Font.color = .systemGreen
-        defaultFormatter.styles.h5Font.color = .systemOrange
+        defaultFormatter.styles.h5Font.color = .systemBrown
         defaultFormatter.styles.h6Font.color = .systemPink
         Appearance.default.formatters.markdownFormatter = defaultFormatter
     }

--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -60,5 +60,16 @@ extension StreamChatWrapper {
         Components.default.messageActionsVC = DemoChatMessageActionsVC.self
         Components.default.reactionsSorting = { $0.type.position < $1.type.position }
         Components.default.messageLayoutOptionsResolver = DemoChatMessageLayoutOptionsResolver()
+        
+        // Customize MarkdownFormatter
+        let defaultFormatter = DefaultMarkdownFormatter()
+        defaultFormatter.styles.codeFont.color = .systemPurple
+        defaultFormatter.styles.h1Font.color = .systemBlue
+        defaultFormatter.styles.h2Font.color = .systemRed
+        defaultFormatter.styles.h3Font.color = .systemYellow
+        defaultFormatter.styles.h4Font.color = .systemGreen
+        defaultFormatter.styles.h5Font.color = .systemOrange
+        defaultFormatter.styles.h6Font.color = .systemPink
+        Appearance.default.formatters.markdownFormatter = defaultFormatter
     }
 }

--- a/Scripts/updateDependency.sh
+++ b/Scripts/updateDependency.sh
@@ -74,7 +74,7 @@ if [[ $dependency_directory == *"DifferenceKit"* ]]; then
 fi
 
 if [[ $dependency_directory == *"SwiftyMarkdown"* ]]; then
-    # We currently use customized version of SwiftyLineProcessor.swift
+    # We currently use customized version of SwiftyMarkdown
     git restore $output_directory/SwiftyMarkdown/SwiftyLineProcessor.swift || true
     git restore $output_directory/SwiftyMarkdown/SwiftyTokeniser.swift || true
 fi

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -74,31 +74,30 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
 
 /// Configures the font style properties for base Markdown elements
 public struct MarkdownStyles {
-
     /// The regular paragraph font.
     public var bodyFont: MarkdownFont = .init()
-    
+
     /// The font used for coding blocks in markdown text.
     public var codeFont: MarkdownFont = .init()
-    
+
     /// The font used for links found in markdown text.
     public var linkFont: MarkdownFont = .init()
-    
+
     /// The font used for H1 headers in markdown text.
     public var h1Font: MarkdownFont = .init()
-    
+
     /// The font used for H2 headers in markdown text.
     public var h2Font: MarkdownFont = .init()
-    
+
     /// The font used for H3 headers in markdown text.
     public var h3Font: MarkdownFont = .init()
-    
+
     /// The font used for H4 headers in markdown text.
     public var h4Font: MarkdownFont = .init()
-    
+
     /// The font used for H5 headers in markdown text.
     public var h5Font: MarkdownFont = .init()
-    
+
     /// The font used for H6 headers in markdown text.
     public var h6Font: MarkdownFont = .init()
 

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -74,14 +74,14 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
 
 /// Configures the font style properties for base Markdown elements
 public struct MarkdownStyles {
-    
+
     /// The regular paragraph font.
     public var bodyFont: MarkdownFont = .init()
     
     /// The font used for coding blocks in markdown text.
     public var codeFont: MarkdownFont = .init()
     
-    /// /// The font used for links found in markdown text.
+    /// The font used for links found in markdown text.
     public var linkFont: MarkdownFont = .init()
     
     /// The font used for H1 headers in markdown text.

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -72,6 +72,7 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
     }
 }
 
+/// Configures the font style properties for base Markdown elements
 public struct MarkdownStyles {
     public var bodyFont: MarkdownFont = .init()
     public var codeFont: MarkdownFont = .init()

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -63,13 +63,15 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
         if let fontSize = font.size {
             swiftyMarkdownFont.fontSize = fontSize
         }
+        if let fontColor = font.color {
+            swiftyMarkdownFont.color = fontColor
+        }
         if let fontStyle = font.styling?.asSwiftyMarkdownFontStyle() {
             swiftyMarkdownFont.fontStyle = fontStyle
         }
     }
 }
 
-// TODO: Should we put this inside the DefaultFormatter?
 public struct MarkdownStyles {
     public var bodyFont: MarkdownFont = .init()
     public var codeFont: MarkdownFont = .init()
@@ -87,13 +89,15 @@ public struct MarkdownStyles {
 }
 
 public struct MarkdownFont {
-    var name: String?
-    var size: Double?
-    var styling: MarkdownFontStyle?
+    public var name: String?
+    public var size: Double?
+    public var color: UIColor?
+    public var styling: MarkdownFontStyle?
 
     public init() {
         name = nil
         size = nil
+        color = nil
         styling = nil
     }
 }

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -19,14 +19,15 @@ public protocol MarkdownFormatter {
 
 /// Default implementation for the Markdown formatter
 open class DefaultMarkdownFormatter: MarkdownFormatter {
-    enum Attributes {
-        enum Code {
-            static let fontName: String = "CourierNewPSMT"
-        }
-    }
+    public var styles: MarkdownStyles
+    public var markdownRegexPattern: String
 
-    private let markdownRegexPattern: String =
-        "((?:\\`(.*?)\\`)|(?:\\*{1,2}(.*?)\\*{1,2})|(?:\\~{2}(.*?)\\~{2})|(?:\\_{1,2}(.*?)\\_{1,2})|^(>){1}|(#){1,6}|(=){3,10}|(-){1,3}|(\\d{1,3}\\.)|(?:\\[(.*?)\\])(?:\\((.*?)\\))|(?:\\[(.*?)\\])(?:\\[(.*?)\\])|(\\]\\:))+"
+    private let defaultMarkdownRegex = "((?:\\`(.*?)\\`)|(?:\\*{1,2}(.*?)\\*{1,2})|(?:\\~{2}(.*?)\\~{2})|(?:\\_{1,2}(.*?)\\_{1,2})|^(>){1}|(#){1,6}|(=){3,10}|(-){1,3}|(\\d{1,3}\\.)|(?:\\[(.*?)\\])(?:\\((.*?)\\))|(?:\\[(.*?)\\])(?:\\[(.*?)\\])|(\\]\\:))+"
+
+    public init() {
+        styles = MarkdownStyles()
+        markdownRegexPattern = defaultMarkdownRegex
+    }
 
     private lazy var regex: NSRegularExpression? = {
         guard let regex = try? NSRegularExpression(pattern: markdownRegexPattern, options: .anchorsMatchLines) else {
@@ -43,7 +44,76 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
 
     open func format(_ string: String) -> NSAttributedString {
         let markdownFormatter = SwiftyMarkdown(string: string)
-        markdownFormatter.code.fontName = Attributes.Code.fontName
+        modify(swiftyMarkdownFont: markdownFormatter.code, with: styles.codeFont)
+        modify(swiftyMarkdownFont: markdownFormatter.body, with: styles.bodyFont)
+        modify(swiftyMarkdownFont: markdownFormatter.link, with: styles.linkFont)
+        modify(swiftyMarkdownFont: markdownFormatter.h1, with: styles.h1Font)
+        modify(swiftyMarkdownFont: markdownFormatter.h2, with: styles.h2Font)
+        modify(swiftyMarkdownFont: markdownFormatter.h3, with: styles.h3Font)
+        modify(swiftyMarkdownFont: markdownFormatter.h4, with: styles.h4Font)
+        modify(swiftyMarkdownFont: markdownFormatter.h5, with: styles.h5Font)
+        modify(swiftyMarkdownFont: markdownFormatter.h6, with: styles.h6Font)
         return markdownFormatter.attributedString()
+    }
+
+    private func modify(swiftyMarkdownFont: FontProperties, with font: MarkdownFont) {
+        if let fontName = font.name {
+            swiftyMarkdownFont.fontName = fontName
+        }
+        if let fontSize = font.size {
+            swiftyMarkdownFont.fontSize = fontSize
+        }
+        if let fontStyle = font.styling?.asSwiftyMarkdownFontStyle() {
+            swiftyMarkdownFont.fontStyle = fontStyle
+        }
+    }
+}
+
+// TODO: Should we put this inside the DefaultFormatter?
+public struct MarkdownStyles {
+    public var bodyFont: MarkdownFont = .init()
+    public var codeFont: MarkdownFont = .init()
+    public var linkFont: MarkdownFont = .init()
+    public var h1Font: MarkdownFont = .init()
+    public var h2Font: MarkdownFont = .init()
+    public var h3Font: MarkdownFont = .init()
+    public var h4Font: MarkdownFont = .init()
+    public var h5Font: MarkdownFont = .init()
+    public var h6Font: MarkdownFont = .init()
+
+    public init() {
+        codeFont.name = "CourierNewPSMT"
+    }
+}
+
+public struct MarkdownFont {
+    var name: String?
+    var size: Double?
+    var styling: MarkdownFontStyle?
+
+    public init() {
+        name = nil
+        size = nil
+        styling = nil
+    }
+}
+
+public enum MarkdownFontStyle: Int {
+    case normal
+    case bold
+    case italic
+    case boldItalic
+
+    func asSwiftyMarkdownFontStyle() -> FontStyle {
+        switch self {
+        case .normal:
+            return .normal
+        case .bold:
+            return .bold
+        case .italic:
+            return .italic
+        case .boldItalic:
+            return .boldItalic
+        }
     }
 }

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -74,14 +74,32 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
 
 /// Configures the font style properties for base Markdown elements
 public struct MarkdownStyles {
+    
+    /// This is the base font style and will be used for e.g. headers if no other style override it
     public var bodyFont: MarkdownFont = .init()
+    
+    /// Code style font: `...`
     public var codeFont: MarkdownFont = .init()
+    
+    /// Link style font: [...](...)
     public var linkFont: MarkdownFont = .init()
+    
+    /// H1 style font: # ...
     public var h1Font: MarkdownFont = .init()
+    
+    /// H2 style font: ## ...
     public var h2Font: MarkdownFont = .init()
+    
+    /// H3 style font: ### ...
     public var h3Font: MarkdownFont = .init()
+    
+    /// H4 style font: #### ...
     public var h4Font: MarkdownFont = .init()
+    
+    /// H5 style font: ##### ...
     public var h5Font: MarkdownFont = .init()
+    
+    /// H6 style font: ###### ...
     public var h6Font: MarkdownFont = .init()
 
     public init() {

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -75,31 +75,31 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
 /// Configures the font style properties for base Markdown elements
 public struct MarkdownStyles {
     
-    /// This is the base font style and will be used for e.g. headers if no other style override it
+    /// The regular paragraph font.
     public var bodyFont: MarkdownFont = .init()
     
-    /// Code style font: `...`
+    /// The font used for coding blocks in markdown text.
     public var codeFont: MarkdownFont = .init()
     
-    /// Link style font: [...](...)
+    /// /// The font used for links found in markdown text.
     public var linkFont: MarkdownFont = .init()
     
-    /// H1 style font: # ...
+    /// The font used for H1 headers in markdown text.
     public var h1Font: MarkdownFont = .init()
     
-    /// H2 style font: ## ...
+    /// The font used for H2 headers in markdown text.
     public var h2Font: MarkdownFont = .init()
     
-    /// H3 style font: ### ...
+    /// The font used for H3 headers in markdown text.
     public var h3Font: MarkdownFont = .init()
     
-    /// H4 style font: #### ...
+    /// The font used for H4 headers in markdown text.
     public var h4Font: MarkdownFont = .init()
     
-    /// H5 style font: ##### ...
+    /// The font used for H5 headers in markdown text.
     public var h5Font: MarkdownFont = .init()
     
-    /// H6 style font: ###### ...
+    /// The font used for H6 headers in markdown text.
     public var h6Font: MarkdownFont = .init()
 
     public init() {

--- a/Tests/StreamChatUITests/Utils/DefaultMarkdownFormatter_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/DefaultMarkdownFormatter_Tests.swift
@@ -234,7 +234,7 @@ final class DefaultMarkdownFormatter_Tests: XCTestCase {
                 XCTAssertEqual(expectedBoldAttributedSubstring, attributedString.attributedSubstring(from: range).string)
             } else if let fontAttribute = fontAttribute,
                       let fontNameAttribute = fontAttribute.fontDescriptor.fontAttributes[.name] as? String,
-                      fontNameAttribute == DefaultMarkdownFormatter.Attributes.Code.fontName {
+                      fontNameAttribute == DefaultMarkdownFormatter().styles.codeFont.name {
                 XCTAssertEqual(expectedCodeAttributedSubstring, attributedString.attributedSubstring(from: range).string)
             } else if let linkAttribute = attributes[.link] as? NSURL,
                       let url = linkAttribute.absoluteString {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/stream-chat-swift/issues/2908

### 🎯 Goal

Fix markdown-formatter customization accessibility

### 🛠 Implementation

Make the required stuff in `SwiftyMarkdown.swift` publically accessible

### 🧪 Manual Testing Notes

- Open any sample project (e.g.: `iMessage`)
- Create a custom markdown-formatter (e.g.: `CustomMarkdownFormatter()`)
- Inherit it from `DefaultMarkdownFormatter()`
- Update `format(_ string: String)` (e.g.: `markdownFormatter.bold.fontName = "CourierNewPSMT"`)
- Implement custom markdown-formatter: `appearance.formatters.markdownFormatter = CustomMarkdownFormatter()`
- Open the app
- Send a message (e.g.: `**test**`)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjMwZHdibzhmeHVhZnY2aDVteXJjZDM3ZTdvb3ZyazlwdGFweWkyaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ohdY5OaQmUmVW/giphy.gif)
