### PR TITLE
Expose `notificationsMuted` in `ChatChannelMember`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add mute expiration support when muting a channel [#3083](https://github.com/GetStream/stream-chat-swift/pull/3083)
 - Add `ChatClient.loadAppSettings` and `ChatClient.appSettings` [#3091](https://github.com/GetStream/stream-chat-swift/pull/3091)
 - Load the app settings when connecting the user [#3091](https://github.com/GetStream/stream-chat-swift/pull/3091)
+- Expose `notificationsMuted` in `ChatChannelMember` [#3111](https://github.com/GetStream/stream-chat-swift/pull/3111)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/DemoApp/Screens/MembersViewController.swift
+++ b/DemoApp/Screens/MembersViewController.swift
@@ -61,11 +61,44 @@ class MembersViewController: UITableViewController, ChatChannelMemberListControl
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let member = members[indexPath.row]
-        dump(member)
+        showDetailViewController(MemberDetailViewController(member: member), sender: self)
     }
 
     func memberListController(_ controller: ChatChannelMemberListController, didChangeMembers changes: [ListChange<ChatChannelMember>]) {
         members = Array(controller.members)
         updateData()
+    }
+}
+
+class MemberDetailViewController: UIViewController {
+    let member: ChatChannelMember
+
+    init(member: ChatChannelMember) {
+        self.member = member
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    lazy var textView: UITextView = {
+        let view = UITextView()
+        view.isSelectable = true
+        view.isEditable = false
+        return view
+    }()
+
+    override func loadView() {
+        view = textView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        var debugMember: String = ""
+        dump(member, to: &debugMember)
+        textView.text = debugMember
     }
 }

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
@@ -39,6 +39,7 @@ struct MemberPayload: Decodable {
         case isInvited = "invited"
         case inviteAcceptedAt = "invite_accepted_at"
         case inviteRejectedAt = "invite_rejected_at"
+        case notificationsMuted = "notifications_muted"
     }
 
     let userId: String
@@ -63,6 +64,9 @@ struct MemberPayload: Decodable {
     /// A date when an invited was rejected.
     let inviteRejectedAt: Date?
 
+    /// A boolean value that returns whether the user has muted the channel or not.
+    let notificationsMuted: Bool
+
     init(
         user: UserPayload?,
         userId: String,
@@ -74,7 +78,8 @@ struct MemberPayload: Decodable {
         isShadowBanned: Bool? = nil,
         isInvited: Bool? = nil,
         inviteAcceptedAt: Date? = nil,
-        inviteRejectedAt: Date? = nil
+        inviteRejectedAt: Date? = nil,
+        notificationsMuted: Bool = false
     ) {
         self.user = user
         self.userId = userId
@@ -87,6 +92,7 @@ struct MemberPayload: Decodable {
         self.isInvited = isInvited
         self.inviteAcceptedAt = inviteAcceptedAt
         self.inviteRejectedAt = inviteRejectedAt
+        self.notificationsMuted = notificationsMuted
     }
 
     init(from decoder: Decoder) throws {
@@ -101,6 +107,7 @@ struct MemberPayload: Decodable {
         isInvited = try container.decodeIfPresent(Bool.self, forKey: .isInvited)
         inviteAcceptedAt = try container.decodeIfPresent(Date.self, forKey: .inviteAcceptedAt)
         inviteRejectedAt = try container.decodeIfPresent(Date.self, forKey: .inviteRejectedAt)
+        notificationsMuted = try container.decodeIfPresent(Bool.self, forKey: .notificationsMuted) ?? false
 
         if let user = user {
             userId = user.id

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -18,6 +18,7 @@ class MemberDTO: NSManagedObject {
     @NSManaged var banExpiresAt: DBDate?
     @NSManaged var isBanned: Bool
     @NSManaged var isShadowBanned: Bool
+    @NSManaged var notificationsMuted: Bool
 
     @NSManaged var inviteAcceptedAt: DBDate?
     @NSManaged var inviteRejectedAt: DBDate?
@@ -131,6 +132,7 @@ extension NSManagedObjectContext {
         dto.isInvited = payload.isInvited ?? false
         dto.inviteAcceptedAt = payload.inviteAcceptedAt?.bridgeDate
         dto.inviteRejectedAt = payload.inviteRejectedAt?.bridgeDate
+        dto.notificationsMuted = payload.notificationsMuted
 
         if let query = query {
             let queryDTO = try saveQuery(query)
@@ -199,7 +201,8 @@ extension ChatChannelMember {
             inviteRejectedAt: dto.inviteRejectedAt?.bridgeDate,
             isBannedFromChannel: dto.isBanned,
             banExpiresAt: dto.banExpiresAt?.bridgeDate,
-            isShadowBannedFromChannel: dto.isShadowBanned
+            isShadowBannedFromChannel: dto.isShadowBanned,
+            notificationsMuted: dto.notificationsMuted
         )
     }
 }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23A339" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23C71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -171,6 +171,7 @@
         <attribute name="isShadowBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="memberCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="notificationsMuted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="members" inverseEntity="ChannelDTO"/>
         <relationship name="membershipChannel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="membership" inverseEntity="ChannelDTO"/>
         <relationship name="queries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelMemberListQueryDTO" inverseName="members" inverseEntity="ChannelMemberListQueryDTO"/>

--- a/Sources/StreamChat/Models/Member.swift
+++ b/Sources/StreamChat/Models/Member.swift
@@ -42,6 +42,9 @@ public class ChatChannelMember: ChatUser {
     ///
     public let isShadowBannedFromChannel: Bool
 
+    /// A boolean value that returns whether the user has muted the channel or not.
+    public let notificationsMuted: Bool
+
     init(
         id: String,
         name: String?,
@@ -65,7 +68,8 @@ public class ChatChannelMember: ChatUser {
         inviteRejectedAt: Date?,
         isBannedFromChannel: Bool,
         banExpiresAt: Date?,
-        isShadowBannedFromChannel: Bool
+        isShadowBannedFromChannel: Bool,
+        notificationsMuted: Bool
     ) {
         self.memberRole = memberRole
         self.memberCreatedAt = memberCreatedAt
@@ -76,6 +80,7 @@ public class ChatChannelMember: ChatUser {
         self.isBannedFromChannel = isBannedFromChannel
         self.isShadowBannedFromChannel = isShadowBannedFromChannel
         self.banExpiresAt = banExpiresAt
+        self.notificationsMuted = notificationsMuted
 
         super.init(
             id: id,

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Member.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Member.json
@@ -3,6 +3,7 @@
   "updated_at" : "2020-06-05T12:53:09.862721Z",
   "banned" : true,
   "shadow_banned" : true,
+  "notifications_muted": true,
   "ban_expires" : "2021-03-08T15:42:31.355923Z",
   "user_id" : "broken-waterfall-5",
   "channel_role" : "owner",

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatChannelMember_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatChannelMember_Mock.swift
@@ -30,7 +30,8 @@ public extension ChatChannelMember {
         inviteRejectedAt: Date? = nil,
         isBannedFromChannel: Bool = false,
         banExpiresAt: Date? = nil,
-        isShadowBannedFromChannel: Bool = false
+        isShadowBannedFromChannel: Bool = false,
+        notificationsMuted: Bool = false
     ) -> ChatChannelMember {
         .init(
             id: id,
@@ -55,7 +56,8 @@ public extension ChatChannelMember {
             inviteRejectedAt: inviteRejectedAt,
             isBannedFromChannel: isBannedFromChannel,
             banExpiresAt: banExpiresAt,
-            isShadowBannedFromChannel: isShadowBannedFromChannel
+            isShadowBannedFromChannel: isShadowBannedFromChannel,
+            notificationsMuted: notificationsMuted
         )
     }
 }

--- a/TestTools/StreamChatTestTools/TestData/DummyData/ChatChannelMember.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/ChatChannelMember.swift
@@ -30,7 +30,8 @@ extension ChatChannelMember {
             inviteRejectedAt: nil,
             isBannedFromChannel: true,
             banExpiresAt: .unique,
-            isShadowBannedFromChannel: true
+            isShadowBannedFromChannel: true, 
+            notificationsMuted: false
         )
     }
 }

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MemberPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MemberPayload_Tests.swift
@@ -19,6 +19,7 @@ final class MemberPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.banExpiresAt, "2021-03-08T15:42:31.355923Z".toDate())
         XCTAssertEqual(payload.isBanned, true)
         XCTAssertEqual(payload.isShadowBanned, true)
+        XCTAssertEqual(payload.notificationsMuted, true)
 
         XCTAssertNotNil(payload.user)
         XCTAssertEqual(payload.user!.id, "broken-waterfall-5")

--- a/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
@@ -49,7 +49,8 @@ final class MemberModelDTO_Tests: XCTestCase {
             updatedAt: .unique,
             banExpiresAt: .unique,
             isBanned: true,
-            isShadowBanned: true
+            isShadowBanned: true,
+            notificationsMuted: true
         )
 
         // Asynchronously save the payload to the db
@@ -69,6 +70,7 @@ final class MemberModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.isBanned, loadedMember?.isBannedFromChannel)
             Assert.willBeEqual(payload.banExpiresAt, loadedMember?.banExpiresAt)
             Assert.willBeEqual(payload.isShadowBanned, loadedMember?.isShadowBannedFromChannel)
+            Assert.willBeEqual(payload.notificationsMuted, loadedMember?.notificationsMuted)
 
             Assert.willBeEqual(payload.user!.id, loadedMember?.id)
             Assert.willBeEqual(payload.user!.isOnline, loadedMember?.isOnline)


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Expose `notificationsMuted` in `ChatChannelMember`. 

The value is true if the member has muted the channel. The property would probably be more clear if it was `hasMutedChannel`, but to keep it consistent with the backend and the other SDKs, we won't change it.

### 📝 Summary
- Exposes `notificationsMuted` in `ChatChannelMember`
- Show Member Info when tapping on the channel member in the Demo App

### 🎨 Showcase

https://github.com/GetStream/stream-chat-swift/assets/12814114/55f03b67-da7b-40f7-a7c8-1cc4f54e4bc8

### 🧪 Manual Testing Notes
1. Open the app with Han Solo
2. Mute a Channel
3. Open the app with Leia Organa
4. Open the same Channel
5. Tap on Debug icon
6. Tap on "Show Channel Member"
7. Tap on "Han Solo"
8. It should have `notificationsMuted` to `true`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)