### PR TITLE
[ChatStateLayer] Switch to StateLayerDatabaseObserver in the state layer

### DIFF
--- a/Sources/StreamChat/Controllers/DatabaseObserver/StateLayerDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/StateLayerDatabaseObserver.swift
@@ -52,7 +52,7 @@ final class StateLayerDatabaseObserver<ResultType: DatabaseObserverType, Item, D
 
 @available(iOS 13.0, *)
 extension StateLayerDatabaseObserver where ResultType == EntityResult {
-    func item() -> Item? {
+    var item: Item? {
         var item: Item?
         context.performAndWait {
             item = Self.makeEntity(frc: frc, context: context, itemCreator: itemCreator, sorting: sorting)
@@ -60,11 +60,11 @@ extension StateLayerDatabaseObserver where ResultType == EntityResult {
         return item
     }
     
-    func startObserving(initial: Bool = false, didChange: @escaping (Item?) async -> Void) throws {
+    func startObserving(didChange: @escaping (Item?) async -> Void) throws {
         try startObserving(didChange: { item in Task(priority: .high) { await didChange(item) } })
     }
     
-    func startObserving(initial: Bool = false, didChange: @escaping (Item?) -> Void) throws {
+    func startObserving(didChange: @escaping (Item?) -> Void) throws {
         resultsDelegate = FetchedResultsDelegate(onDidChange: { [weak self] in
             guard let self else { return }
             // Runs on the NSManagedObjectContext's queue, therefore skip performAndWait
@@ -73,9 +73,6 @@ extension StateLayerDatabaseObserver where ResultType == EntityResult {
         })
         frc.delegate = resultsDelegate
         try frc.performFetch()
-        if initial {
-            didChange(item())
-        }
     }
     
     static func makeEntity(
@@ -102,7 +99,7 @@ extension StateLayerDatabaseObserver where ResultType == EntityResult {
 
 @available(iOS 13.0, *)
 extension StateLayerDatabaseObserver where ResultType == ListResult {
-    func items() -> StreamCollection<Item> {
+    var items: StreamCollection<Item> {
         var collection: StreamCollection<Item>!
         context.performAndWait {
             collection = Self.makeCollection(frc: frc, context: context, itemCreator: itemCreator, sorting: sorting)
@@ -110,11 +107,11 @@ extension StateLayerDatabaseObserver where ResultType == ListResult {
         return collection
     }
     
-    func startObserving(initial: Bool = false, didChange: @escaping (StreamCollection<Item>) async -> Void) throws {
-        try startObserving(initial: initial, didChange: { items in Task(priority: .high) { await didChange(items) } })
+    func startObserving(didChange: @escaping (StreamCollection<Item>) async -> Void) throws {
+        try startObserving(didChange: { items in Task(priority: .high) { await didChange(items) } })
     }
     
-    func startObserving(initial: Bool = false, didChange: @escaping (StreamCollection<Item>) -> Void) throws {
+    func startObserving(didChange: @escaping (StreamCollection<Item>) -> Void) throws {
         resultsDelegate = FetchedResultsDelegate(onDidChange: { [weak self] in
             guard let self else { return }
             // Runs on the NSManagedObjectContext's queue, therefore skip performAndWait
@@ -123,9 +120,6 @@ extension StateLayerDatabaseObserver where ResultType == ListResult {
         })
         frc.delegate = resultsDelegate
         try frc.performFetch()
-        if initial {
-            didChange(items())
-        }
     }
     
     static func makeCollection(

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -35,7 +35,7 @@ public final class ChannelListState: ObservableObject {
             })
         )
         if initialChannels.isEmpty {
-            channels = observer.channelListObserver.items()
+            channels = observer.channelListObserver.items
         }
     }
     

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -743,6 +743,7 @@ public class Chat {
                 chat: self,
                 messageOrder: state.messageOrder,
                 database: databaseContainer,
+                clientConfig: client.config,
                 replyPaginationHandler: MessagesPaginationStateHandler()
             )
             messageStates.setObject(state, forKey: messageId as NSString)

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -79,11 +79,6 @@ public final class ChatState: ObservableObject {
     /// Use load messages in ``Chat`` for loading more messages.
     @Published public internal(set) var messages = StreamCollection<ChatMessage>([])
     
-    /// An array of latest message list changes.
-    ///
-    /// - Note: The ``messageListChanges`` property is updated just before ``messages`` property changes.
-    public private(set) var messageListChanges: [ListChange<MessageId>] = []
-    
     /// Access a message which is available locally by its id.
     ///
     /// - Note: This method does a local lookup of the message and returns a message present in ``ChatState/messages``.

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -48,7 +48,11 @@ public final class ChatState: ObservableObject {
                 watchersDidChange: { [weak self] in await self?.setValue($0, for: \.watchers) }
             )
         )
-        messages = observer.messagesObserver.items()
+        channel = observer.channelObserver.item
+        members = observer.memberListState.members
+        messages = observer.messagesObserver.items
+        typingUsers = channel?.currentlyTypingUsers ?? Set()
+        watchers = observer.watchersObserver.items
     }
     
     // MARK: - Represented Channel

--- a/Sources/StreamChat/StateLayer/MemberListState.swift
+++ b/Sources/StreamChat/StateLayer/MemberListState.swift
@@ -15,6 +15,9 @@ public final class MemberListState: ObservableObject {
         observer.start(
             with: .init(membersDidChange: { [weak self] members in await self?.setValue(members, for: \.members) })
         )
+        if members.isEmpty {
+            self.members = observer.memberListObserver.items
+        }
     }
     
     /// An array of members for the specified ``ChannelMemberListQuery``.

--- a/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
@@ -45,7 +45,10 @@ extension MessageSearchState {
                     sorting: []
                 )
                 do {
-                    try messagesObserver?.startObserving(initial: true, didChange: handlers.messagesDidChange)
+                    if let messagesObserver {
+                        try messagesObserver.startObserving(didChange: handlers.messagesDidChange)
+                        Task { await handlers.messagesDidChange(messagesObserver.items) }
+                    }
                 } catch {
                     log.error("Failed to start the message result observer for query (\(query) with error \(error)")
                 }

--- a/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
@@ -41,12 +41,12 @@ extension MessageSearchState {
                 messagesObserver = StateLayerDatabaseObserver(
                     databaseContainer: database,
                     fetchRequest: MessageDTO.messagesFetchRequest(for: query),
-                    itemCreator: { try $0.asModel() as ChatMessage },
-                    sorting: []
+                    itemCreator: { try $0.asModel() as ChatMessage }
                 )
                 do {
                     if let messagesObserver {
                         try messagesObserver.startObserving(didChange: handlers.messagesDidChange)
+                        // Sending the initial value since we keep recreating the observer
                         Task { await handlers.messagesDidChange(messagesObserver.items) }
                     }
                 } catch {

--- a/Sources/StreamChat/StateLayer/MessageState.swift
+++ b/Sources/StreamChat/StateLayer/MessageState.swift
@@ -13,12 +13,12 @@ public final class MessageState: ObservableObject {
 
     let replyPaginationHandler: MessagesPaginationStateHandling
     
-    init(message: ChatMessage, chat: Chat, messageOrder: MessageOrdering, database: DatabaseContainer, replyPaginationHandler: MessagesPaginationStateHandling) {
+    init(message: ChatMessage, chat: Chat, messageOrder: MessageOrdering, database: DatabaseContainer, clientConfig: ChatClientConfig, replyPaginationHandler: MessagesPaginationStateHandling) {
         self.chat = chat
         self.message = message
         self.messageOrder = messageOrder
         self.replyPaginationHandler = replyPaginationHandler
-        observer = Observer(messageId: message.id, messageOrder: messageOrder, database: database)
+        observer = Observer(messageId: message.id, messageOrder: messageOrder, database: database, clientConfig: clientConfig)
         observer.start(
             with: .init(
                 messageDidChange: { [weak self] in await self?.setValue($0, for: \.message) },
@@ -26,6 +26,8 @@ public final class MessageState: ObservableObject {
                 repliesDidChange: { [weak self] in await self?.setValue($0, for: \.replies) }
             )
         )
+        reactions = message.latestReactions.sorted(by: { $0.updatedAt > $1.updatedAt })
+        replies = observer.repliesObserver.items
     }
     
     var messageId: MessageId { message.id }

--- a/Sources/StreamChat/StateLayer/UserListState.swift
+++ b/Sources/StreamChat/StateLayer/UserListState.swift
@@ -16,7 +16,7 @@ public final class UserListState: ObservableObject {
             with: .init(usersDidChange: { [weak self] change in await self?.setValue(change, for: \.users) })
         )
         if users.isEmpty {
-            self.users = observer.usersObserver.items()
+            self.users = observer.usersObserver.items
         }
     }
     

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -24,6 +24,7 @@ final class Chat_Tests: XCTestCase {
         env.cleanUp()
         channelId = nil
         chat = nil
+        env = nil
         expectedTestError = nil
     }
     

--- a/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
@@ -19,8 +19,8 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        channelId = nil
         client.cleanUp()
+        channelId = nil
         client = nil
     }
 
@@ -31,7 +31,6 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         var changeCount = 0
         let observer = makeChannelObserver()
         try observer.startObserving(
-            initial: false,
             didChange: { _ in
                 changeCount += 1
                 expectation.fulfill()
@@ -50,7 +49,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         #else
         wait(for: [expectation], timeout: defaultTimeout)
         #endif
-        XCTAssertEqual("first", observer.item()?.name)
+        XCTAssertEqual("first", observer.item?.name)
         XCTAssertEqual(1, changeCount)
     }
     
@@ -64,7 +63,6 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         var changeCount = 0
         let observer = makeChannelObserver()
         try observer.startObserving(
-            initial: false,
             didChange: { _ in
                 changeCount += 1
                 expectation.fulfill()
@@ -84,7 +82,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         #else
         wait(for: [expectation], timeout: defaultTimeout)
         #endif
-        XCTAssertEqual("second", observer.item()?.name)
+        XCTAssertEqual("second", observer.item?.name)
         XCTAssertEqual(1, changeCount)
     }
     
@@ -93,7 +91,6 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         var changeCount = 0
         let observer = makeChannelObserver()
         try observer.startObserving(
-            initial: false,
             didChange: { _ in
                 changeCount += 1
                 expectation.fulfill()
@@ -118,8 +115,8 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         #else
         wait(for: [expectation], timeout: defaultTimeout)
         #endif
-        XCTAssertEqual("second", observer.item()?.name)
-        XCTAssertEqual("team2", observer.item()?.team)
+        XCTAssertEqual("second", observer.item?.name)
+        XCTAssertEqual("team2", observer.item?.team)
         XCTAssertEqual(2, changeCount)
     }
     
@@ -135,7 +132,6 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         var changeCount = 0
         let observer = makeMessagesListObserver()
         try observer.startObserving(
-            initial: false,
             didChange: { _ in
                 changeCount += 1
                 expectation.fulfill()
@@ -154,9 +150,9 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         #else
         wait(for: [expectation], timeout: defaultTimeout)
         #endif
-        XCTAssertEqual(8, observer.items().count)
+        XCTAssertEqual(8, observer.items.count)
         let expectedIds = (firstPayload.messages + secondPayload.messages).map(\.id)
-        XCTAssertEqual(expectedIds, observer.items().map(\.id))
+        XCTAssertEqual(expectedIds, observer.items.map(\.id))
         XCTAssertEqual(1, changeCount)
     }
     
@@ -169,12 +165,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(
-            initial: false,
-            didChange: { _ in
-                changeCount += 1
-                expectation.fulfill()
-            }
+        try observer.startObserving(didChange: { _ in
+            changeCount += 1
+            expectation.fulfill()
+        }
         )
         
         let secondPayload = makeChannelPayload(messageCount: 3, createdAtOffset: 5)
@@ -193,8 +187,8 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         #else
         wait(for: [expectation], timeout: defaultTimeout)
         #endif
-        XCTAssertEqual(3, observer.items().count)
-        XCTAssertEqual(secondPayload.messages.map(\.id), observer.items().map(\.id))
+        XCTAssertEqual(3, observer.items.count)
+        XCTAssertEqual(secondPayload.messages.map(\.id), observer.items.map(\.id))
         XCTAssertEqual(1, changeCount)
     }
     
@@ -208,7 +202,6 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         var changeCount = 0
         let observer = makeMessagesListObserver()
         try observer.startObserving(
-            initial: false,
             didChange: { _ in
                 changeCount += 1
                 expectation.fulfill()
@@ -233,9 +226,9 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         #else
         wait(for: [expectation], timeout: defaultTimeout)
         #endif
-        XCTAssertEqual(11, observer.items().count)
+        XCTAssertEqual(11, observer.items.count)
         let expectedIds = (firstPayload.messages + secondPayload.messages + thirdPayload.messages).map(\.id)
-        XCTAssertEqual(expectedIds, observer.items().map(\.id))
+        XCTAssertEqual(expectedIds, observer.items.map(\.id))
         XCTAssertEqual(2, changeCount)
     }
     


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Use the dedicated StateLayerDatabaseObserver in every state layer type

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
