### PR TITLE
[ChatStateLayer] Skip capabilities

### DIFF
--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -513,12 +513,3 @@ public extension ChatChannel {
         ownCapabilities.contains(.slowMode)
     }
 }
-
-extension ChatChannel {
-    func requireCapability(of capability: ChannelCapability) throws {
-        guard !ownCapabilities.contains(capability) else { return }
-        let error = ClientError.ChannelFeatureDisabled("Channel feature: \(capability) is disabled for \(cid).")
-        log.error(error.localizedDescription)
-        throw error
-    }
-}

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -469,9 +469,8 @@ public final class Chat {
     ///   - messageId: The id of the message to be pinned.
     ///   - pinning: The pinning expiration information. Supports an infinite expiration, setting a date, or the amount of time a message is pinned.
     ///
-    /// - Throws: An error while communicating with the Stream API or missing required capabilities.
+    /// - Throws: An error while communicating with the Stream API.
     public func pinMessage(_ messageId: MessageId, pinning: MessagePinning) async throws {
-        try state.channel?.requireCapability(of: .pinMessage)
         try await messageUpdater.pinMessage(messageId: messageId, pinning: pinning)
         try await messageEditor.waitForAPIRequest(messageId: messageId)
     }
@@ -482,9 +481,8 @@ public final class Chat {
     ///
     /// - Parameter messageId: The id of the message to unpin.
     ///
-    /// - Throws: An error while communicating with the Stream API or missing required capabilities.
+    /// - Throws: An error while communicating with the Stream API.
     public func unpinMessage(_ messageId: MessageId) async throws {
-        try state.channel?.requireCapability(of: .pinMessage)
         try await messageUpdater.unpinMessage(messageId: messageId)
         try await messageEditor.waitForAPIRequest(messageId: messageId)
     }
@@ -561,10 +559,9 @@ public final class Chat {
     
     /// Marks all the unread messages in the channel as read.
     ///
-    /// - Throws: An error while communicating with the Stream API or missing required capabilities.
+    /// - Throws: An error while communicating with the Stream API.
     public func markRead() async throws {
         guard let channel = state.channel else { throw ClientError.ChannelDoesNotExist(cid: cid) }
-        try channel.requireCapability(of: .readEvents)
         try await readStateSender.markRead(channel)
     }
     
@@ -572,10 +569,9 @@ public final class Chat {
     ///
     /// - Parameter messageId: The id of the first message that will be marked as unread.
     ///
-    /// - Throws: An error while communicating with the Stream API or missing required capabilities.
+    /// - Throws: An error while communicating with the Stream API.
     public func markUnread(from messageId: MessageId) async throws {
         guard let channel = state.channel else { throw ClientError.ChannelDoesNotExist(cid: cid) }
-        try channel.requireCapability(of: .readEvents)
         try await readStateSender.markUnread(from: messageId, in: channel)
     }
     
@@ -796,9 +792,8 @@ public final class Chat {
     ///
     /// - Parameter parentMessageId: A message id of the message in a thread the user is replying to.
     ///
-    /// - Throws: An error while communicating with the Stream API or missing required capabilities.
+    /// - Throws: An error while communicating with the Stream API.
     public func keystroke(parentMessageId: MessageId? = nil) async throws {
-        try state.channel?.requireCapability(of: .sendTypingEvents)
         try await typingEventsSender.keystroke(in: cid, parentMessageId: parentMessageId)
     }
     
@@ -808,9 +803,8 @@ public final class Chat {
     ///
     /// - Parameter parentMessageId: A message id of the message in a thread the user is replying to.
     ///
-    /// - Throws: An error while communicating with the Stream API or missing required capabilities.
+    /// - Throws: An error while communicating with the Stream API.
     public func stopTyping(parentMessageId: MessageId? = nil) async throws {
-        try state.channel?.requireCapability(of: .sendTypingEvents)
         try await typingEventsSender.stopTyping(in: cid, parentMessageId: parentMessageId)
     }
     


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Remove capabilities checks as discussed during the tech meeting. We might revisit this in the future, currently it is really inconsistent.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
