### PR TITLE
[ChatStateLayer] Client, connection and channel events

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -2,6 +2,7 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import CoreData
 import Foundation
 
@@ -495,7 +496,47 @@ public class ChatClient {
         }
     }
     
-    // MARK: - Internal
+    // MARK: - Listening for Client Events
+    
+    /// Subscribes to web-socket events of the specified event type.
+    ///
+    /// - Note: The handler is always called on the main thread.
+    ///
+    /// An example of observing connection status changes:
+    /// ```swift
+    /// client.subscribe(to: ConnectionStatusUpdated.self) { connectionEvent in
+    ///     switch connectionEvent.connectionStatus {
+    ///         case .connected:
+    ///           …
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: ``Chat.subscribe(to:handler:)`` for subscribing to channel specific events.
+    ///
+    /// - Parameters:
+    ///   - event: The event type to subscribe to (e.g. ``ConnectionStatusUpdated``).
+    ///   - handler: The handler closure which is called when the event happens.
+    ///
+    /// - Returns: A cancellable instance, which you use when you end the subscription. Deallocation of the result will tear down the subscription stream.
+    @available(iOS 13.0, *)
+    public func subscribe<E>(to event: E.Type, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
+        eventNotificationCenter.subscribe(to: E.self, handler: handler)
+    }
+
+    /// Subscribes to all the web-socket events.
+    ///
+    /// - SeeAlso: ``Chat.subscribe(handler:)`` for subscribing to channel specific events.
+    ///
+    /// - Parameter handler: The handler closure which is called when the event happens.
+    ///
+    /// - Returns: A cancellable instance, which you use when you end the subscription. Deallocation of the result will tear down the subscription stream.
+    @available(iOS 13.0, *)
+    public func subscribe(_ handler: @escaping (Event) -> Void) -> AnyCancellable {
+        eventNotificationCenter.subscribe(handler: handler)
+    }
+    
+    // MARK: -
 
     /// Fetches the app settings and updates the `ChatClient.appSettings`.
     /// - Parameter completion: The completion block once the app settings has finished fetching.
@@ -513,6 +554,8 @@ public class ChatClient {
             }
         }
     }
+
+    // MARK: - Internal
 
     func createBackgroundWorkers() {
         guard config.isClientInActiveMode else { return }

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -504,7 +504,7 @@ public class ChatClient {
     ///
     /// An example of observing connection status changes:
     /// ```swift
-    /// client.subscribe(to: ConnectionStatusUpdated.self) { connectionEvent in
+    /// client.subscribe(toEvent: ConnectionStatusUpdated.self) { connectionEvent in
     ///     switch connectionEvent.connectionStatus {
     ///         case .connected:
     ///           …
@@ -512,7 +512,7 @@ public class ChatClient {
     /// }
     /// ```
     ///
-    /// - SeeAlso: ``Chat.subscribe(to:handler:)`` for subscribing to channel specific events.
+    /// - SeeAlso: ``Chat.subscribe(toEvent:handler:)`` for subscribing to channel specific events.
     ///
     /// - Parameters:
     ///   - event: The event type to subscribe to (e.g. ``ConnectionStatusUpdated``).
@@ -520,7 +520,7 @@ public class ChatClient {
     ///
     /// - Returns: A cancellable instance, which you use when you end the subscription. Deallocation of the result will tear down the subscription stream.
     @available(iOS 13.0, *)
-    public func subscribe<E>(to event: E.Type, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
+    public func subscribe<E>(toEvent event: E.Type, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
         eventNotificationCenter.subscribe(to: E.self, handler: handler)
     }
 

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -953,14 +953,14 @@ public final class Chat {
     ///
     /// - Note: The handler is always called on the main thread.
     /// - Important: Subscribing to events not related to this channel, like ``ConnectionStatusUpdated``, does not trigger the handler.
-    /// - SeeAlso: ``ChatClient.subscribe(to:handler:)`` for subscribing to client events.
+    /// - SeeAlso: ``ChatClient.subscribe(toEvent:handler:)`` for subscribing to client events.
     ///
     /// - Parameters:
     ///   - event: The event type to subscribe to (e.g. ``MessageNewEvent``).
     ///   - handler: The handler closure which is called when the event happens.
     ///
     /// - Returns: A cancellable instance, which you use when you end the subscription. Deallocation of the result will tear down the subscription stream.
-    public func subscribe<E>(to event: E.Type, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
+    public func subscribe<E>(toEvent event: E.Type, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
         eventNotificationCenter.subscribe(
             to: event,
             filter: { [cid] in

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -949,9 +949,10 @@ public final class Chat {
         try await channelUpdater.stopWatching(cid: cid)
     }
     
-    /// Subscribes to web-socket events of a single type in this channel.
+    /// Subscribes to web-socket events of a single type which is a channel specific event in this channel.
     ///
     /// - Note: The handler is always called on the main thread.
+    /// - Important: Subscribing to events not related to this channel, like ``ConnectionStatusUpdated``, does not trigger the handler.
     /// - SeeAlso: ``ChatClient.subscribe(to:handler:)`` for subscribing to client events.
     ///
     /// - Parameters:

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -2,6 +2,7 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 /// An object which represents a `ChatChannel`.
@@ -12,6 +13,7 @@ public final class Chat {
     private let channelUpdater: ChannelUpdater
     private let databaseContainer: DatabaseContainer
     private let eventNotificationCenter: EventNotificationCenter
+    private let eventSender: EventSender
     private let memberUpdater: ChannelMemberUpdater
     private let messageEditor: MessageEditor
     private let messageSender: MessageSender
@@ -51,6 +53,10 @@ public final class Chat {
             client: client
         )
         memberUpdater = environment.memberUpdaterBuilder(
+            client.databaseContainer,
+            client.apiClient
+        )
+        eventSender = environment.eventSenderBuilder(
             client.databaseContainer,
             client.apiClient
         )
@@ -943,6 +949,51 @@ public final class Chat {
         try await channelUpdater.stopWatching(cid: cid)
     }
     
+    /// Subscribes to web-socket events of a single type in this channel.
+    ///
+    /// - Note: The handler is always called on the main thread.
+    /// - SeeAlso: ``ChatClient.subscribe(to:handler:)`` for subscribing to client events.
+    ///
+    /// - Parameters:
+    ///   - event: The event type to subscribe to (e.g. ``MessageNewEvent``).
+    ///   - handler: The handler closure which is called when the event happens.
+    ///
+    /// - Returns: A cancellable instance, which you use when you end the subscription. Deallocation of the result will tear down the subscription stream.
+    public func subscribe<E>(to event: E.Type, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
+        eventNotificationCenter.subscribe(
+            to: event,
+            filter: { [cid] in
+                EventNotificationCenter.channelFilter(cid: cid, event: $0)
+            },
+            handler: handler
+        )
+    }
+    
+    /// Subscribes to all the web-socket events of this channel.
+    ///
+    /// - SeeAlso: ``ChatClient.subscribe(handler:)`` for subscribing to client events.
+    ///
+    /// - Parameter handler: The handler closure which is called when the event happens.
+    ///
+    /// - Returns: A cancellable instance, which you use when you end the subscription. Deallocation of the result will tear down the subscription stream.
+    public func subscribe(_ handler: @escaping (Event) -> Void) -> AnyCancellable {
+        eventNotificationCenter.subscribe(
+            filter: { [cid] in
+                EventNotificationCenter.channelFilter(cid: cid, event: $0)
+            },
+            handler: handler
+        )
+    }
+    
+    /// Sends a custom event to the channel.
+    ///
+    /// Please refer to [Custom Events](https://getstream.io/chat/docs/ios-swift/custom_events/?language=swift) for additional details.
+    ///
+    /// - Parameter payload: The custom event payload to be sent.
+    public func sendEvent<EventPayload>(_ payload: EventPayload) async throws where EventPayload: CustomEventPayload {
+        try await eventSender.sendEvent(payload, to: cid)
+    }
+    
     // MARK: -
     
     /// Loads watchers for the specified pagination parameters and updates ``ChatState/watchers``.
@@ -983,12 +1034,17 @@ extension Chat {
             _ eventNotificationCenter: EventNotificationCenter,
             _ paginationState: MessagesPaginationState
         ) -> ChatState = ChatState.init
+
+        var eventSenderBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> EventSender = EventSender.init
         
         var memberUpdaterBuilder: (
             _ database: DatabaseContainer,
             _ apiClient: APIClient
         ) -> ChannelMemberUpdater = ChannelMemberUpdater.init
-        
+
         var messageUpdaterBuilder: (
             _ isLocalStorageEnabled: Bool,
             _ messageRepository: MessageRepository,

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -2,6 +2,7 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 /// The type is designed to pre-process some incoming `Event` via middlewares before being published
@@ -71,5 +72,35 @@ class EventNotificationCenter: NotificationCenter {
 extension EventNotificationCenter {
     func process(_ event: Event, postNotification: Bool = true, completion: (() -> Void)? = nil) {
         process([event], postNotifications: postNotification, completion: completion)
+    }
+}
+
+@available(iOS 13.0, *)
+extension EventNotificationCenter {
+    func subscribe<E>(to event: E.Type, filter: @escaping (E) -> Bool = { _ in true }, handler: @escaping (E) -> Void) -> AnyCancellable where E: Event {
+        publisher(for: .NewEventReceived)
+            .compactMap { $0.event as? E }
+            .filter(filter)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: handler)
+    }
+    
+    func subscribe(filter: @escaping (Event) -> Bool = { _ in true }, handler: @escaping (Event) -> Void) -> AnyCancellable {
+        publisher(for: .NewEventReceived)
+            .compactMap(\.event)
+            .filter(filter)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: handler)
+    }
+    
+    static func channelFilter(cid: ChannelId, event: Event) -> Bool {
+        switch event {
+        case let channelEvent as ChannelSpecificEvent:
+            return channelEvent.cid == cid
+        case let channelEvent as UnknownChannelEvent:
+            return channelEvent.cid == cid
+        default:
+            return false
+        }
     }
 }

--- a/Sources/StreamChat/Workers/EventSender.swift
+++ b/Sources/StreamChat/Workers/EventSender.swift
@@ -22,3 +22,14 @@ class EventSender: Worker {
         }
     }
 }
+
+@available(iOS 13.0, *)
+extension EventSender {
+    func sendEvent<Payload: CustomEventPayload>(_ payload: Payload, to cid: ChannelId) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            sendEvent(payload, to: cid) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add functionality in `ChannelEventsController`, `EventsController`, and `ChatConnectionController ` to the new state layer.

### 📝 Summary

* Add subscribe methods for channel events to `Chat`(related to `ChannelEventsController`)
* Add send custom event to `Chat` (related to `ChannelEventsController`)
* Add subscribe methods for client events to `ChatClient` (related to `EventsController`)
* Connection events use the same subscribe method in `ChatClient` (related to `ChatConnectionController`)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
