### PR TITLE
Invalid reaction scores were saved to CoreData store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `ChatClient.loadAppSettings` and `ChatClient.appSettings` [#3091](https://github.com/GetStream/stream-chat-swift/pull/3091)
 - Load the app settings when connecting the user [#3091](https://github.com/GetStream/stream-chat-swift/pull/3091)
 - Expose `notificationsMuted` in `ChatChannelMember` [#3111](https://github.com/GetStream/stream-chat-swift/pull/3111)
+### 🐞 Fixed
+- Fix saving reaction counts for messages [#3109](https://github.com/GetStream/stream-chat-swift/pull/3109)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -721,7 +721,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         dto.user = user
 
         dto.reactionScores = payload.reactionScores.mapKeys { $0.rawValue }
-        dto.reactionCounts = payload.reactionScores.mapKeys { $0.rawValue }
+        dto.reactionCounts = payload.reactionCounts.mapKeys { $0.rawValue }
 
         // If user edited their message to remove mentioned users, we need to get rid of it
         // as backend does


### PR DESCRIPTION
### 🔗 Issue Links

None

### 🎯 Goal

Invalid reaction scores are saved to the CoreData store.

### 📝 Summary

- Seems like a type in `MessageDTO` when converting API response to `MessageDTO`

### 🛠 Implementation

Add a test for reaction scores and counts and fix the reaction score saving.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGZpYW9tbW8wYmo0MTN1MWZod2xseTdoM3NyMm01Ymt3cHM1NWh2YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT1R9Afr4fUyfssVna/giphy.gif)
