### PR TITLE
[ChatStateLayer] User search results were incorrect

### DIFF
--- a/Sources/StreamChat/Query/Sorting/UserListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/UserListSortingKey.swift
@@ -48,3 +48,26 @@ extension UserListSortingKey {
         .init(key: rawValue, ascending: isAscending)
     }
 }
+
+private extension UserListSortingKey {
+    var keyPath: PartialKeyPath<ChatUser> {
+        switch self {
+        case .id:
+            return \ChatUser.id
+        case .name:
+            return \ChatUser.name
+        case .role:
+            return \ChatUser.userRole
+        case .isBanned:
+            return \ChatUser.isBanned
+        case .lastActivityAt:
+            return \ChatUser.lastActiveAt
+        }
+    }
+}
+
+extension Sorting where Key == UserListSortingKey {
+    var sortValue: SortValue<ChatUser> {
+        SortValue(keyPath: key.keyPath, isAscending: isAscending)
+    }
+}

--- a/Sources/StreamChat/StateLayer/UserSearch.swift
+++ b/Sources/StreamChat/StateLayer/UserSearch.swift
@@ -61,14 +61,9 @@ public class UserSearch {
     
     private func search(query: UserListQuery, pagination: Pagination) async throws -> [ChatUser] {
         let query = query.withPagination(pagination)
-        let task = Task {
-            let users = try await userListUpdater.fetch(userListQuery: query, pagination: pagination)
-            try Task.checkCancellation()
-            return users
-        }
-        await state.setActiveTask(task, query: query)
-        let users = try await task.value
-        await state.setUsers(users, for: query, pagination: pagination)
+        await state.handleStartingFetchingQuery(query)
+        let users = try await userListUpdater.fetch(userListQuery: query, pagination: pagination)
+        await state.handleFinishedFetchingQuery(query, users: users)
         return users
     }
 }

--- a/Sources/StreamChat/StateLayer/UserSearch.swift
+++ b/Sources/StreamChat/StateLayer/UserSearch.swift
@@ -61,9 +61,9 @@ public class UserSearch {
     
     private func search(query: UserListQuery, pagination: Pagination) async throws -> [ChatUser] {
         let query = query.withPagination(pagination)
-        await state.handleStartingFetchingQuery(query)
+        await state.setQuery(query)
         let users = try await userListUpdater.fetch(userListQuery: query, pagination: pagination)
-        await state.handleFinishedFetchingQuery(query, users: users)
+        await state.handleDidFetchQuery(query, users: users)
         return users
     }
 }

--- a/Sources/StreamChat/StateLayer/UserSearchState.swift
+++ b/Sources/StreamChat/StateLayer/UserSearchState.swift
@@ -14,10 +14,6 @@ public final class UserSearchState: ObservableObject {
     
     /// An array of search results for the specified query and pagination state.
     @Published public internal(set) var users = StreamCollection<ChatUser>([])
-    
-    // MARK: - Private
-    
-    private var activeTask: Task<[ChatUser], Error>?
 }
 
 // MARK: - Mutating the State on the Main Actor
@@ -27,23 +23,40 @@ extension UserSearchState {
     @MainActor func value<Value>(forKeyPath keyPath: KeyPath<UserSearchState, Value>) -> Value {
         self[keyPath: keyPath]
     }
+    
+    @MainActor private func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<UserSearchState, Value>) {
+        self[keyPath: keyPath] = value
+    }
         
-    @MainActor func setActiveTask(_ task: Task<[ChatUser], Error>, query: UserListQuery) {
-        if let activeTask {
-            activeTask.cancel()
-        }
-        activeTask = task
+    @MainActor func handleStartingFetchingQuery(_ query: UserListQuery) {
         self.query = query
     }
-    
-    @MainActor func setUsers(_ newUsers: [ChatUser], for query: UserListQuery, pagination: Pagination) {
-        // When the query changes we set the pagination to 0, otherwise we are loading more results for the same query
-        if pagination.offset == 0 {
-            users = StreamCollection(newUsers)
-        } else {
-            var result = Array(users[..<pagination.offset])
-            result.append(contentsOf: newUsers)
-            users = StreamCollection(result)
+
+    func handleFinishedFetchingQuery(_ completedQuery: UserListQuery, users incomingUsers: [ChatUser]) async {
+        if let query = await value(forKeyPath: \.query), query.hasFilterOrSortingChanged(completedQuery) {
+            // Discard since filter or sorting has changed
+            return
         }
+        let result: StreamCollection<ChatUser>
+        if completedQuery.pagination?.offset == 0 {
+            // Reset to the first page
+            result = StreamCollection(incomingUsers)
+        } else {
+            // Filter and sorting are the same but incoming users might contain duplicates (depends how pagination is used)
+            let incomingIds = Set(incomingUsers.map(\.id))
+            let incomingRemovedUsers = users.filter { !incomingIds.contains($0.id) }
+            let sortValues = completedQuery.sort.map(\.sortValue)
+            result = StreamCollection((incomingRemovedUsers + incomingUsers).sort(using: sortValues))
+        }
+        await setValue(result, for: \.users)
+    }
+}
+
+@available(iOS 13.0, *)
+extension UserListQuery {
+    func hasFilterOrSortingChanged(_ otherQuery: UserListQuery) -> Bool {
+        guard filter?.filterHash == otherQuery.filter?.filterHash else { return true }
+        guard sort == otherQuery.sort else { return true }
+        return false
     }
 }

--- a/Tests/StreamChatTests/StateLayer/UserSearch_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/UserSearch_Tests.swift
@@ -56,7 +56,7 @@ final class UserSearch_Tests: XCTestCase {
         await XCTAssertAsyncFailure(try await userSearch.search(term: "name"), testError)
     }
     
-    func test_cancellation_whenSendingMultipleRequests_thenPreviousRequestsAreCancelled() async throws {
+    func test_searchOrder_whenSendingMultipleRequests_thenIrrelevantResultsAreIgnored() async throws {
         let expectation = XCTestExpectation()
         var counter = 0
         env.userListUpdaterMock.fetch_query_called = { _ in
@@ -99,12 +99,7 @@ final class UserSearch_Tests: XCTestCase {
         let firstResult = makeUsers(name: "nam", count: 10, offset: 0)
         env.userListUpdaterMock.fetch_completions[0](.success(firstResult))
         
-        do {
-            _ = try await result1.count
-            XCTFail("Expected to cancel but did not")
-        } catch {
-            XCTAssertEqual(error, CancellationError())
-        }
+        _ = try await result1.count
         
         XCTAssertEqual(5, try await result2.count)
         XCTAssertEqual(secondResult.users.map(\.id), userSearch.state.users.map(\.id))
@@ -143,7 +138,7 @@ final class UserSearch_Tests: XCTestCase {
     private func makeUsers(name: String, count: Int, offset: Int) -> UserListPayload {
         let users = (0..<count)
             .map { $0 + offset }
-            .map { UserPayload.dummy(userId: "\($0)", name: "name_\($0)") }
+            .map { UserPayload.dummy(userId: "\($0)", name: "name_\(String(format: "%03d", $0))") }
         return UserListPayload(users: users)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

User search did not work at all

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
