### PR TITLE
Fix Message View not updated when new translations are added or removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix support for markdown ordered list with all numbers [#3090](https://github.com/GetStream/stream-chat-swift/pull/3090)
 - Fix support for markdown italic and bold styles inside snake-styled text [#3094](https://github.com/GetStream/stream-chat-swift/pull/3094)
+- Fix Message View not updated when new translations are added or removed [#3103](https://github.com/GetStream/stream-chat-swift/pull/3103)
 
 # [4.50.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.50.0)
 _March 11, 2024_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -47,6 +47,7 @@ extension ChatMessage: Differentiable {
             && reactionCounts == source.reactionCounts
             && reactionScores == source.reactionScores
             && extraData == source.extraData
+            && translations == source.translations
             && currentUserReactionsCount == source.currentUserReactionsCount
             && threadParticipantsCount == source.threadParticipantsCount
             && readByCount == source.readByCount

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -273,6 +273,20 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertFalse(messageDiff1.isContentEqual(to: messageDiff2))
     }
 
+    func test_messageIsContentEqual_whenTranslationsAreDifferent() throws {
+        let sameUser = ChatUser.mock(id: .unique, name: "Leia Organa")
+
+        // When translations are the same, should be equal
+        let messageSame1 = ChatMessage.mock(id: "1", text: "same", author: sameUser, translations: [.portuguese: "mesmo"])
+        let messageSame2 = ChatMessage.mock(id: "1", text: "same", author: sameUser, translations: [.portuguese: "mesmo"])
+        XCTAssert(messageSame1.isContentEqual(to: messageSame2))
+
+        // When translations are different, should not be equal
+        let messageDiff1 = ChatMessage.mock(id: "1", text: "same", author: sameUser, translations: [.portuguese: "mesmo"])
+        let messageDiff2 = ChatMessage.mock(id: "1", text: "same", author: sameUser, translations: [.portuguese: "mesmo", .arabic: "no idea"])
+        XCTAssertFalse(messageDiff1.isContentEqual(to: messageDiff2))
+    }
+
     // MARK: - isScrollToBottomButtonVisible
 
     func test_isScrollToBottomButtonVisible_whenLastCellNotVisible_whenMoreContentThanOnePage_whenFirstPageIsLoaded_returnsTrue() {


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/stream-chat-swift/issues/3099

### 🎯 Goal

Fix Message View not updated when new translations are added or removed.

### 🧪 Manual Testing Notes
N/A (At the moment we don't have a way to add multiple translations to a message in the DemoApp)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)