### PR TITLE
[ChatStateLayer] DB observing improvements & tests for MessageState

### DIFF
--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -266,8 +266,8 @@ class DatabaseContainer: NSPersistentContainer {
     }
     
     @available(iOS 13.0, *)
-    func backgroundRead<T>(from context: NSManagedObjectContext? = nil, _ actions: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {
-        let context = context ?? backgroundReadOnlyContext
+    func read<T>(_ actions: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {
+        let context = stateLayerContext
         return try await withCheckedThrowingContinuation { continuation in
             context.perform {
                 do {

--- a/Sources/StreamChat/Extensions/Task+Extensions.swift
+++ b/Sources/StreamChat/Extensions/Task+Extensions.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+extension Task {
+    @discardableResult static func mainActor(operation: @escaping () async throws -> Success) -> Task<Success, Failure> where Failure == any Error {
+        Task { @MainActor in
+            try await operation()
+        }
+    }
+}

--- a/Sources/StreamChat/Extensions/Task+Extensions.swift
+++ b/Sources/StreamChat/Extensions/Task+Extensions.swift
@@ -6,8 +6,8 @@ import Foundation
 
 @available(iOS 13.0, *)
 extension Task {
-    @discardableResult static func mainActor(operation: @escaping () async throws -> Success) -> Task<Success, Failure> where Failure == any Error {
-        Task { @MainActor in
+    @discardableResult static func mainActor(priority: TaskPriority? = nil, operation: @escaping @MainActor() async throws -> Success) -> Task<Success, Failure> where Failure == any Error {
+        Task(priority: priority) { @MainActor in
             try await operation()
         }
     }

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -264,7 +264,7 @@ class MessageRepository {
 extension MessageRepository {
     /// Fetches messages from the database with a date range.
     func messages(from fromDate: Date, to toDate: Date, in cid: ChannelId) async throws -> [ChatMessage] {
-        try await database.backgroundRead { context in
+        try await database.read { context in
             try MessageDTO.loadMessages(
                 from: fromDate,
                 to: toDate,
@@ -280,7 +280,7 @@ extension MessageRepository {
     
     /// Fetches a message id before the specified message when sorting by the creation date in the local database.
     func message(before id: MessageId, in cid: ChannelId) async throws -> MessageId? {
-        try await database.backgroundRead { context in
+        try await database.read { context in
             let deletedMessagesVisibility = context.deletedMessagesVisibility ?? .alwaysVisible
             let shouldShowShadowedMessages = context.shouldShowShadowedMessages ?? true
             return try MessageDTO.loadMessage(
@@ -295,7 +295,7 @@ extension MessageRepository {
     
     /// Fetches replies from the database with a date range.
     func replies(from fromDate: Date, to toDate: Date, in message: MessageId) async throws -> [ChatMessage] {
-        try await database.backgroundRead { context in
+        try await database.read { context in
             try MessageDTO.loadReplies(
                 from: fromDate,
                 to: toDate,

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -70,7 +70,7 @@ extension ChannelListState {
                 },
                 EventObserver(notificationCenter: nc, transform: { $0 as? ChannelVisibleEvent }) { [weak self] event in
                     guard let self else { return }
-                    let channel = try await self.database.backgroundRead { context in
+                    let channel = try await self.database.read { context in
                         guard let dto = ChannelDTO.load(cid: event.cid, context: context) else {
                             throw ClientError.ChannelDoesNotExist(cid: event.cid)
                         }
@@ -102,7 +102,7 @@ extension ChannelListState {
         }
         
         private func isChannelInList(_ cid: ChannelId) async throws -> Bool {
-            try await database.backgroundRead { [query] context in
+            try await database.read { [query] context in
                 guard let (channelDTO, queryDTO) = context.getChannelWithQuery(cid: cid, query: query) else { return false }
                 return queryDTO.channels.contains(channelDTO)
             }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -740,7 +740,6 @@ public class Chat {
             let message = try await messageUpdater.getMessage(cid: cid, messageId: messageId)
             let state = MessageState(
                 message: message,
-                chat: self,
                 messageOrder: state.messageOrder,
                 database: databaseContainer,
                 clientConfig: client.config,

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -12,7 +12,7 @@ extension ChatClient {
     ///
     /// - Throws: An error if no user is currently logged-in.
     public func makeConnectedUser() async throws -> ConnectedUser {
-        let user = try await databaseContainer.backgroundRead { try CurrentUserDTO.load(context: $0) }
+        let user = try await databaseContainer.read { try CurrentUserDTO.load(context: $0) }
         return ConnectedUser(user: user, client: self)
     }
 }

--- a/Sources/StreamChat/StateLayer/ConnectedUserState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUserState+Observer.swift
@@ -23,9 +23,9 @@ extension ConnectedUserState {
         
         func start(with handlers: Handlers) {
             do {
-                try userObserver.startObserving(didChange: { user in
+                try userObserver.startObserving(onContextDidChange: { user in
                     guard let user else { return }
-                    await handlers.userDidChange(user)
+                    Task.mainActor { await handlers.userDidChange(user) }
                 })
             } catch {
                 log.error("Failed to start the current user observer")

--- a/Sources/StreamChat/StateLayer/MessageState.swift
+++ b/Sources/StreamChat/StateLayer/MessageState.swift
@@ -7,30 +7,25 @@ import Foundation
 /// Represents a ``ChatMessage`` and its state.
 @available(iOS 13.0, *)
 public final class MessageState: ObservableObject {
-    private let chat: Chat
     private let messageOrder: MessageOrdering
     private let observer: Observer
 
     let replyPaginationHandler: MessagesPaginationStateHandling
     
-    init(message: ChatMessage, chat: Chat, messageOrder: MessageOrdering, database: DatabaseContainer, clientConfig: ChatClientConfig, replyPaginationHandler: MessagesPaginationStateHandling) {
-        self.chat = chat
+    init(message: ChatMessage, messageOrder: MessageOrdering, database: DatabaseContainer, clientConfig: ChatClientConfig, replyPaginationHandler: MessagesPaginationStateHandling) {
         self.message = message
         self.messageOrder = messageOrder
         self.replyPaginationHandler = replyPaginationHandler
         observer = Observer(messageId: message.id, messageOrder: messageOrder, database: database, clientConfig: clientConfig)
         observer.start(
             with: .init(
-                messageDidChange: { [weak self] in await self?.setValue($0, for: \.message) },
-                reactionsDidChange: { [weak self] in await self?.setValue($0, for: \.reactions) },
+                messageDidChange: { [weak self] in await self?.handleMessageDidChange($0, changedReactions: $1) },
                 repliesDidChange: { [weak self] in await self?.setValue($0, for: \.replies) }
             )
         )
-        reactions = message.latestReactions.sorted(by: { $0.updatedAt > $1.updatedAt })
+        reactions = message.latestReactions.sorted(by: MessageState.reactionsSorting)
         replies = observer.repliesObserver.items
     }
-    
-    var messageId: MessageId { message.id }
     
     var replyPaginationState: MessagesPaginationState {
         replyPaginationHandler.state
@@ -88,5 +83,19 @@ public final class MessageState: ObservableObject {
     // Force mutations on main actor since ChatState is meant to be used by UI.
     @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<MessageState, Value>) {
         self[keyPath: keyPath] = value
+    }
+    
+    @MainActor func handleMessageDidChange(_ message: ChatMessage, changedReactions: [ChatMessageReaction]?) {
+        if let changedReactions {
+            reactions = changedReactions
+        }
+        self.message = message
+    }
+}
+
+@available(iOS 13.0, *)
+extension MessageState {
+    static func reactionsSorting(_ first: ChatMessageReaction, _ second: ChatMessageReaction) -> Bool {
+        first.updatedAt > second.updatedAt
     }
 }

--- a/Sources/StreamChat/StateLayer/MessageState.swift
+++ b/Sources/StreamChat/StateLayer/MessageState.swift
@@ -12,11 +12,22 @@ public final class MessageState: ObservableObject {
 
     let replyPaginationHandler: MessagesPaginationStateHandling
     
-    init(message: ChatMessage, messageOrder: MessageOrdering, database: DatabaseContainer, clientConfig: ChatClientConfig, replyPaginationHandler: MessagesPaginationStateHandling) {
+    init(
+        message: ChatMessage,
+        messageOrder: MessageOrdering,
+        database: DatabaseContainer,
+        clientConfig: ChatClientConfig,
+        replyPaginationHandler: MessagesPaginationStateHandling
+    ) {
         self.message = message
         self.messageOrder = messageOrder
         self.replyPaginationHandler = replyPaginationHandler
-        observer = Observer(messageId: message.id, messageOrder: messageOrder, database: database, clientConfig: clientConfig)
+        observer = Observer(
+            messageId: message.id,
+            messageOrder: messageOrder,
+            database: database,
+            clientConfig: clientConfig
+        )
         observer.start(
             with: .init(
                 messageDidChange: { [weak self] in await self?.handleMessageDidChange($0, changedReactions: $1) },

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -732,7 +732,7 @@ extension ChannelUpdater {
             }
         }
         guard let ids = payload.watchers?.map(\.id) else { return [] }
-        return try await database.backgroundRead { context in
+        return try await database.read { context in
             try ids.compactMap { try UserDTO.load(id: $0, context: context)?.asModel() }
         }
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -256,8 +256,11 @@
 		4F427F6A2BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6C2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
 		4F427F6D2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
-		4F5151982BC407ED001B7152 /* UserList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151972BC407ED001B7152 /* UserList_Tests.swift */; };
 		4F5151962BC3DEA1001B7152 /* UserSearch_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */; };
+		4F5151982BC407ED001B7152 /* UserList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151972BC407ED001B7152 /* UserList_Tests.swift */; };
+		4F51519A2BC57C40001B7152 /* MessageState_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151992BC57C40001B7152 /* MessageState_Tests.swift */; };
+		4F51519C2BC66FBE001B7152 /* Task+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F51519B2BC66FBE001B7152 /* Task+Extensions.swift */; };
+		4F51519D2BC66FBE001B7152 /* Task+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F51519B2BC66FBE001B7152 /* Task+Extensions.swift */; };
 		4F73F3982B91BD3000563CD9 /* MessageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F3972B91BD3000563CD9 /* MessageState.swift */; };
 		4F73F3992B91BD3000563CD9 /* MessageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F3972B91BD3000563CD9 /* MessageState.swift */; };
 		4F73F39E2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */; };
@@ -2961,8 +2964,10 @@
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
-		4F5151972BC407ED001B7152 /* UserList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList_Tests.swift; sourceTree = "<group>"; };
 		4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearch_Tests.swift; sourceTree = "<group>"; };
+		4F5151972BC407ED001B7152 /* UserList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList_Tests.swift; sourceTree = "<group>"; };
+		4F5151992BC57C40001B7152 /* MessageState_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState_Tests.swift; sourceTree = "<group>"; };
+		4F51519B2BC66FBE001B7152 /* Task+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Extensions.swift"; sourceTree = "<group>"; };
 		4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList_Tests.swift; sourceTree = "<group>"; };
 		4F73F3972B91BD3000563CD9 /* MessageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState.swift; sourceTree = "<group>"; };
 		4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageState+Observer.swift"; sourceTree = "<group>"; };
@@ -4940,6 +4945,7 @@
 				4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */,
 				4FB4AB9E2BAD6DBD00712C4E /* Chat_Tests.swift */,
 				4F14F1292BBE8C1900B1074E /* MessageSearch_Tests.swift */,
+				4F5151992BC57C40001B7152 /* MessageState_Tests.swift */,
 				4F072F022BC008D9006A66CA /* StateLayerDatabaseObserver_Tests.swift */,
 				4F5151972BC407ED001B7152 /* UserList_Tests.swift */,
 				4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */,
@@ -7140,6 +7146,7 @@
 			children = (
 				4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */,
 				A36C39F42860680A0004EB7E /* URL+EnrichedURL.swift */,
+				4F51519B2BC66FBE001B7152 /* Task+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -10906,6 +10913,7 @@
 				DA640FC12535CFA100D32944 /* ChannelMemberListSortingKey.swift in Sources */,
 				7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */,
 				404296DA2A0112D00089126D /* AudioQueuePlayer.swift in Sources */,
+				4F51519C2BC66FBE001B7152 /* Task+Extensions.swift in Sources */,
 				792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */,
 				79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */,
 				F688643624E6DA8700A71361 /* CurrentUserController.swift in Sources */,
@@ -11287,6 +11295,7 @@
 				8A0CC9EB24C601F600705CF9 /* MemberEvents_Tests.swift in Sources */,
 				C1A25D6029E70DEB00DAE933 /* FetchCache_Tests.swift in Sources */,
 				A32D55142860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift in Sources */,
+				4F51519A2BC57C40001B7152 /* MessageState_Tests.swift in Sources */,
 				792B805224D95D4300C2963E /* Cached_StressTests.swift in Sources */,
 				4F14F12A2BBE8C1900B1074E /* MessageSearch_Tests.swift in Sources */,
 				A34ECB4A27F5CA1B00A804C1 /* TypingEvents_IntegrationTests.swift in Sources */,
@@ -11769,6 +11778,7 @@
 				C121E89A274544B000023E4C /* MuteDetails.swift in Sources */,
 				C121E89B274544B000023E4C /* Controller.swift in Sources */,
 				404296DE2A0114900089126D /* StreamAudioQueuePlayer_Tests.swift in Sources */,
+				4F51519D2BC66FBE001B7152 /* Task+Extensions.swift in Sources */,
 				C121E89C274544B000023E4C /* DataController.swift in Sources */,
 				AD17CDFA27E4DB2700E0D092 /* PushProvider.swift in Sources */,
 				C121E89D274544B000023E4C /* UserSearchController.swift in Sources */,

--- a/TestTools/StreamChatTestTools/TestData/DummyData/MessageReactionPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/MessageReactionPayload.swift
@@ -9,6 +9,7 @@ extension MessageReactionPayload {
     static func dummy(
         type: MessageReactionType = .init(rawValue: .unique),
         messageId: String,
+        updatedAt: Date = .unique,
         user: UserPayload,
         extraData: [String: RawJSON] = [:]
     ) -> MessageReactionPayload {
@@ -17,7 +18,7 @@ extension MessageReactionPayload {
             score: .random(in: 0...10),
             messageId: messageId,
             createdAt: .unique,
-            updatedAt: .unique,
+            updatedAt: updatedAt,
             user: user,
             extraData: extraData
         )

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -230,37 +230,6 @@ final class Chat_Tests: XCTestCase {
         XCTAssertEqual(false, chat.state.isLoadingNextMessages)
     }
     
-    // MARK: -
-    
-    /// Configures chat for testing.
-    ///
-    /// - Parameter usesMockedChannelUpdater: Set it for false for tests which need to update the local DB and simulate API requests.
-    private func setUpChat(usesMockedChannelUpdater: Bool) {
-        chat = Chat(
-            cid: channelId,
-            channelQuery: ChannelQuery(cid: channelId),
-            channelListQuery: nil,
-            messageOrdering: .bottomToTop,
-            memberSorting: [Sorting(key: .createdAt)],
-            channelUpdater: usesMockedChannelUpdater ? env.channelUpdaterMock : env.channelUpdater,
-            client: env.client,
-            environment: env.chatEnvironment
-        )
-    }
-    
-    private func makeChannelPayload(messageCount: Int, createdAtOffset: Int) -> ChannelPayload {
-        // Note that message pagination relies on createdAt and cid
-        let messages: [MessagePayload] = (0..<messageCount)
-            .map {
-                .dummy(
-                    messageId: "\($0 + createdAtOffset)",
-                    createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0 + createdAtOffset)),
-                    cid: chat.cid
-                )
-            }
-        return ChannelPayload.dummy(channel: .dummy(cid: chat.cid), messages: messages)
-    }
-    
     // MARK: - Members
     
     func test_addMembers_whenAPIRequestSucceeds_thenAddMembersSucceeds() async throws {
@@ -1351,6 +1320,37 @@ final class Chat_Tests: XCTestCase {
     // TODO: not done
     public func test_loadNextWatchersAction_whenAPIRequestFails_thenLoadNextWatchersActionSucceeds() async throws {
         // loadNextWatchers(limit: Int? = nil)
+    }
+    
+    // MARK: - Test Data
+    
+    /// Configures chat for testing.
+    ///
+    /// - Parameter usesMockedChannelUpdater: Set it for false for tests which need to update the local DB and simulate API requests.
+    private func setUpChat(usesMockedChannelUpdater: Bool) {
+        chat = Chat(
+            cid: channelId,
+            channelQuery: ChannelQuery(cid: channelId),
+            channelListQuery: nil,
+            messageOrdering: .bottomToTop,
+            memberSorting: [Sorting(key: .createdAt)],
+            channelUpdater: usesMockedChannelUpdater ? env.channelUpdaterMock : env.channelUpdater,
+            client: env.client,
+            environment: env.chatEnvironment
+        )
+    }
+    
+    private func makeChannelPayload(messageCount: Int, createdAtOffset: Int) -> ChannelPayload {
+        // Note that message pagination relies on createdAt and cid
+        let messages: [MessagePayload] = (0..<messageCount)
+            .map {
+                .dummy(
+                    messageId: "\($0 + createdAtOffset)",
+                    createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0 + createdAtOffset)),
+                    cid: chat.cid
+                )
+            }
+        return ChannelPayload.dummy(channel: .dummy(cid: chat.cid), messages: messages)
     }
 }
 

--- a/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
@@ -54,9 +54,19 @@ final class MessageState_Tests: XCTestCase {
     func test_restoringReactions_whenReactionsStored_thenInitialStateIsSet() async throws {
         let messagePayload = makeMessagePayload(reactionCount: 3, messageId: messageId)
         try await env.client.databaseContainer.write { session in
-            try session.saveMessage(payload: messagePayload, for: self.channelId, syncOwnReactions: true, cache: nil)
-            // Unrelated
-            try session.saveMessage(payload: self.makeMessagePayload(reactionCount: 3, messageId: self.unrelatedMessageId), for: self.channelId, syncOwnReactions: true, cache: nil)
+            try session.saveMessage(
+                payload: messagePayload,
+                for: self.channelId,
+                syncOwnReactions: true,
+                cache: nil
+            )
+            // Add reactions to other messages for ensuring MessageState does not pick them up
+            try session.saveMessage(
+                payload: self.makeMessagePayload(reactionCount: 3, messageId: self.unrelatedMessageId),
+                for: self.channelId,
+                syncOwnReactions: true,
+                cache: nil
+            )
         }
         
         try await setUpMessageState(writeMessages: false)
@@ -70,9 +80,19 @@ final class MessageState_Tests: XCTestCase {
         
         let messagePayload = makeMessagePayload(reactionCount: 3, messageId: messageId)
         try await env.client.databaseContainer.write { session in
-            try session.saveMessage(payload: messagePayload, for: self.channelId, syncOwnReactions: true, cache: nil)
-            // Unrelated
-            try session.saveMessage(payload: self.makeMessagePayload(reactionCount: 3, messageId: self.unrelatedMessageId), for: self.channelId, syncOwnReactions: true, cache: nil)
+            try session.saveMessage(
+                payload: messagePayload,
+                for: self.channelId,
+                syncOwnReactions: true,
+                cache: nil
+            )
+            // Add reactions to other messages for ensuring MessageState does not pick them up
+            try session.saveMessage(
+                payload: self.makeMessagePayload(reactionCount: 3, messageId: self.unrelatedMessageId),
+                for: self.channelId,
+                syncOwnReactions: true,
+                cache: nil
+            )
         }
         
         // Default sorting is updatedAt and ascending (generated payload is sorted like this)
@@ -85,13 +105,23 @@ final class MessageState_Tests: XCTestCase {
         let replyPayloads = makeMessageRepliesPayload(repliesCount: 3, parentMessageId: messageId)
         try await env.client.databaseContainer.write { session in
             for replyPayload in replyPayloads {
-                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                let message = try session.saveMessage(
+                    payload: replyPayload,
+                    for: self.channelId,
+                    syncOwnReactions: true,
+                    cache: nil
+                )
                 message.showInsideThread = true
             }
             // Unrelated
             let unrelatedReplies = self.makeMessageRepliesPayload(repliesCount: 5, parentMessageId: self.unrelatedMessageId)
             for replyPayload in unrelatedReplies {
-                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                let message = try session.saveMessage(
+                    payload: replyPayload,
+                    for: self.channelId,
+                    syncOwnReactions: true,
+                    cache: nil
+                )
                 message.showInsideThread = true
             }
         }
@@ -109,13 +139,23 @@ final class MessageState_Tests: XCTestCase {
         let replyPayloads = makeMessageRepliesPayload(repliesCount: 3, parentMessageId: messageId)
         try await env.client.databaseContainer.write { session in
             for replyPayload in replyPayloads {
-                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                let message = try session.saveMessage(
+                    payload: replyPayload,
+                    for: self.channelId,
+                    syncOwnReactions: true,
+                    cache: nil
+                )
                 message.showInsideThread = true
             }
             // Unrelated
             let unrelatedReplies = self.makeMessageRepliesPayload(repliesCount: 5, parentMessageId: self.unrelatedMessageId)
             for replyPayload in unrelatedReplies {
-                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                let message = try session.saveMessage(
+                    payload: replyPayload,
+                    for: self.channelId,
+                    syncOwnReactions: true,
+                    cache: nil
+                )
                 message.showInsideThread = true
             }
         }

--- a/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
@@ -134,7 +134,7 @@ final class MessageState_Tests: XCTestCase {
             }
         }
         
-        let message = try await env.client.databaseContainer.backgroundRead { context in
+        let message = try await env.client.databaseContainer.read { context in
             guard let dto = context.message(id: self.messageId) else { throw ClientError.MessageDoesNotExist(messageId: self.messageId) }
             return try dto.asModel()
         }

--- a/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
@@ -1,0 +1,223 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+@available(iOS 13.0, *)
+final class MessageState_Tests: XCTestCase {
+    private var channelId: ChannelId!
+    private var env: TestEnvironment!
+    private var messageId: MessageId!
+    private var testError: TestError!
+    private var unrelatedMessageId: MessageId!
+    // Main actor since message state mutates on the main actor and we want to read results on the main actor
+    @MainActor private var messageState: MessageState!
+    
+    override func setUpWithError() throws {
+        channelId = .unique
+        env = TestEnvironment()
+        messageId = .unique
+        unrelatedMessageId = .unique
+        
+        // Channel is required for saving messages
+        env.client.databaseContainer.write { session in
+            try session.saveChannel(payload: self.makeChannelPayload(messageId: nil))
+        }
+    }
+
+    @MainActor override func tearDownWithError() throws {
+        env.cleanUp()
+        channelId = nil
+        env = nil
+        messageId = nil
+        messageState = nil
+        unrelatedMessageId = nil
+    }
+
+    // MARK: - Observing Message
+    
+    func test_observingMessage_whenMessageChanges_thenStateChanges() async throws {
+        try await setUpMessageState()
+        XCTAssertEqual(nil, await messageState.message.localState)
+        
+        try await modifyMessage { dto in
+            dto.localMessageState = .sendingFailed
+        }
+        XCTAssertEqual(LocalMessageState.sendingFailed, await messageState.message.localState)
+    }
+    
+    // MARK: - Observing Reactions
+    
+    func test_restoringReactions_whenReactionsStored_thenInitialStateIsSet() async throws {
+        let messagePayload = makeMessagePayload(reactionCount: 3, messageId: messageId)
+        try await env.client.databaseContainer.write { session in
+            try session.saveMessage(payload: messagePayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+            // Unrelated
+            try session.saveMessage(payload: self.makeMessagePayload(reactionCount: 3, messageId: self.unrelatedMessageId), for: self.channelId, syncOwnReactions: true, cache: nil)
+        }
+        
+        try await setUpMessageState(writeMessages: false)
+        // Default sorting is updatedAt and ascending (generated payload is sorted like this)
+        XCTAssertEqual(messagePayload.latestReactions.map(\.updatedAt), await messageState.reactions.map(\.updatedAt))
+    }
+    
+    func test_observingReactions_whenReactionsChange_thenStateChanges() async throws {
+        try await setUpMessageState()
+        XCTAssertEqual(0, await messageState.reactions.count)
+        
+        let messagePayload = makeMessagePayload(reactionCount: 3, messageId: messageId)
+        try await env.client.databaseContainer.write { session in
+            try session.saveMessage(payload: messagePayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+            // Unrelated
+            try session.saveMessage(payload: self.makeMessagePayload(reactionCount: 3, messageId: self.unrelatedMessageId), for: self.channelId, syncOwnReactions: true, cache: nil)
+        }
+        
+        // Default sorting is updatedAt and ascending (generated payload is sorted like this)
+        XCTAssertEqual(messagePayload.latestReactions.map(\.updatedAt), await messageState.reactions.map(\.updatedAt))
+    }
+    
+    // MARK: - Observing Replies
+    
+    func test_restoringReplies_whenRepliesStored_thenInitialStateIsSet() async throws {
+        let replyPayloads = makeMessageRepliesPayload(repliesCount: 3, parentMessageId: messageId)
+        try await env.client.databaseContainer.write { session in
+            for replyPayload in replyPayloads {
+                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                message.showInsideThread = true
+            }
+            // Unrelated
+            let unrelatedReplies = self.makeMessageRepliesPayload(repliesCount: 5, parentMessageId: self.unrelatedMessageId)
+            for replyPayload in unrelatedReplies {
+                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                message.showInsideThread = true
+            }
+        }
+        
+        try await setUpMessageState()
+        
+        XCTAssertEqual(3, await messageState.replies.count)
+        XCTAssertEqual(replyPayloads.map(\.id), await messageState.replies.map(\.id))
+    }
+    
+    func test_observingReplies_whenRepliesChange_thenStateChanges() async throws {
+        try await setUpMessageState()
+        XCTAssertEqual(0, await messageState.replies.count)
+        
+        let replyPayloads = makeMessageRepliesPayload(repliesCount: 3, parentMessageId: messageId)
+        try await env.client.databaseContainer.write { session in
+            for replyPayload in replyPayloads {
+                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                message.showInsideThread = true
+            }
+            // Unrelated
+            let unrelatedReplies = self.makeMessageRepliesPayload(repliesCount: 5, parentMessageId: self.unrelatedMessageId)
+            for replyPayload in unrelatedReplies {
+                let message = try session.saveMessage(payload: replyPayload, for: self.channelId, syncOwnReactions: true, cache: nil)
+                message.showInsideThread = true
+            }
+        }
+        
+        XCTAssertEqual(3, await messageState.replies.count)
+        XCTAssertEqual(replyPayloads.map(\.id), await messageState.replies.map(\.id))
+    }
+    
+    // MARK: - Test Data
+    
+    private func setUpMessageState(writeMessages: Bool = true) async throws {
+        if writeMessages {
+            try await env.client.databaseContainer.write { session in
+                try session.saveChannel(payload: self.makeChannelPayload(messageId: self.messageId))
+                try session.saveChannel(payload: self.makeChannelPayload(messageId: self.unrelatedMessageId))
+            }
+        }
+        
+        let message = try await env.client.databaseContainer.backgroundRead { context in
+            guard let dto = context.message(id: self.messageId) else { throw ClientError.MessageDoesNotExist(messageId: self.messageId) }
+            return try dto.asModel()
+        }
+        await MainActor.run {
+            messageState = MessageState(
+                message: message,
+                messageOrder: .bottomToTop,
+                database: env.client.databaseContainer,
+                clientConfig: env.client.config,
+                replyPaginationHandler: env.client.makeMessagesPaginationStateHandler()
+            )
+        }
+    }
+    
+    private func modifyMessage(_ block: @escaping (MessageDTO) -> Void) async throws {
+        try await env.client.databaseContainer.write { session in
+            guard let dto = session.message(id: self.messageId) else { throw ClientError.MessageDoesNotExist(messageId: self.messageId) }
+            block(dto)
+        }
+    }
+    
+    private func makeChannelPayload(messageId: MessageId?) -> ChannelPayload {
+        // Note that message pagination relies on createdAt and cid
+        var messages = [MessagePayload]()
+        if let messageId {
+            messages.append(
+                MessagePayload.dummy(
+                    messageId: messageId,
+                    createdAt: Date(timeIntervalSinceReferenceDate: 0),
+                    cid: .unique
+                )
+            )
+        }
+        return ChannelPayload.dummy(channel: .dummy(cid: channelId), messages: messages)
+    }
+    
+    private func makeMessagePayload(reactionCount: Int, messageId: MessageId) -> MessagePayload {
+        let reactions = (0..<reactionCount)
+            .reversed() // last updated ones first
+            .map {
+                MessageReactionPayload.dummy(
+                    messageId: messageId,
+                    updatedAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0)),
+                    user: .dummy(userId: .unique)
+                )
+            }
+        return MessagePayload.dummy(messageId: messageId, latestReactions: reactions)
+    }
+    
+    private func makeMessageRepliesPayload(repliesCount: Int, parentMessageId: MessageId) -> [MessagePayload] {
+        (0..<repliesCount)
+            .map {
+                MessagePayload.dummy(
+                    messageId: "\(parentMessageId)_reply_\($0)",
+                    parentId: parentMessageId,
+                    createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0)),
+                    cid: channelId
+                )
+            }
+    }
+}
+
+@available(iOS 13.0, *)
+extension MessageState_Tests {
+    final class TestEnvironment {
+        let client: ChatClient_Mock
+        private(set) var state: MessageSearchState!
+        private(set) var messageUpdater: MessageUpdater!
+        
+        func cleanUp() {
+            client.cleanUp()
+        }
+        
+        init() {
+            client = ChatClient_Mock(
+                config: ChatClient_Mock.defaultMockedConfig
+            )
+            messageUpdater = MessageUpdater(
+                isLocalStorageEnabled: true,
+                messageRepository: client.mockMessageRepository,
+                database: client.mockDatabaseContainer,
+                apiClient: client.mockAPIClient
+            )
+        }
+    }
+}

--- a/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
@@ -30,12 +30,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeChannelObserver()
-        try observer.startObserving(
-            didChange: { _ in
-                changeCount += 1
-                expectation.fulfill()
-            }
-        )
+        try observer.startObserving(onContextDidChange: { _ in
+            changeCount += 1
+            expectation.fulfill()
+        })
         
         let firstPayload = makeChannelPayload(name: "first")
         try await client.mockDatabaseContainer.write { session in
@@ -62,12 +60,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeChannelObserver()
-        try observer.startObserving(
-            didChange: { _ in
-                changeCount += 1
-                expectation.fulfill()
-            }
-        )
+        try observer.startObserving(onContextDidChange: { _ in
+            changeCount += 1
+            expectation.fulfill()
+        })
         
         let secondPayload = makeChannelPayload(name: "second")
         try await client.mockDatabaseContainer.write { session in
@@ -90,12 +86,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeChannelObserver()
-        try observer.startObserving(
-            didChange: { _ in
-                changeCount += 1
-                expectation.fulfill()
-            }
-        )
+        try observer.startObserving(onContextDidChange: { _ in
+            changeCount += 1
+            expectation.fulfill()
+        })
         
         let firstPayload = makeChannelPayload(name: "first", team: "team1")
         try await client.mockDatabaseContainer.write { session in
@@ -131,12 +125,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(
-            didChange: { _ in
-                changeCount += 1
-                expectation.fulfill()
-            }
-        )
+        try observer.startObserving(onContextDidChange: { _ in
+            changeCount += 1
+            expectation.fulfill()
+        })
         
         let secondPayload = makeChannelPayload(messageCount: 3, createdAtOffset: 5)
         try await client.mockDatabaseContainer.write { session in
@@ -165,11 +157,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(didChange: { _ in
+        try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
-        }
-        )
+        })
         
         let secondPayload = makeChannelPayload(messageCount: 3, createdAtOffset: 5)
         try await client.mockDatabaseContainer.write { session in
@@ -201,12 +192,10 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(
-            didChange: { _ in
-                changeCount += 1
-                expectation.fulfill()
-            }
-        )
+        try observer.startObserving(onContextDidChange: { _ in
+            changeCount += 1
+            expectation.fulfill()
+        })
         
         let secondPayload = makeChannelPayload(messageCount: 3, createdAtOffset: 5)
         try await client.mockDatabaseContainer.write { session in


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

- Basic test coverage for MessageState

### 📝 Summary

- Tests for MessageState
- Changed database observer to react more quickly (I saw that it switched to global executor and then to main when it was not needed)
- Changed the DB read method to use the same state layer context

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
