### PR TITLE
[ChatStateLayer] Async connect and disconnect in ChatClient

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -269,6 +269,8 @@ public class ChatClient {
         Self.attachmentTypesRegistry[Payload.type] = payloadType
     }
 
+    // MARK: - Connecting to the Client
+    
     /// Connects the client with the given user.
     ///
     /// - Parameters:
@@ -338,8 +340,29 @@ public class ChatClient {
             completion: completion
         )
     }
+    
+    /// Connects the client with the given user.
+    ///
+    /// - Note: Connect endpoint uses an upsert mechanism. If the user does not exist, it will be created with the given `userInfo`. If user already exists, it will get updated with non-nil fields from the `userInfo`.
+    /// - Important: This method can only be used when `token` does not expire. If the token expires, the `connect` API with token provider has to be used.
+    ///
+    /// - Parameters:
+    ///   - userInfo: User info that is passed to the `connect` endpoint for user creation
+    ///   - token: Authorization token for the user.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: A type representing the connected user and its state.
+    @available(iOS 13.0, *)
+    @discardableResult public func connectUser(userInfo: UserInfo, token: Token) async throws -> ConnectedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            connectUser(userInfo: userInfo, token: token) { error in
+                continuation.resume(with: error)
+            }
+        }
+        return try await makeConnectedUser()
+    }
 
-    /// Connects a guest user
+    /// Connects a guest user.
     /// - Parameters:
     ///   - userInfo: User info that is passed to the `connect` endpoint for user creation
     ///   - extraData: Extra data for user that is passed to the `connect` endpoint for user creation.
@@ -350,13 +373,52 @@ public class ChatClient {
     ) {
         authenticationRepository.connectGuestUser(userInfo: userInfo, completion: { completion?($0) })
     }
+    
+    /// Connects a guest user.
+    ///
+    /// - Parameters:
+    ///   - userInfo: User info that is passed to the `connect` endpoint for user creation
+    ///   - extraData: Extra data for user that is passed to the `connect` endpoint for user creation.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: A type representing the connected user and its state.
+    @available(iOS 13.0, *)
+    @discardableResult public func connectGuestUser(userInfo: UserInfo) async throws -> ConnectedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            connectGuestUser(userInfo: userInfo) { error in
+                continuation.resume(with: error)
+            }
+        }
+        return try await makeConnectedUser()
+    }
 
-    /// Connects anonymous user
+    /// Connects an anonymous user
     /// - Parameter completion: The completion that will be called once the **first** user session for the given token is setup.
     public func connectAnonymousUser(completion: ((Error?) -> Void)? = nil) {
         authenticationRepository.connectAnonymousUser(
             completion: { completion?($0) }
         )
+    }
+    
+    /// Connects an anonymous user.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: A type representing the connected user and its state.
+    @available(iOS 13.0, *)
+    @discardableResult public func connectAnonymousUser() async throws -> ConnectedUser {
+        try await withCheckedThrowingContinuation { continuation in
+            connectAnonymousUser { error in
+                continuation.resume(with: error)
+            }
+        }
+        return try await makeConnectedUser()
+    }
+    
+    /// Sets the user token to the client, this method is only needed to perform API calls
+    /// without connecting as a user.
+    /// You should only use this in special cases like a notification service or other background process
+    public func setToken(token: Token) {
+        authenticationRepository.setToken(token: token, completeTokenWaiters: true)
     }
 
     /// Disconnects the chat client from the chat servers. No further updates from the servers
@@ -377,6 +439,17 @@ public class ChatClient {
         authenticationRepository.cancelTimers()
     }
 
+    /// Disconnects the chat client from the chat servers. No further updates from the servers
+    /// are received.
+    @available(iOS 13.0, *)
+    public func disconnect() async {
+        await withCheckedContinuation { continuation in
+            disconnect {
+                continuation.resume()
+            }
+        }
+    }
+    
     /// Disconnects the chat client form the chat servers and removes all the local data related.
     @available(*, deprecated, message: "Use the asynchronous version of `logout` for increased safety")
     public func logout() {
@@ -411,6 +484,18 @@ public class ChatClient {
             completion()
         }
     }
+    
+    /// Disconnects the chat client form the chat servers and removes all the local data related.
+    @available(iOS 13.0, *)
+    public func logout() async {
+        await withCheckedContinuation { continuation in
+            logout {
+                continuation.resume()
+            }
+        }
+    }
+    
+    // MARK: - Internal
 
     /// Fetches the app settings and updates the `ChatClient.appSettings`.
     /// - Parameter completion: The completion block once the app settings has finished fetching.
@@ -464,13 +549,6 @@ public class ChatClient {
 
     func completeTokenWaiters(token: Token?) {
         authenticationRepository.completeTokenWaiters(token: token)
-    }
-
-    /// Sets the user token to the client, this method is only needed to perform API calls
-    /// without connecting as a user.
-    /// You should only use this in special cases like a notification service or other background process
-    public func setToken(token: Token) {
-        authenticationRepository.setToken(token: token, completeTokenWaiters: true)
     }
 
     /// Starts the process to  refresh the token


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add async variants to the `ChatClient` which return the new `ConnectedUser` instance.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
