### PR TITLE
Bump timeout for DB tests on older iOS versions

### DIFF
--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
@@ -66,20 +66,23 @@ final class ChannelListPayload_Tests: XCTestCase {
 
     func test_hugeChannelListQuery_save_DB_empty() throws {
         let decodedPayload = createHugeChannelList()
+        let timeout: TimeInterval = ProcessInfo().operatingSystemVersion.majorVersion < 16 ? 50 : 20
+        
         measure {
             let databaseContainer = DatabaseContainer_Spy()
-            saveChannelListPayload(decodedPayload, database: databaseContainer)
+            saveChannelListPayload(decodedPayload, database: databaseContainer, timeout: timeout)
         }
     }
 
     func test_hugeChannelListQuery_save_DB_filled() throws {
         let decodedPayload = createHugeChannelList()
         let databaseContainer = DatabaseContainer_Spy()
+        let timeout: TimeInterval = ProcessInfo().operatingSystemVersion.majorVersion < 16 ? 50 : 20
 
-        saveChannelListPayload(decodedPayload, database: databaseContainer)
+        saveChannelListPayload(decodedPayload, database: databaseContainer, timeout: timeout)
 
         measure {
-            saveChannelListPayload(decodedPayload, database: databaseContainer)
+            saveChannelListPayload(decodedPayload, database: databaseContainer, timeout: timeout)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix flaky DB-related unit tests on older iOS versions