### PR TITLE
[ChatStateLayer] ChannelList tests

### DIFF
--- a/Sources/StreamChat/Controllers/DatabaseObserver/StateLayerListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/StateLayerListDatabaseObserver.swift
@@ -1,0 +1,130 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+/// A CoreDate store observer which immediately reports changes as soon as the store has been changed.
+///
+/// Skips granual list changes what would require to convert DTO to a model object. It reports only when the list has changed and returns a lazy loaded collection.
+@available(iOS 13.0, *)
+final class StateLayerListDatabaseObserver<Item, DTO: NSManagedObject> {
+    private let frc: NSFetchedResultsController<DTO>
+    private(set) var resultsDelegate: FetchedResultsDelegate?
+    private let queue = DispatchQueue(label: "io.getstream.streamchat.statelayerdatabaseobserver")
+
+    let itemCreator: (DTO) throws -> Item
+    let sorting: [SortValue<Item>]
+    let request: NSFetchRequest<DTO>
+    let context: NSManagedObjectContext
+    
+    init(
+        context: NSManagedObjectContext,
+        fetchRequest: NSFetchRequest<DTO>,
+        itemCreator: @escaping (DTO) throws -> Item,
+        sorting: [SortValue<Item>] = [],
+        fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type = NSFetchedResultsController<DTO>.self
+    ) {
+        self.context = context
+        request = fetchRequest
+        self.itemCreator = itemCreator
+        self.sorting = sorting
+        frc = fetchedResultsControllerType.init(
+            fetchRequest: request,
+            managedObjectContext: context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+    }
+    
+    convenience init(
+        databaseContainer: DatabaseContainer,
+        fetchRequest: NSFetchRequest<DTO>,
+        itemCreator: @escaping (DTO) throws -> Item,
+        sorting: [SortValue<Item>]
+    ) {
+        // We must use the writableContext since state layer needs to react to the change immediately.
+        // Otherwise async functions updating the CoreData store can return before we have updated the respective state object.
+        self.init(
+            context: databaseContainer.writableContext,
+            fetchRequest: fetchRequest,
+            itemCreator: itemCreator,
+            sorting: sorting
+        )
+    }
+    
+    var items: StreamCollection<Item> {
+        queue.sync { _items }
+    }
+
+    private var _items = StreamCollection<Item>([])
+    
+    func startObserving(didChange: ((StreamCollection<Item>) async -> Void)? = nil) throws {
+        resultsDelegate = FetchedResultsDelegate(onDidChange: { [weak self] in
+            guard let self else { return }
+            // Runs on the NSManagedObjectContext's queue
+            let collection = Self.makeCollection(
+                frc: self.frc,
+                context: self.context,
+                itemCreator: self.itemCreator,
+                sorting: self.sorting
+            )
+            queue.sync {
+                self._items = collection
+            }
+            Task { await didChange?(collection) }
+        })
+        frc.delegate = resultsDelegate
+        try frc.performFetch()
+        // Set initial state on the calling thread, which requires to use performAndWait
+        queue.async { [frc, context, itemCreator, sorting, weak self] in
+            var collection: StreamCollection<Item>!
+            context.performAndWait {
+                collection = Self.makeCollection(frc: frc, context: context, itemCreator: itemCreator, sorting: sorting)
+            }
+            self?._items = collection
+        }
+    }
+    
+    static func makeCollection(
+        frc: NSFetchedResultsController<DTO>,
+        context: NSManagedObjectContext,
+        itemCreator: @escaping (DTO) throws -> Item,
+        sorting: [SortValue<Item>]
+    ) -> StreamCollection<Item> {
+        var result = LazyCachedMapCollection<Item>(
+            source: frc.fetchedObjects ?? [],
+            map: { dto in
+                var resultItem: Item!
+                do {
+                    resultItem = try itemCreator(dto)
+                } catch {
+                    log.assertionFailure("Unable to convert a DB entity to model: \(error.localizedDescription)")
+                }
+                return resultItem
+            },
+            context: context
+        )
+        if !sorting.isEmpty {
+            let sorted = Array(result).sort(using: sorting)
+            result = LazyCachedMapCollection(source: sorted, map: { $0 }, context: context)
+        }
+        return StreamCollection(result)
+    }
+}
+
+@available(iOS 13.0, *)
+extension StateLayerListDatabaseObserver {
+    final class FetchedResultsDelegate: NSObject, NSFetchedResultsControllerDelegate {
+        let onDidChange: (() -> Void)?
+        
+        init(onDidChange: (() -> Void)?) {
+            self.onDidChange = onDidChange
+        }
+        
+        func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+            onDidChange?()
+        }
+    }
+}

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -236,8 +236,8 @@ class DatabaseContainer: NSPersistentContainer {
     }
     
     @available(iOS 13.0, *)
-    func backgroundRead<T>(_ actions: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {
-        let context = backgroundReadOnlyContext
+    func backgroundRead<T>(from context: NSManagedObjectContext? = nil, _ actions: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {
+        let context = context ?? backgroundReadOnlyContext
         return try await withCheckedThrowingContinuation { continuation in
             context.perform {
                 do {

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -13,7 +13,7 @@ public class ChannelList {
     private let channelListUpdater: ChannelListUpdater
     
     init(
-        channels: [ChatChannel],
+        initialChannels: [ChatChannel]?,
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)?,
         channelListUpdater: ChannelListUpdater,
@@ -23,7 +23,7 @@ public class ChannelList {
         self.channelListUpdater = channelListUpdater
         self.query = query
         state = environment.stateBuilder(
-            channels,
+            initialChannels,
             query,
             dynamicFilter,
             client.config,
@@ -51,8 +51,7 @@ public class ChannelList {
     
     /// Loads more channels and updates ``ChannelListState/channels``.
     ///
-    /// - Parameters
-    ///   - limit: The limit for the page size. The default limit is 20.
+    /// - Parameter limit: The limit for the page size. The default limit is 20.
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
@@ -67,7 +66,7 @@ public class ChannelList {
 extension ChannelList {
     struct Environment {
         var stateBuilder: (
-            _ channels: [ChatChannel],
+            _ initialChannels: [ChatChannel]?,
             _ query: ChannelListQuery,
             _ dynamicFilter: ((ChatChannel) -> Bool)?,
             _ clientConfig: ChatClientConfig,

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -13,7 +13,7 @@ public class ChannelList {
     private let channelListUpdater: ChannelListUpdater
     
     init(
-        initialChannels: [ChatChannel]?,
+        initialChannels: [ChatChannel],
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)?,
         channelListUpdater: ChannelListUpdater,
@@ -66,7 +66,7 @@ public class ChannelList {
 extension ChannelList {
     struct Environment {
         var stateBuilder: (
-            _ initialChannels: [ChatChannel]?,
+            _ initialChannels: [ChatChannel],
             _ query: ChannelListQuery,
             _ dynamicFilter: ((ChatChannel) -> Bool)?,
             _ clientConfig: ChatClientConfig,

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -44,7 +44,7 @@ extension ChannelListState {
         }
         
         struct Handlers {
-            let channelsDidChange: (StreamCollection<ChatChannel>, [ListChange<ChannelId>]) async -> Void
+            let channelsDidChange: (StreamCollection<ChatChannel>) async -> Void
         }
         
         func start(with handlers: Handlers) {
@@ -82,8 +82,8 @@ extension ChannelListState {
             ]
             
             do {
-                try channelListObserver.startObserving(didChange: { channels, changes in
-                    await handlers.channelsDidChange(channels, changes)
+                try channelListObserver.startObserving(didChange: { channels, _ in
+                    await handlers.channelsDidChange(channels)
                 })
             } catch {
                 log.error("Failed to start the channel list observer for query: \(query)")

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -7,7 +7,7 @@ import Foundation
 @available(iOS 13.0, *)
 extension ChannelListState {
     final class Observer {
-        private let channelListObserver: BackgroundListDatabaseObserver<ChatChannel, ChannelDTO>
+        let channelListObserver: StateLayerListDatabaseObserver<ChatChannel, ChannelDTO>
         private let clientConfig: ChatClientConfig
         private let channelListUpdater: ChannelListUpdater
         private let database: DatabaseContainer
@@ -31,16 +31,13 @@ extension ChannelListState {
             self.query = query
             self.eventNotificationCenter = eventNotificationCenter
             
-            // Note that for channel list we sort outside of NSFetchRequest because ChannelListQuery defines its own sorting (see runtimeSorting)
-            channelListObserver = BackgroundListDatabaseObserver(
-                context: database.backgroundReadOnlyContext,
+            channelListObserver = StateLayerListDatabaseObserver(
+                databaseContainer: database,
                 fetchRequest: ChannelDTO.channelListFetchRequest(
                     query: query,
                     chatClientConfig: clientConfig
                 ),
-                itemCreator: {
-                    try $0.asModel() as ChatChannel
-                },
+                itemCreator: { try $0.asModel() as ChatChannel },
                 sorting: query.sort.runtimeSorting
             )
         }
@@ -83,14 +80,10 @@ extension ChannelListState {
                 }
             ]
             
-            channelListObserver.onDidChange = { [weak channelListObserver] _ in
-                guard let items = channelListObserver?.items else { return }
-                let collection = StreamCollection(items)
-                Task { await handlers.channelsDidChange(collection) }
-            }
-            
             do {
-                try channelListObserver.startObserving()
+                try channelListObserver.startObserving(didChange: { items in
+                    await handlers.channelsDidChange(items)
+                })
             } catch {
                 log.error("Failed to start the channel list observer for query: \(query)")
             }

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -33,7 +33,7 @@ public final class ChannelListState: ObservableObject {
             with: .init(channelsDidChange: { [weak self] channels in await self?.setValue(channels, for: \.channels) })
         )
         if initialChannels == nil {
-            channels = observer.channelListObserver.items
+            channels = observer.channelListObserver.currentItems()
         }
     }
     

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -30,8 +30,8 @@ public final class ChannelListState: ObservableObject {
             eventNotificationCenter: eventNotificationCenter
         )
         observer.start(
-            with: .init(channelsDidChange: { [weak self] channels, changes in
-                await self?.handleChannelsDidChange(channels, changes)
+            with: .init(channelsDidChange: { [weak self] channels in
+                await self?.handleChannelsDidChange(channels)
             })
         )
         if initialChannels.isEmpty {
@@ -42,19 +42,13 @@ public final class ChannelListState: ObservableObject {
     /// An array of channels for the specified ``ChannelListQuery``.
     @Published public private(set) var channels = StreamCollection<ChatChannel>([])
     
-    /// An array of latest channel list changes.
-    ///
-    /// - Note: The ``channelListChanges`` property is updated just before ``channels`` property changes.
-    public private(set) var channelListChanges: [ListChange<ChannelId>] = []
-    
     // MARK: - Mutating the State
     
     @MainActor func value<Value>(forKeyPath keyPath: KeyPath<ChannelListState, Value>) -> Value {
         self[keyPath: keyPath]
     }
     
-    @MainActor private func handleChannelsDidChange(_ channels: StreamCollection<ChatChannel>, _ changes: [ListChange<ChannelId>]) {
-        channelListChanges = changes
+    @MainActor private func handleChannelsDidChange(_ channels: StreamCollection<ChatChannel>) {
         self.channels = channels
     }
 }

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -11,7 +11,7 @@ public final class ChannelListState: ObservableObject {
     let query: ChannelListQuery
     
     init(
-        channels: [ChatChannel],
+        initialChannels: [ChatChannel]?,
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)?,
         clientConfig: ChatClientConfig,
@@ -19,7 +19,7 @@ public final class ChannelListState: ObservableObject {
         database: DatabaseContainer,
         eventNotificationCenter: EventNotificationCenter
     ) {
-        self.channels = StreamCollection<ChatChannel>(channels)
+        channels = StreamCollection<ChatChannel>(initialChannels ?? [])
         self.query = query
         observer = Observer(
             query: query,
@@ -32,6 +32,9 @@ public final class ChannelListState: ObservableObject {
         observer.start(
             with: .init(channelsDidChange: { [weak self] channels in await self?.setValue(channels, for: \.channels) })
         )
+        if initialChannels == nil {
+            channels = observer.channelListObserver.items
+        }
     }
     
     /// An array of channels for the specified ``ChannelListQuery``.

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -11,7 +11,7 @@ public final class ChannelListState: ObservableObject {
     let query: ChannelListQuery
     
     init(
-        initialChannels: [ChatChannel]?,
+        initialChannels: [ChatChannel],
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)?,
         clientConfig: ChatClientConfig,
@@ -19,7 +19,7 @@ public final class ChannelListState: ObservableObject {
         database: DatabaseContainer,
         eventNotificationCenter: EventNotificationCenter
     ) {
-        channels = StreamCollection<ChatChannel>(initialChannels ?? [])
+        channels = StreamCollection<ChatChannel>(initialChannels)
         self.query = query
         observer = Observer(
             query: query,
@@ -31,10 +31,10 @@ public final class ChannelListState: ObservableObject {
         )
         observer.start(
             with: .init(channelsDidChange: { [weak self] channels, changes in
-                await self?.noteChannelsDidChange(channels, changes)
+                await self?.handleChannelsDidChange(channels, changes)
             })
         )
-        if initialChannels == nil {
+        if initialChannels.isEmpty {
             channels = observer.channelListObserver.currentItems()
         }
     }
@@ -53,7 +53,7 @@ public final class ChannelListState: ObservableObject {
         self[keyPath: keyPath]
     }
     
-    @MainActor private func noteChannelsDidChange(_ channels: StreamCollection<ChatChannel>, _ changes: [ListChange<ChannelId>]) {
+    @MainActor private func handleChannelsDidChange(_ channels: StreamCollection<ChatChannel>, _ changes: [ListChange<ChannelId>]) {
         channelListChanges = changes
         self.channels = channels
     }

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -44,8 +44,8 @@ public final class ChannelListState: ObservableObject {
     
     /// An array of latest channel list changes.
     ///
-    /// - Note: The ``channels`` property changes before the ``channelListChanges`` property.
-    @Published public private(set) var channelListChanges: [ListChange<ChannelId>] = []
+    /// - Note: The ``channelListChanges`` property is updated just before ``channels`` property changes.
+    public private(set) var channelListChanges: [ListChange<ChannelId>] = []
     
     // MARK: - Mutating the State
     
@@ -53,8 +53,8 @@ public final class ChannelListState: ObservableObject {
         self[keyPath: keyPath]
     }
     
-    @MainActor func noteChannelsDidChange(_ channels: StreamCollection<ChatChannel>, _ changes: [ListChange<ChannelId>]) {
-        self.channels = channels
+    @MainActor private func noteChannelsDidChange(_ channels: StreamCollection<ChatChannel>, _ changes: [ListChange<ChannelId>]) {
         channelListChanges = changes
+        self.channels = channels
     }
 }

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -36,7 +36,7 @@ extension ChatClient {
     /// - Returns: An instance of ``ChannelList`` which represents actions and the current state of the list.
     public func makeChannelList(with query: ChannelListQuery, dynamicFilter: ((ChatChannel) -> Bool)? = nil) async throws -> ChannelList {
         let channels = try await channelListUpdater.update(channelListQuery: query)
-        let channelList = ChannelList(channels: channels, query: query, dynamicFilter: dynamicFilter, channelListUpdater: channelListUpdater, client: self)
+        let channelList = ChannelList(initialChannels: channels, query: query, dynamicFilter: dynamicFilter, channelListUpdater: channelListUpdater, client: self)
         syncRepository.trackChannelListQuery { [weak channelList] in channelList?.state.query }
         return channelList
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -244,12 +244,16 @@
 		4F05ECB92B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */; };
 		4F12DC8C2B70DE82009E48CC /* DifferenceKit+Stream_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */; };
 		4F12DC922B73801D009E48CC /* NukeImageLoader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F12DC912B73801D009E48CC /* NukeImageLoader_Tests.swift */; };
+		4F14F1242BBA9CEF00B1074E /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1232BBA9CEF00B1074E /* Result+Extensions.swift */; };
+		4F14F1262BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1252BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift */; };
+		4F14F1272BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1252BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift */; };
 		4F427F662BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F672BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F692BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6A2BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6C2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
 		4F427F6D2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
+		4F5758F12BB45B2F00D89A94 /* ChannelList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */; };
 		4F73F3982B91BD3000563CD9 /* MessageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F3972B91BD3000563CD9 /* MessageState.swift */; };
 		4F73F3992B91BD3000563CD9 /* MessageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F3972B91BD3000563CD9 /* MessageState.swift */; };
 		4F73F39E2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */; };
@@ -2942,9 +2946,12 @@
 		4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DifferenceKit+Stream.swift"; sourceTree = "<group>"; };
 		4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DifferenceKit+Stream_Tests.swift"; sourceTree = "<group>"; };
 		4F12DC912B73801D009E48CC /* NukeImageLoader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NukeImageLoader_Tests.swift; sourceTree = "<group>"; };
+		4F14F1232BBA9CEF00B1074E /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
+		4F14F1252BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateLayerListDatabaseObserver.swift; sourceTree = "<group>"; };
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
+		4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList_Tests.swift; sourceTree = "<group>"; };
 		4F73F3972B91BD3000563CD9 /* MessageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState.swift; sourceTree = "<group>"; };
 		4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageState+Observer.swift"; sourceTree = "<group>"; };
 		4F83FA452BA43DC3008BD8CD /* MemberList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberList.swift; sourceTree = "<group>"; };
@@ -4914,6 +4921,7 @@
 		4FB4AB9D2BAD6D9700712C4E /* StateLayer */ = {
 			isa = PBXGroup;
 			children = (
+				4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */,
 				4FB4AB9E2BAD6DBD00712C4E /* Chat_Tests.swift */,
 			);
 			path = StateLayer;
@@ -7566,6 +7574,7 @@
 				A3C7BA8F27E37EE000BBF4FA /* URLSessionConfiguration+Equatable.swift */,
 				A3C7BADA27E4E82100BBF4FA /* WebSocketEngineError+Equatable.swift */,
 				84196FA22805892500185E99 /* LocalMessageState+Extensions.swift */,
+				4F14F1232BBA9CEF00B1074E /* Result+Extensions.swift */,
 				A3BEB6B227F3245E00D6D80D /* XCTestCase+MockData.swift */,
 				792E3DDE25CACFA80040B0C2 /* XCTestCase+TestImages.swift */,
 				82F714A02B077F3300442A74 /* XCTestCase+iOS13.swift */,
@@ -8490,6 +8499,7 @@
 				C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */,
 				C189D7772AEBC6CD00D4B966 /* BackgroundDatabaseObserver.swift */,
 				79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */,
+				4F14F1252BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift */,
 			);
 			path = DatabaseObserver;
 			sourceTree = "<group>";
@@ -10582,6 +10592,7 @@
 				A344077C27D753530044F150 /* ChatMessageImageAttachment_Mock.swift in Sources */,
 				ADB951AB291C1DE400800554 /* AttachmentUploader_Spy.swift in Sources */,
 				ADCE32F72A055A9200B52559 /* MessagesPaginationStateHandler_Mock.swift in Sources */,
+				4F14F1242BBA9CEF00B1074E /* Result+Extensions.swift in Sources */,
 				A3C3BC4027E87F5C00224761 /* ChannelMemberListUpdater_Mock.swift in Sources */,
 				A3C3BC2527E87F2000224761 /* MessageReactionPayload.swift in Sources */,
 				A311B42F27E8BC8400CFCF6D /* UserController_Delegate.swift in Sources */,
@@ -10791,6 +10802,7 @@
 				79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */,
 				799C9439247D2FB9001F1104 /* ChannelDTO.swift in Sources */,
 				799C9443247D3DA7001F1104 /* APIClient.swift in Sources */,
+				4F14F1262BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift in Sources */,
 				79200D4C25025B81002F4EB1 /* Error+InternetNotAvailable.swift in Sources */,
 				C12DBE5F2A67DFE80045D9F0 /* SortValue.swift in Sources */,
 				8A0CC9F124C606EF00705CF9 /* ReactionEvents.swift in Sources */,
@@ -11100,6 +11112,7 @@
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
 				882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */,
 				4042966929FA6B4B0089126D /* StreamAudioRecorder_Tests.swift in Sources */,
+				4F5758F12BB45B2F00D89A94 /* ChannelList_Tests.swift in Sources */,
 				88D85D9D252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift in Sources */,
 				88BEBCDC2536FDF200D9E8B7 /* MemberListController+SwiftUI_Tests.swift in Sources */,
 				430156DC26B1862C0006E7EA /* CustomDataHashMap_Tests.swift in Sources */,
@@ -11826,6 +11839,7 @@
 				40789D2029F6AC500018C2BB /* AudioPlaying.swift in Sources */,
 				C121E8E9274544B200023E4C /* Cached.swift in Sources */,
 				4042968129FAC9F80089126D /* AudioAnalysing.swift in Sources */,
+				4F14F1272BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift in Sources */,
 				4F427F6A2BA2F52100D92238 /* ConnectedUserState.swift in Sources */,
 				C121E8EA274544B200023E4C /* CoreDataLazy.swift in Sources */,
 				C121E8EB274544B200023E4C /* Result+Extensions.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -247,13 +247,13 @@
 		4F14F1242BBA9CEF00B1074E /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1232BBA9CEF00B1074E /* Result+Extensions.swift */; };
 		4F14F1262BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1252BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift */; };
 		4F14F1272BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1252BBBDD7400B1074E /* StateLayerListDatabaseObserver.swift */; };
+		4F14F1282BBD2D8700B1074E /* ChannelList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */; };
 		4F427F662BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F672BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F692BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6A2BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6C2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
 		4F427F6D2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
-		4F5758F12BB45B2F00D89A94 /* ChannelList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */; };
 		4F73F3982B91BD3000563CD9 /* MessageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F3972B91BD3000563CD9 /* MessageState.swift */; };
 		4F73F3992B91BD3000563CD9 /* MessageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F3972B91BD3000563CD9 /* MessageState.swift */; };
 		4F73F39E2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */; };
@@ -11112,7 +11112,7 @@
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
 				882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */,
 				4042966929FA6B4B0089126D /* StreamAudioRecorder_Tests.swift in Sources */,
-				4F5758F12BB45B2F00D89A94 /* ChannelList_Tests.swift in Sources */,
+				4F14F1282BBD2D8700B1074E /* ChannelList_Tests.swift in Sources */,
 				88D85D9D252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift in Sources */,
 				88BEBCDC2536FDF200D9E8B7 /* MemberListController+SwiftUI_Tests.swift in Sources */,
 				430156DC26B1862C0006E7EA /* CustomDataHashMap_Tests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Extensions/Result+Extensions.swift
+++ b/TestTools/StreamChatTestTools/Extensions/Result+Extensions.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Result {
+    func invoke(with completion: ((Self) -> Void)? = nil) {
+        completion?(self)
+    }
+}
+
+extension Result where Success == Void {
+    func invoke(with completion: ((Error?) -> Void)? = nil) {
+        switch self {
+        case .success:
+            completion?(nil)
+        case .failure(let error):
+            completion?(error)
+        }
+    }
+}

--- a/TestTools/StreamChatTestTools/Extensions/XCTest+Helpers.swift
+++ b/TestTools/StreamChatTestTools/Extensions/XCTest+Helpers.swift
@@ -23,14 +23,6 @@ public func XCTAssertEqual<T: Equatable>(_ expected: T,
     }
 }
 
-/// Asserts diff between the expected and received collections after sorting both collections
-public func XCTAssertEqualIgnoringOrder<T: RandomAccessCollection>(_ expected: T,
-                                                      _ received: T,
-                                                      file: StaticString = #filePath,
-                                                      line: UInt = #line) where T.Element: Comparable {
-    XCTAssertEqual(expected.sorted(), received.sorted(), file: file, line: line)
-}
-
 // MARK: Errors
 
 /// Asserts when two given errors are not equal

--- a/TestTools/StreamChatTestTools/Extensions/XCTest+Helpers.swift
+++ b/TestTools/StreamChatTestTools/Extensions/XCTest+Helpers.swift
@@ -23,6 +23,14 @@ public func XCTAssertEqual<T: Equatable>(_ expected: T,
     }
 }
 
+/// Asserts diff between the expected and received collections after sorting both collections
+public func XCTAssertEqualIgnoringOrder<T: RandomAccessCollection>(_ expected: T,
+                                                      _ received: T,
+                                                      file: StaticString = #filePath,
+                                                      line: UInt = #line) where T.Element: Comparable {
+    XCTAssertEqual(expected.sorted(), received.sorted(), file: file, line: line)
+}
+
 // MARK: Errors
 
 /// Asserts when two given errors are not equal
@@ -325,15 +333,15 @@ public func XCTAssertResultFailure<Value, U: Error, ErrorType: Error>(_ result: 
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 @available(iOS 13.0, *)
-func XCTAssertAsyncFailure<Failure>(
-    _ expression: @autoclosure () async throws -> Void,
+func XCTAssertAsyncFailure<Success, Failure>(
+    _ expression: @autoclosure () async throws -> Success,
     _ expectedError: @autoclosure () -> Failure,
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
 ) async where Failure: Error {
     do {
-        try await expression()
+        _ = try await expression()
         XCTFail("Expected to fail with error \(expectedError())", file: file, line: line)
     } catch {
         guard let receivedError = error as? Failure else {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -458,9 +458,3 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         enrichUrl_completion = completion
     }
 }
-
-private extension Result where Success == Void {
-    func invoke(with completion: ((Error?) -> Void)? = nil) {
-        completion?(error)
-    }
-}

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -16,6 +16,7 @@ final class APIClient_Spy: APIClient, Spy {
     /// The last endpoint `request` function was called with.
     @Atomic var request_endpoint: AnyEndpoint?
     @Atomic var request_completion: Any?
+    @Atomic var request_completion_result: Result<Any, Error>?
     @Atomic private var request_result: Any?
     @Atomic var request_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
@@ -11,6 +11,7 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
 
     @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Result<[ChatChannel], Error>) -> Void)?
+    @Atomic var update_completion_result: Result<[ChatChannel], Error>?
 
     @Atomic var fetch_queries: [ChannelListQuery] = []
     @Atomic var fetch_completion: ((Result<ChannelListPayload, Error>) -> Void)?
@@ -31,6 +32,7 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
     func cleanUp() {
         update_queries.removeAll()
         update_completion = nil
+        update_completion_result = nil
 
         fetch_queries.removeAll()
         fetch_completion = nil
@@ -47,6 +49,7 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
     ) {
         _update_queries.mutate { $0.append(channelListQuery) }
         update_completion = completion
+        update_completion_result?.invoke(with: completion)
     }
 
     override func markAllRead(completion: ((Error?) -> Void)? = nil) {

--- a/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
@@ -1,0 +1,282 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+@available(iOS 13.0, *)
+final class ChannelList_Tests: XCTestCase {
+    private var channelList: ChannelList!
+    private var env: TestEnvironment!
+    private var memberId: UserId!
+    private var testError: TestError!
+    
+    override func setUpWithError() throws {
+        memberId = .unique
+        testError = TestError()
+        env = TestEnvironment()
+        setUpChannelList(usesMockedChannelUpdater: true)
+    }
+
+    override func tearDownWithError() throws {
+        env.cleanUp()
+        channelList = nil
+        env = nil
+        memberId = nil
+        testError = nil
+    }
+    
+    /// For tests which rely on the channel updater to update the local database.
+    private func setUpChannelList(usesMockedChannelUpdater: Bool, dynamicFilter: ((ChatChannel) -> Bool)? = nil) {
+        channelList = ChannelList(
+            initialChannels: nil,
+            query: .init(filter: .in(.members, values: [memberId])),
+            dynamicFilter: dynamicFilter,
+            channelListUpdater: usesMockedChannelUpdater ? env.channelListUpdaterMock : env.channelListUpdater,
+            client: env.client,
+            environment: env.channelListEnvironment
+        )
+    }
+    
+    private func makeChannels(count: Int) -> [ChatChannel] {
+        (0..<count)
+            .map { _ in ChatChannel.mock(cid: .unique) }
+            .sorted(by: { $0.cid.rawValue < $1.cid.rawValue })
+    }
+    
+    private func makeMatchingChannelPayload() -> ChannelPayload {
+        makeMatchingChannelListPayload(channelCount: 1).channels[0]
+    }
+    
+    private func makeMatchingChannelListPayload(channelCount: Int) -> ChannelListPayload {
+        let channelPayloads = (0..<channelCount)
+            .map { _ in ChannelId(type: .messaging, id: .unique) }
+            .map { dummyPayload(with: $0, members: [.dummy(user: .dummy(userId: memberId))]) }
+        return ChannelListPayload(channels: channelPayloads)
+    }
+    
+    // MARK: - Restoring State from the Core Data Store
+    
+    func test_restoringState_whenDatabaseHasEntries_thenStateIsUpdated() async throws {
+        let channelListPayload = makeMatchingChannelListPayload(channelCount: 5)
+        try await env.client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: channelListPayload, query: self.channelList.query)
+        }
+        setUpChannelList(usesMockedChannelUpdater: true)
+        XCTAssertEqualIgnoringOrder(channelListPayload.channels.map(\.channel.cid.rawValue), channelList.state.channels.map(\.cid.rawValue))
+    }
+    
+    func test_restoringState_whenDatabaseHasEntriesWhichShouldBeIgnored_thenStateOnlyIncludesQueryMatchingResults() async throws {
+        let matchingChannelListPayload = makeMatchingChannelListPayload(channelCount: 5)
+        let deletedChannelPayload = makeMatchingChannelPayload()
+        try await env.client.mockDatabaseContainer.write { session in
+            // These match with the query
+            session.saveChannelList(payload: matchingChannelListPayload, query: self.channelList.query)
+            // Should be ignored because it was deleted
+            let dto = try session.saveChannel(payload: deletedChannelPayload, query: self.channelList.query, cache: nil)
+            dto.deletedAt = .unique
+            // Unrelated channel to the query
+            try session.saveChannel(payload: self.dummyPayload(with: .unique))
+        }
+        setUpChannelList(usesMockedChannelUpdater: true)
+        XCTAssertEqualIgnoringOrder(matchingChannelListPayload.channels.map(\.channel.cid.rawValue), channelList.state.channels.map(\.cid.rawValue))
+    }
+    
+    // MARK: - Pagination and Channel Updater Arguments
+
+    func test_loadChannels_whenChannelUpdaterSucceeds_thenLoadSucceeds() async throws {
+        let pageSize = 5
+        let responseChannels = makeChannels(count: pageSize)
+        env.channelListUpdaterMock.update_completion_result = .success(responseChannels)
+        
+        let pagination = Pagination(pageSize: pageSize, offset: 0)
+        let result = try await channelList.loadChannels(with: pagination)
+        
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.count, 1)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.filter, channelList.query.filter)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.sort, channelList.query.sort)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.pagination.pageSize, pageSize)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.pagination.offset, 0)
+        XCTAssertEqual(responseChannels, result)
+    }
+    
+    func test_loadChannels_whenChannelUpdaterFails_thenLoadFails() async throws {
+        env.channelListUpdaterMock.update_completion_result = .failure(testError)
+        let pagination = Pagination(pageSize: 5, offset: 0)
+        await XCTAssertAsyncFailure(try await channelList.loadChannels(with: pagination), testError)
+    }
+    
+    func test_loadNextChannels_whenChannelUpdaterSucceeds_thenLoadSucceeds() async throws {
+        let pageSize = 2
+        let responseChannels = makeChannels(count: pageSize)
+        env.channelListUpdaterMock.update_completion_result = .success(responseChannels)
+        let result = try await channelList.loadNextChannels(limit: pageSize)
+        
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.count, 1)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.filter, channelList.query.filter)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.sort, channelList.query.sort)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.pagination.pageSize, pageSize)
+        XCTAssertEqual(env.channelListUpdaterMock.update_queries.first?.pagination.offset, 0)
+        XCTAssertEqual(responseChannels, result)
+    }
+    
+    func test_loadNextChannels_whenChannelUpdaterFails_thenLoadFails() async throws {
+        env.channelListUpdaterMock.update_completion_result = .failure(testError)
+        await XCTAssertAsyncFailure(try await channelList.loadNextChannels(), testError)
+    }
+    
+    // MARK: - Pagination and State
+    
+    func test_loadChannels_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+        setUpChannelList(usesMockedChannelUpdater: false)
+        let pageSize = 2
+        let channelListPayload = makeMatchingChannelListPayload(channelCount: pageSize)
+        env.client.mockAPIClient.test_mockResponseResult(.success(channelListPayload))
+
+        let pagination = Pagination(pageSize: pageSize, offset: 0)
+        let result = try await channelList.loadChannels(with: pagination)
+        XCTAssertEqualIgnoringOrder(channelListPayload.channels.map(\.channel.cid.rawValue), result.map(\.cid.rawValue))
+        XCTAssertEqualIgnoringOrder(channelListPayload.channels.map(\.channel.cid.rawValue), channelList.state.channels.map(\.cid.rawValue))
+    }
+    
+    func test_loadNextChannels_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+        // Initial DB state
+        let existingChannelListPayload = makeMatchingChannelListPayload(channelCount: 2)
+        try await env.client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: existingChannelListPayload, query: self.channelList.query)
+        }
+        setUpChannelList(usesMockedChannelUpdater: false)
+        
+        // Load more channels
+        let nextChannelListPayload = makeMatchingChannelListPayload(channelCount: 3)
+        env.client.mockAPIClient.test_mockResponseResult(.success(nextChannelListPayload))
+        let result = try await channelList.loadNextChannels()
+        XCTAssertEqual(nextChannelListPayload.channels.map(\.channel.cid), result.map(\.cid))
+        // State should contain both the existing and next channels
+        let expectedChannels = existingChannelListPayload.channels + nextChannelListPayload.channels
+        XCTAssertEqualIgnoringOrder(expectedChannels.map(\.channel.cid.rawValue), channelList.state.channels.map(\.cid.rawValue))
+    }
+    
+    // MARK: - Observing the Core Data Store
+    
+    func test_observingLocalStore_whenStoreChanges_thenStateChanges() async throws {
+        let expectation = XCTestExpectation(description: "State changed")
+        let incomingChannelListPayload = makeMatchingChannelListPayload(channelCount: 2)
+        let cancellable = channelList.state.$channels
+            .dropFirst() // ignore initial
+            .sink { channels in
+                XCTAssertEqualIgnoringOrder(incomingChannelListPayload.channels.map(\.channel.cid.rawValue), channels.map(\.cid.rawValue))
+                expectation.fulfill()
+            }
+        try await env.client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: incomingChannelListPayload, query: self.channelList.query)
+        }
+        await fulfillment(of: [expectation], timeout: defaultTimeout)
+        cancellable.cancel()
+    }
+    
+    // MARK: - Linking and Unlinking Channels
+    
+    func test_observingEvents_whenAddedToChannelEventReceived_thenChannelIsLinkedAndStateUpdates() async throws {
+        // Allow any channel to be linked by returning true
+        setUpChannelList(usesMockedChannelUpdater: false, dynamicFilter: { _ in true })
+        // Create channel list
+        let existingChannelListPayload = makeMatchingChannelListPayload(channelCount: 1)
+        try await env.client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: existingChannelListPayload, query: self.channelList.query)
+        }
+        
+        // New channel event
+        let incomingChannelPayload = makeMatchingChannelPayload()
+        let incomingCid = incomingChannelPayload.channel.cid
+        let event = NotificationAddedToChannelEvent(
+            channel: .mock(cid: incomingCid),
+            unreadCount: nil,
+            member: .mock(id: .unique),
+            createdAt: .unique
+        )
+        // Write the incoming channel to the database
+        try await env.client.mockDatabaseContainer.write { session in
+            try session.saveChannel(payload: incomingChannelPayload)
+        }
+        
+        let stateExpectation = XCTestExpectation(description: "State changed")
+        let cancellable = channelList.state.$channels
+            .dropFirst() // ignore initial
+            .sink { channels in
+                let expectedCids = existingChannelListPayload.channels.map(\.channel.cid.rawValue) + CollectionOfOne(incomingCid.rawValue)
+                XCTAssertEqualIgnoringOrder(expectedCids, channels.map(\.cid.rawValue))
+                stateExpectation.fulfill()
+            }
+        
+        // Processing the event is picked up by the state
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        env.client.eventNotificationCenter.process([event], completion: { eventExpectation.fulfill() })
+        await fulfillment(of: [eventExpectation, stateExpectation], timeout: defaultTimeout)
+        cancellable.cancel()
+    }
+    
+    func test_observingEvents_whenChannelUpdatedEventReceived_thenChannelIsUnlinkedAndStateUpdates() async throws {
+        // Allow unlink a channel
+        setUpChannelList(usesMockedChannelUpdater: false, dynamicFilter: { _ in false })
+        // Create channel list
+        let existingChannelListPayload = makeMatchingChannelListPayload(channelCount: 1)
+        let existingCid = try XCTUnwrap(existingChannelListPayload.channels.first?.channel.cid)
+        try await env.client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: existingChannelListPayload, query: self.channelList.query)
+        }
+        // Ensure that the channel is in the state
+        XCTAssertEqualIgnoringOrder(existingChannelListPayload.channels.map(\.channel.cid.rawValue), channelList.state.channels.map(\.cid.rawValue))
+        
+        let event = ChannelUpdatedEvent(
+            channel: .mock(cid: existingCid, memberCount: 4),
+            user: .unique,
+            message: .unique,
+            createdAt: .unique
+        )
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        env.client.eventNotificationCenter.process([event], completion: { eventExpectation.fulfill() })
+        await fulfillment(of: [eventExpectation], timeout: defaultTimeout)
+        
+        // Ensure the unlinking removed it from the state
+        XCTAssertEqual([], channelList.state.channels.map(\.cid))
+    }
+}
+
+@available(iOS 13.0, *)
+extension ChannelList_Tests {
+    final class TestEnvironment {
+        let client: ChatClient_Mock
+        private(set) var channelListState: ChannelListState!
+        private(set) var channelListUpdater: ChannelListUpdater!
+        private(set) var channelListUpdaterMock: ChannelListUpdater_Spy!
+        
+        func cleanUp() {
+            client.cleanUp()
+            channelListUpdaterMock?.cleanUp()
+        }
+        
+        init() {
+            client = ChatClient_Mock(
+                config: ChatClient_Mock.defaultMockedConfig
+            )
+            channelListUpdater = ChannelListUpdater(
+                database: client.mockDatabaseContainer,
+                apiClient: client.mockAPIClient
+            )
+            channelListUpdaterMock = ChannelListUpdater_Spy(
+                database: client.mockDatabaseContainer,
+                apiClient: client.mockAPIClient
+            )
+        }
+        
+        lazy var channelListEnvironment: ChannelList.Environment = .init(
+            stateBuilder: { [unowned self] in
+                self.channelListState = ChannelListState(initialChannels: $0, query: $1, dynamicFilter: $2, clientConfig: $3, channelListUpdater: $4, database: $5, eventNotificationCenter: $6)
+                return channelListState
+            }
+        )
+    }
+}

--- a/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
@@ -173,7 +173,11 @@ final class ChannelList_Tests: XCTestCase {
         try await env.client.mockDatabaseContainer.write { session in
             session.saveChannelList(payload: incomingChannelListPayload, query: self.channelList.query)
         }
+        #if swift(>=5.8)
         await fulfillment(of: [expectation], timeout: defaultTimeout)
+        #else
+        wait(for: [expectation], timeout: defaultTimeout)
+        #endif
         cancellable.cancel()
     }
     
@@ -214,7 +218,11 @@ final class ChannelList_Tests: XCTestCase {
         // Processing the event is picked up by the state
         let eventExpectation = XCTestExpectation(description: "Event processed")
         env.client.eventNotificationCenter.process([event], completion: { eventExpectation.fulfill() })
+        #if swift(>=5.8)
         await fulfillment(of: [eventExpectation, stateExpectation], timeout: defaultTimeout)
+        #else
+        wait(for: [eventExpectation, stateExpectation], timeout: defaultTimeout)
+        #endif
         cancellable.cancel()
     }
     
@@ -238,8 +246,11 @@ final class ChannelList_Tests: XCTestCase {
         )
         let eventExpectation = XCTestExpectation(description: "Event processed")
         env.client.eventNotificationCenter.process([event], completion: { eventExpectation.fulfill() })
+        #if swift(>=5.8)
         await fulfillment(of: [eventExpectation], timeout: defaultTimeout)
-        
+        #else
+        wait(for: [eventExpectation], timeout: defaultTimeout)
+        #endif
         // Ensure the unlinking removed it from the state
         XCTAssertEqual([], channelList.state.channels.map(\.cid))
     }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

* Add basic test coverage to `ChannelList`, `ChannelListState`, and `ChannelListState.Observer`

### 📝 Summary

- New CoreDate observer which does not lag (otherwise `loadChannel` finished, but `ChannelListState.channels` were not updated)
- Various tests covering main uses-cases

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
