### PR TITLE
Turn off cell reconfiguring in channel list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _March 26, 2024_
 - Expose `notificationsMuted` in `ChatChannelMember` [#3111](https://github.com/GetStream/stream-chat-swift/pull/3111)
 ### 🐞 Fixed
 - Fix saving reaction counts for messages [#3109](https://github.com/GetStream/stream-chat-swift/pull/3109)
+- Fix a crash in channel list when reconfiguring cells [#3136](https://github.com/GetStream/stream-chat-swift/pull/3136)
 ### 🔄 Changed
 - Deprecates `ChatClientConfig.maxAttachmentSize` in favour of defining the value from Stream's Dashboard [#3105](https://github.com/GetStream/stream-chat-swift/pull/3105)
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -254,7 +254,7 @@ open class ChatChannelListVC: _ViewController,
         let previousChannels = channels
         let newChannels = Array(controller.channels)
         let stagedChangeset = StagedChangeset(source: previousChannels, target: newChannels)
-        collectionView.reload(using: stagedChangeset, reconfigure: { _ in true }) { [weak self] newChannels in
+        collectionView.reload(using: stagedChangeset, reconfigure: { _ in false }) { [weak self] newChannels in
             self?.channels = newChannels
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Fix crash in channel list

### 📝 Summary

We got a report that reconfigure cell triggered an assertion in Apple's code which led to a crash. After closer inspection the core issue is ChatChannelListVC.reloadChannels reentrancy.

### 🛠 Implementation

Turn it off for now and enable it when we are properly handling reentrancy.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

