### PR TITLE
Fix member list not updated after moderator is demoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix pinning messages with attachments stuck in sending state [#3116](https://github.com/GetStream/stream-chat-swift/pull/3116)
+- Fix member list not updated after moderator is demoted [#3132](https://github.com/GetStream/stream-chat-swift/pull/3132)
 
 # [4.51.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.51.0)
 _March 26, 2024_

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -112,11 +112,14 @@ extension StreamChatWrapper {
         if let deviceId = currentUserController.currentUser?.currentDevice?.id {
             currentUserController.removeDevice(id: deviceId) { error in
                 if let error = error {
-                    log.warning("removing the device failed with an error \(error)")
+                    log.error("Removing the device failed with an error \(error)")
                 }
 
                 client.logout(completion: completion)
             }
+        } else {
+            log.error("No deviceId has been found from the current user.")
+            client.logout(completion: completion)
         }
     }
 }

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -108,6 +108,7 @@ extension StreamChatWrapper {
             return
         }
         let currentUserController = client.currentUserController()
+        currentUserController.synchronize()
         if let deviceId = currentUserController.currentUser?.currentDevice?.id {
             currentUserController.removeDevice(id: deviceId) { error in
                 if let error = error {

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -429,6 +429,15 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     membersController: client.memberListController(query: .init(cid: cid, pageSize: 105))
                 ), animated: true)
             }),
+            .init(title: "Show Channel Moderators", handler: { [unowned self] _ in
+                guard let cid = channelController.channel?.cid else { return }
+                let client = channelController.client
+                self.rootViewController.present(MembersViewController(
+                    membersController: client.memberListController(
+                        query: .init(cid: cid, filter: .equal(.isModerator, to: true), pageSize: 105)
+                    )
+                ), animated: true)
+            }),
             .init(title: "Show Banned Members", handler: { [unowned self] _ in
                 guard let cid = channelController.channel?.cid else { return }
                 let client = channelController.client

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -434,7 +434,7 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                 let client = channelController.client
                 self.rootViewController.present(MembersViewController(
                     membersController: client.memberListController(
-                        query: .init(cid: cid, filter: .equal(.isModerator, to: true), pageSize: 105)
+                        query: .init(cid: cid, filter: .equal(.isModerator, to: true))
                     )
                 ), animated: true)
             }),

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -151,12 +151,10 @@ extension NSManagedObjectContext {
     }
 
     func saveMembers(payload: ChannelMemberListPayload, channelId: ChannelId, query: ChannelMemberListQuery?) -> [MemberDTO] {
-        // If it is the first page of a member moderators query, erase the initial cache.
-        // Currently we do not receive any event when the member role is updated. So there is
-        // no way to remove it from the local DB, so for now we always clear the cache for this type of query.
+        // If it is the first page of the members list, make sure to clear the members from local cache
+        // which are not in the remote response anymore.
         let isFirstPage = query?.pagination.offset == 0
-        let isModeratorQuery = query?.filter?.key == FilterKey<MemberListFilterScope, Bool>.isModerator.rawValue
-        if let queryHash = query?.queryHash, isFirstPage && isModeratorQuery {
+        if let queryHash = query?.queryHash, isFirstPage {
             let queryDTO = ChannelMemberListQueryDTO.load(queryHash: queryHash, context: self)
             queryDTO?.members = []
         }

--- a/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
@@ -143,4 +143,94 @@ final class MemberModelDTO_Tests: XCTestCase {
         let loadedMember = try XCTUnwrap(database.viewContext.member(userId: userId, cid: cid))
         XCTAssertTrue(loadedQuery.members.contains(loadedMember))
     }
+
+    // MARK: - Clear members when is moderator filter query
+
+    // This should be temporary until we have websocket events whenever a moderator has been added/removed.
+    // Currently we do not receive any event when the member role is updated. So there is
+    // no way to remove it from the local DB, so for now we always clear the cache for this type of query.
+
+    func test_saveMembers_whenFilterIsModerator_whenFirstPage_clearPreviousMembersFromQuery() throws {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        let members: ChannelMemberListPayload = .init(members: [.dummy(), .dummy()])
+        let query = ChannelMemberListQuery(cid: cid, filter: .equal(.isModerator, to: true))
+
+        // Save previous members
+        let previousMembers = try saveDummyMembers(toQuery: query, cid: cid)
+        XCTAssertEqual(previousMembers.count, 4)
+
+        // Save new members
+        var newMembers: [ChatChannelMember] = []
+        try database.writeSynchronously { session in
+            newMembers = try session.saveMembers(payload: members, channelId: cid, query: query)
+                .map { try $0.asModel() }
+        }
+
+        // Assert the members in the DB are only the new members.
+        let loadedQuery = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
+        XCTAssertEqual(Set(loadedQuery.members.map(\.user.id)), Set(newMembers.map(\.id)))
+    }
+
+    func test_saveMembers_whenFilterIsModerator_whenAnotherPage_doesNotClearPreviousMembersFromQuery() throws {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        let members: ChannelMemberListPayload = .init(members: [.dummy(), .dummy()])
+        var query = ChannelMemberListQuery(cid: cid, filter: .equal(.isModerator, to: true))
+        query.pagination = .init(pageSize: 20, offset: 25)
+
+        // Save previous members
+        let previousMembers = try saveDummyMembers(toQuery: query, cid: cid)
+        XCTAssertEqual(previousMembers.count, 4)
+
+        // Save new members
+        var newMembers: [ChatChannelMember] = []
+        try database.writeSynchronously { session in
+            newMembers = try session.saveMembers(payload: members, channelId: cid, query: query)
+                .map { try $0.asModel() }
+        }
+
+        // Assert the members in the DB contain the old and new members
+        let loadedQuery = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
+        let allMembers = previousMembers + newMembers
+        XCTAssertEqual(Set(loadedQuery.members.map(\.user.id)), Set(allMembers.map(\.id)))
+    }
+
+    func test_saveMembers_whenFilterNotModerator_whenFirstPage_doestNotClearPreviousMembersFromQuery() throws {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        let members: ChannelMemberListPayload = .init(members: [.dummy(), .dummy()])
+        var query = ChannelMemberListQuery(cid: cid, filter: .equal(.banned, to: false))
+        query.pagination = .init(pageSize: 20, offset: 0)
+
+        // Save previous members
+        let previousMembers = try saveDummyMembers(toQuery: query, cid: cid)
+        XCTAssertEqual(previousMembers.count, 4)
+
+        // Save new members
+        var newMembers: [ChatChannelMember] = []
+        try database.writeSynchronously { session in
+            newMembers = try session.saveMembers(payload: members, channelId: cid, query: query)
+                .map { try $0.asModel() }
+        }
+
+        // Assert the members in the DB contain the old and new members
+        let loadedQuery = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
+        let allMembers = previousMembers + newMembers
+        XCTAssertEqual(Set(loadedQuery.members.map(\.user.id)), Set(allMembers.map(\.id)))
+    }
+
+    private func saveDummyMembers(
+        _ members: [MemberPayload] = [.dummy(), .dummy(), .dummy(), .dummy()],
+        toQuery query: ChannelMemberListQuery,
+        cid: ChannelId
+    ) throws -> [ChatChannelMember] {
+        let members: ChannelMemberListPayload = .init(members: [.dummy(), .dummy(), .dummy(), .dummy()])
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: cid))
+            session.saveMembers(payload: members, channelId: cid, query: query)
+        }
+        let loadedQuery = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
+        return try loadedQuery.members.map { try $0.asModel() }
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/785

### 🎯 Goal
Fix the member list not updated after the moderator is demoted.

### 📝 Summary
At the moment, the backend does not fire any event to notify that a moderator has been demoted or promoted. So, if we have a moderator in the local DB that was demoted, it won't be removed from the local DB, so it will never be deleted. 

### 🛠 Implementation
Even if the backend does not fire any event, we should also make sure that when opening the member list for the first time, that we clear the cache, to make sure that removed members do not get included in the response.

### 🧪 Manual Testing Notes
Note: Make sure you have the latest update of `stream-cli` on your machine.

1. Add moderators to a channel through the CLI, example:
`stream-cli chat promote-moderators --type messaging --id 2884427A-E r2-d2 leia_organa`
2. Open the Demo App
3. Swipe the channel and tap on "..."
4. Then tap on "Show Channel Moderators"
5. You should see the added moderators
6. Go back to the Channel List
7. Demote one of the moderators:
`stream-cli chat demote-moderators --type messaging --id 2884427A-E leia_organa`
8. Open the channel moderators again
9. You should only see "r2-d2"

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
