### PR TITLE
Fix pinning messages with attachments stuck in sending state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix pinning messages with attachments stuck in sending state [#3116](https://github.com/GetStream/stream-chat-swift/pull/3116)
 
 # [4.51.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.51.0)
 _March 26, 2024_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -160,10 +160,13 @@ class MessageDTO: NSManagedObject {
     }
 
     static func allAttachmentsAreUploadedOrEmptyPredicate() -> NSCompoundPredicate {
-        .init(
-            format: "SUBQUERY(attachments, $a, $a.localStateRaw == %@).@count == attachments.@count",
-            LocalAttachmentState.uploaded.rawValue
-        )
+        NSCompoundPredicate(orPredicateWithSubpredicates: [
+            .init(
+                format: "SUBQUERY(attachments, $a, $a.localStateRaw == %@).@count == attachments.@count",
+                LocalAttachmentState.uploaded.rawValue
+            ),
+            .init(format: "SUBQUERY(attachments, $a, $a.localStateRaw == nil).@count == attachments.@count")
+        ])
     }
 
     /// Returns a predicate that filters out deleted message by other than the current user


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/778

### 🎯 Goal
Fix pinning message that contains attachments stuck in `sending` state.

### 🛠 Implementation
When we pin a message, we set it as `pendingSync`so that the `MessageEditor` can pick it up. The problem was that pinning a message with attachments did not trigger any change in `MessageEditor`. The reason is that it was observing only attachments that had `localState == uploaded`, but if `localState == nil`, it also means that the attachments are uploaded and are available on the server. 

### 🧪 Manual Testing Notes
1. Send a message with attachment
2. Pin the message
3. It should be pinned and not stuck in pending state

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)