### PR TITLE
[ChatStateLayer] Add test coverage for ConnectedUser

### DIFF
--- a/Sources/StreamChat/StateLayer/ConnectedUserState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUserState+Observer.swift
@@ -7,7 +7,7 @@ import Foundation
 @available(iOS 13.0, *)
 extension ConnectedUserState {
     struct Observer {
-        private let userObserver: StateLayerDatabaseObserver<EntityResult, CurrentChatUser, CurrentUserDTO>
+        let userObserver: StateLayerDatabaseObserver<EntityResult, CurrentChatUser, CurrentUserDTO>
         
         init(database: DatabaseContainer) {
             userObserver = StateLayerDatabaseObserver(

--- a/Sources/StreamChat/StateLayer/ConnectedUserState.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUserState.swift
@@ -17,6 +17,9 @@ import Foundation
             with: .init(
                 userDidChange: { [weak self] in self?.user = $0 })
         )
+        if let user = observer.userObserver.item {
+            self.user = user
+        }
     }
     
     /// The represented user.

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -66,28 +66,32 @@ class CurrentUserUpdater: Worker {
         currentUserId: UserId,
         completion: ((Error?) -> Void)? = nil
     ) {
-        database.write { (session) in
+        database.write({ session in
             try session.saveCurrentDevice(deviceId)
-        }
-
-        apiClient
-            .request(
-                endpoint: .addDevice(
-                    userId: currentUserId,
-                    deviceId: deviceId,
-                    pushProvider: pushProvider,
-                    providerName: providerName
-                ),
-                completion: { result in
-                    if let error = result.error {
-                        log.debug("Device token \(deviceId) failed to be registered on Stream's backend.\n Reason: \(error.localizedDescription)")
-                        completion?(error)
-                        return
+        }, completion: { databaseError in
+            if let databaseError {
+                completion?(databaseError)
+                return
+            }
+            self.apiClient
+                .request(
+                    endpoint: .addDevice(
+                        userId: currentUserId,
+                        deviceId: deviceId,
+                        pushProvider: pushProvider,
+                        providerName: providerName
+                    ),
+                    completion: { result in
+                        if let error = result.error {
+                            log.debug("Device token \(deviceId) failed to be registered on Stream's backend.\n Reason: \(error.localizedDescription)")
+                            completion?(error)
+                            return
+                        }
+                        log.debug("Device token \(deviceId) was successfully registered on Stream's backend.")
+                        completion?(nil)
                     }
-                    log.debug("Device token \(deviceId) was successfully registered on Stream's backend.")
-                    completion?(nil)
-                }
-            )
+                )
+        })
     }
 
     /// Removes a registered device from the current user.
@@ -98,20 +102,24 @@ class CurrentUserUpdater: Worker {
     ///   If `currentUser.devices` is not up-to-date, please make an `fetchDevices` call.
     ///   - completion: Called when device is successfully deregistered, or with error.
     func removeDevice(id: DeviceId, currentUserId: UserId, completion: ((Error?) -> Void)? = nil) {
-        database.write { (session) in
+        database.write({ session in
             session.deleteDevice(id: id)
-        }
-
-        apiClient
-            .request(
-                endpoint: .removeDevice(
-                    userId: currentUserId,
-                    deviceId: id
-                ),
-                completion: { result in
-                    completion?(result.error)
-                }
-            )
+        }, completion: { databaseError in
+            if let databaseError {
+                completion?(databaseError)
+                return
+            }
+            self.apiClient
+                .request(
+                    endpoint: .removeDevice(
+                        userId: currentUserId,
+                        deviceId: id
+                    ),
+                    completion: { result in
+                        completion?(result.error)
+                    }
+                )
+        })
     }
 
     /// Updates the registered devices for the current user from backend.

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		4FD2BE5A2B9AF8B600FFC6F2 /* ChannelListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE582B9AF8B600FFC6F2 /* ChannelListState.swift */; };
 		4FD2BE5C2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */; };
 		4FD2BE5D2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */; };
+		4FD94FC52BCD5EF00084FEDF /* ConnectedUser_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD94FC42BCD5EF00084FEDF /* ConnectedUser_Tests.swift */; };
 		4FDAD05E2BC8179E004048E8 /* StateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDAD05D2BC8179E004048E8 /* StateBuilder.swift */; };
 		4FDAD05F2BC8179E004048E8 /* StateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDAD05D2BC8179E004048E8 /* StateBuilder.swift */; };
 		4FE6E1AA2BAC79F400C80AF1 /* MemberListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6E1A92BAC79F400C80AF1 /* MemberListState+Observer.swift */; };
@@ -2992,6 +2993,7 @@
 		4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
 		4FD2BE582B9AF8B600FFC6F2 /* ChannelListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListState.swift; sourceTree = "<group>"; };
 		4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListState+Observer.swift"; sourceTree = "<group>"; };
+		4FD94FC42BCD5EF00084FEDF /* ConnectedUser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser_Tests.swift; sourceTree = "<group>"; };
 		4FDAD05D2BC8179E004048E8 /* StateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateBuilder.swift; sourceTree = "<group>"; };
 		4FE6E1A92BAC79F400C80AF1 /* MemberListState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListState+Observer.swift"; sourceTree = "<group>"; };
 		4FE6E1AC2BAC7A1B00C80AF1 /* UserListState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserListState+Observer.swift"; sourceTree = "<group>"; };
@@ -4948,6 +4950,7 @@
 			children = (
 				4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */,
 				4FB4AB9E2BAD6DBD00712C4E /* Chat_Tests.swift */,
+				4FD94FC42BCD5EF00084FEDF /* ConnectedUser_Tests.swift */,
 				4FCCACE32BC939EB009D23E1 /* MemberList_Tests.swift */,
 				4F14F1292BBE8C1900B1074E /* MessageSearch_Tests.swift */,
 				4F5151992BC57C40001B7152 /* MessageState_Tests.swift */,
@@ -11342,6 +11345,7 @@
 				C186BFAA27AA979B0099CCA6 /* SyncRepository_Tests.swift in Sources */,
 				DAE566F12500F3C800E39431 /* CurrentUserController+SwiftUI_Tests.swift in Sources */,
 				F69C4BC424F664A700A3D740 /* EventNotificationCenter_Tests.swift in Sources */,
+				4FD94FC52BCD5EF00084FEDF /* ConnectedUser_Tests.swift in Sources */,
 				AD0AD6C02A25140A00CB96CB /* MessagesPaginationState_Tests.swift in Sources */,
 				C12DBE612A67E2D60045D9F0 /* SortingValue_Tests.swift in Sources */,
 				C186BFB627AAFDAB0099CCA6 /* SyncOperations_Tests.swift in Sources */,
@@ -11787,7 +11791,6 @@
 				C121E89A274544B000023E4C /* MuteDetails.swift in Sources */,
 				C121E89B274544B000023E4C /* Controller.swift in Sources */,
 				404296DE2A0114900089126D /* StreamAudioQueuePlayer_Tests.swift in Sources */,
-				4F51519D2BC66FBE001B7152 /* Task+Extensions.swift in Sources */,
 				C121E89C274544B000023E4C /* DataController.swift in Sources */,
 				AD17CDFA27E4DB2700E0D092 /* PushProvider.swift in Sources */,
 				C121E89D274544B000023E4C /* UserSearchController.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
@@ -27,6 +27,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
     @Atomic var fetchDevices_completion: ((Result<[Device], Error>) -> Void)?
 
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
+    @Atomic var markAllRead_completion_result: Result<Void, Error>?
 
     override func updateUserData(
         currentUserId: UserId,
@@ -91,9 +92,11 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         fetchDevices_completion = nil
 
         markAllRead_completion = nil
+        markAllRead_completion_result = nil
     }
 
     override func markAllRead(completion: ((Error?) -> Void)? = nil) {
         markAllRead_completion = completion
+        markAllRead_completion_result?.invoke(with: completion)
     }
 }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/UserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/UserUpdater_Mock.swift
@@ -9,51 +9,63 @@ import XCTest
 final class UserUpdater_Mock: UserUpdater {
     @Atomic var muteUser_userId: UserId?
     @Atomic var muteUser_completion: ((Error?) -> Void)?
+    @Atomic var muteUser_completion_result: Result<Void, Error>?
 
     @Atomic var unmuteUser_userId: UserId?
     @Atomic var unmuteUser_completion: ((Error?) -> Void)?
+    @Atomic var unmuteUser_completion_result: Result<Void, Error>?
 
     @Atomic var loadUser_userId: UserId?
     @Atomic var loadUser_completion: ((Error?) -> Void)?
+    @Atomic var loadUser_completion_result: Result<Void, Error>?
 
     @Atomic var flagUser_flag: Bool?
     @Atomic var flagUser_userId: UserId?
     @Atomic var flagUser_completion: ((Error?) -> Void)?
+    @Atomic var flagUser_completion_result: Result<Void, Error>?
 
     override func muteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
         muteUser_userId = userId
         muteUser_completion = completion
+        muteUser_completion_result?.invoke(with: completion)
     }
 
     override func unmuteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
         unmuteUser_userId = userId
         unmuteUser_completion = completion
+        unmuteUser_completion_result?.invoke(with: completion)
     }
 
     override func loadUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
         loadUser_userId = userId
         loadUser_completion = completion
+        loadUser_completion_result?.invoke(with: completion)
     }
 
     override func flagUser(_ flag: Bool, with userId: UserId, completion: ((Error?) -> Void)? = nil) {
         flagUser_flag = flag
         flagUser_userId = userId
         flagUser_completion = completion
+        flagUser_completion_result?.invoke(with: completion)
     }
 
     // Cleans up all recorded values
     func cleanUp() {
         muteUser_userId = nil
         muteUser_completion = nil
+        muteUser_completion_result = nil
 
         unmuteUser_userId = nil
         unmuteUser_completion = nil
+        unmuteUser_completion_result = nil
 
         loadUser_userId = nil
         loadUser_completion = nil
+        loadUser_completion_result = nil
 
         flagUser_flag = nil
         flagUser_userId = nil
         flagUser_completion = nil
+        flagUser_completion_result = nil
     }
 }

--- a/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
@@ -1,0 +1,199 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+@available(iOS 13.0, *)
+final class ConnectedUser_Tests: XCTestCase {
+    private var connectedUser: ConnectedUser!
+    private var connectedUserId: UserId!
+    private var env: TestEnvironment!
+    
+    override func setUpWithError() throws {
+        connectedUserId = .unique
+        env = TestEnvironment()
+    }
+
+    override func tearDownWithError() throws {
+        env.cleanUp()
+        connectedUser = nil
+        connectedUserId = nil
+        env = nil
+    }
+
+    func test_updateUser_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: false)
+        await XCTAssertEqual("InitialName", connectedUser.state.name)
+        
+        let changedName = "Name"
+        let apiResult = UserUpdateResponse(user: currentUserPayload(name: changedName))
+        env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
+        try await connectedUser.update(name: changedName)
+
+        await XCTAssertEqual(changedName, connectedUser.state.name)
+    }
+    
+    func test_markAllChannelsRead_whenAPIRequestSucceeds_thenMarkAllSucceeds() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: true)
+        env.currentUserUpdaterMock.markAllRead_completion_result = .success(())
+        try await connectedUser.markAllChannelsRead()
+    }
+    
+    func test_loadDevices_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: false)
+        
+        let apiResult = DeviceListPayload(devices: [.dummy, .dummy, .dummy])
+        env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
+        
+        let devices = try await connectedUser.loadDevices()
+        // There is no sorting for devices, therefore force the order when comparing (stored as Set in DB)
+        XCTAssertEqual(apiResult.devices.map(\.id).sorted(), devices.map(\.id).sorted())
+        await XCTAssertEqual(apiResult.devices.map(\.id).sorted(), connectedUser.state.devices.map(\.id).sorted())
+    }
+    
+    func test_loadDevices_whenExistingFetchedDevices_thenDatabaseIsResetToFetchedDevices() async throws {
+        // Set initial state where we have devices stored in DB
+        try await env.client.databaseContainer.write { session in
+            try session.saveCurrentUser(payload: self.currentUserPayload(deviceCount: 2))
+        }
+        
+        // Fetch devices which resets the device list
+        try await setUpConnectedUser(usesMockedUpdaters: false)
+        let apiResult = DeviceListPayload(devices: [.dummy, .dummy, .dummy])
+        env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
+        let devices = try await connectedUser.loadDevices()
+        
+        XCTAssertEqual(apiResult.devices.map(\.id).sorted(), devices.map(\.id).sorted())
+        await XCTAssertEqual(apiResult.devices.map(\.id).sorted(), connectedUser.state.devices.map(\.id).sorted())
+    }
+    
+    func test_addDevices_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: false)
+        await XCTAssertEqual(0, connectedUser.state.devices.count)
+        
+        env.client.mockAPIClient.test_mockResponseResult(.success(EmptyResponse()))
+        try await connectedUser.addDevice(.apn(token: Data("test123".utf8)))
+        
+        // Converted to hex (test123 > 74657374313233)
+        await XCTAssertEqual(["74657374313233"], connectedUser.state.devices.map(\.id))
+    }
+    
+    func test_removeDevice_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: false, initialDeviceCount: 2)
+        
+        env.client.mockAPIClient.test_mockResponseResult(.success(EmptyResponse()))
+        var devices = await connectedUser.state.devices
+        let deviceToRemove = try XCTUnwrap(devices.popLast()?.id)
+        try await connectedUser.removeDevice(deviceToRemove)
+        
+        await XCTAssertEqual(false, connectedUser.state.devices.contains(where: { $0.id == deviceToRemove }))
+        await XCTAssertEqual(devices.map(\.id).sorted(), connectedUser.state.devices.map(\.id))
+    }
+    
+    func test_muteUser_whenUpdatedSucceeds_thenMuteUserSucceeds() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: true)
+        
+        env.userUpdaterMock.muteUser_completion_result = .success(())
+        let id = UserId.unique
+        try await connectedUser.muteUser(id)
+        XCTAssertEqual(id, env.userUpdaterMock.muteUser_userId)
+    }
+    
+    func test_unmuteUser_whenUpdatedSucceeds_thenMuteUserSucceeds() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: true)
+        
+        env.userUpdaterMock.unmuteUser_completion_result = .success(())
+        let id = UserId.unique
+        try await connectedUser.unmuteUser(id)
+        XCTAssertEqual(id, env.userUpdaterMock.unmuteUser_userId)
+    }
+    
+    func test_flagUser_whenUpdatedSucceeds_thenMuteUserSucceeds() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: true)
+        
+        env.userUpdaterMock.flagUser_completion_result = .success(())
+        let id = UserId.unique
+        try await connectedUser.flag(id)
+        XCTAssertEqual(true, env.userUpdaterMock.flagUser_flag)
+        XCTAssertEqual(id, env.userUpdaterMock.flagUser_userId)
+    }
+    
+    func test_unflagUser_whenUpdatedSucceeds_thenMuteUserSucceeds() async throws {
+        try await setUpConnectedUser(usesMockedUpdaters: true)
+        
+        env.userUpdaterMock.flagUser_completion_result = .success(())
+        let id = UserId.unique
+        try await connectedUser.unflag(id)
+        XCTAssertEqual(false, env.userUpdaterMock.flagUser_flag)
+        XCTAssertEqual(id, env.userUpdaterMock.flagUser_userId)
+    }
+    
+    // MARK: - Test Data
+    
+    private func setUpConnectedUser(usesMockedUpdaters: Bool, initialDeviceCount: Int = 0) async throws {
+        var user: CurrentChatUser!
+        try await env.client.databaseContainer.write { session in
+            user = try session.saveCurrentUser(payload: self.currentUserPayload(deviceCount: initialDeviceCount)).asModel()
+        }
+        env.client.mockAuthenticationRepository.mockedCurrentUserId = connectedUserId
+        connectedUser = ConnectedUser(
+            user: user,
+            client: env.client,
+            environment: env.connectedUserEnvironment(
+                usesMockedUpdaters: usesMockedUpdaters
+            )
+        )
+    }
+    
+    private func currentUserPayload(name: String = "InitialName", deviceCount: Int = 0) -> CurrentUserPayload {
+        let devices = (0..<deviceCount).map { _ in DevicePayload.dummy }
+        return CurrentUserPayload.dummy(
+            userId: connectedUserId,
+            name: name,
+            role: .admin,
+            devices: devices
+        )
+    }
+}
+
+@available(iOS 13.0, *)
+extension ConnectedUser_Tests {
+    final class TestEnvironment {
+        let client: ChatClient_Mock
+        private(set) var state: MessageSearchState!
+        private(set) var currentUserUpdater: CurrentUserUpdater!
+        private(set) var currentUserUpdaterMock: CurrentUserUpdater_Mock!
+        private(set) var userUpdater: UserUpdater!
+        private(set) var userUpdaterMock: UserUpdater_Mock!
+        
+        func cleanUp() {
+            client.cleanUp()
+            currentUserUpdaterMock.cleanUp()
+            userUpdaterMock.cleanUp()
+        }
+        
+        init() {
+            client = ChatClient_Mock(
+                config: ChatClient_Mock.defaultMockedConfig
+            )
+        }
+        
+        func connectedUserEnvironment(usesMockedUpdaters: Bool) -> ConnectedUser.Environment {
+            ConnectedUser.Environment(
+                currentUserUpdaterBuilder: { [unowned self] in
+                    self.currentUserUpdater = CurrentUserUpdater(database: $0, apiClient: $1)
+                    self.currentUserUpdaterMock = CurrentUserUpdater_Mock(database: $0, apiClient: $1)
+                    return usesMockedUpdaters ? currentUserUpdaterMock : currentUserUpdater
+                },
+                userUpdaterBuilder: { [unowned self] in
+                    self.userUpdater = UserUpdater(database: $0, apiClient: $1)
+                    self.userUpdaterMock = UserUpdater_Mock(database: $0, apiClient: $1)
+                    return usesMockedUpdaters ? userUpdaterMock : userUpdater
+                }
+            )
+        }
+    }
+}

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -357,12 +357,18 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             try $0.saveCurrentUser(payload: userPayload)
         }
 
+        apiClient.test_mockResponseResult(.success(EmptyResponse()))
+        let expectation = XCTestExpectation()
+        
         // Call removeDevice
         currentUserUpdater.removeDevice(id: "01", currentUserId: userPayload.id) {
             // No error should be returned
             XCTAssertNil($0)
+            expectation.fulfill()
         }
 
+        wait(for: [expectation], timeout: defaultTimeout)
+        
         // Assert that request is made to the correct endpoint
         let expectedEndpoint: Endpoint<EmptyResponse> = .removeDevice(userId: userPayload.id, deviceId: "01")
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
@@ -375,13 +381,19 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         try database.writeSynchronously {
             try $0.saveCurrentUser(payload: userPayload)
         }
+        
+        apiClient.test_mockResponseResult(.success(EmptyResponse()))
+        let expectation = XCTestExpectation()
 
         // Call removeDevice
         var completionCalledError: Error?
         currentUserUpdater.removeDevice(id: "", currentUserId: .unique) {
             completionCalledError = $0
+            expectation.fulfill()
         }
 
+        wait(for: [expectation], timeout: defaultTimeout)
+        
         // Simulate API error
         let error = TestError()
         apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Tests for ConnectedUser

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)