### PR TITLE
[ChatStateLayer] Initial state handling in the StateLayerDatabaseObserver

### DIFF
--- a/Sources/StreamChat/Controllers/DatabaseObserver/StateLayerDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/StateLayerDatabaseObserver.swift
@@ -60,18 +60,23 @@ extension StateLayerDatabaseObserver where ResultType == EntityResult {
         return item
     }
     
-    /// Starts observing the database and dispatches changes on the MainActor.
+    /// Starts observing the database and dispatches changes on the ``MainActor``.
     ///
-    /// - Important: Does not send the initial value, use the ``item`` for setting the initial value.
-    func startObserving(didChange: @escaping (Item?) async -> Void) throws {
+    /// - Parameter didChange: The callback which is triggered when the observed item changes. Runs on the ``MainActor``.
+    ///
+    /// - Returns: Returns the current state of the item in the local database.
+    func startObserving(didChange: @escaping (Item?) async -> Void) throws -> Item? {
         try startObserving(onContextDidChange: { item in Task.mainActor { await didChange(item) } })
     }
     
     /// Starts observing the database and dispatches changes on the NSManagedObjectContext's queue.
     ///
-    /// - Note: Use it if we need to do additional processing on the context's queue.
-    /// - Important: Does not send the initial value, use the ``item`` for setting the initial value.
-    func startObserving(onContextDidChange: @escaping (Item?) -> Void) throws {
+    /// - Parameter onContextDidChange: The callback which is triggered when the observed item changes. Runs on the ``NSManagedObjectContext``'s queue.
+    ///
+    /// - Note: Use it if you need to do additional processing on the context's queue.
+    ///
+    /// - Returns: Returns the current state of the item in the local database.
+    func startObserving(onContextDidChange: @escaping (Item?) -> Void) throws -> Item? {
         resultsDelegate = FetchedResultsDelegate(onDidChange: { [weak self] in
             guard let self else { return }
             // Runs on the NSManagedObjectContext's queue, therefore skip performAndWait
@@ -80,6 +85,7 @@ extension StateLayerDatabaseObserver where ResultType == EntityResult {
         })
         frc.delegate = resultsDelegate
         try frc.performFetch()
+        return item
     }
     
     static func makeEntity(
@@ -116,16 +122,21 @@ extension StateLayerDatabaseObserver where ResultType == ListResult {
     
     /// Starts observing the database and dispatches changes on the MainActor.
     ///
-    /// - Important: Does not send the initial value, use the ``item`` for setting the initial value.
-    func startObserving(didChange: @escaping (StreamCollection<Item>) async -> Void) throws {
+    /// - Parameter didChange: The callback which is triggered when the observed item changes. Runs on the ``MainActor``.
+    ///
+    /// - Returns: Returns the current state of items in the local database.
+    func startObserving(didChange: @escaping (StreamCollection<Item>) async -> Void) throws -> StreamCollection<Item> {
         try startObserving(onContextDidChange: { items in Task.mainActor { await didChange(items) } })
     }
     
     /// Starts observing the database and dispatches changes on the NSManagedObjectContext's queue.
     ///
-    /// - Note: Use it if we need to do additional processing on the context's queue.
-    /// - Important: Does not send the initial value, use the ``item`` for setting the initial value.
-    func startObserving(onContextDidChange: @escaping (StreamCollection<Item>) -> Void) throws {
+    /// - Parameter onContextDidChange: The callback which is triggered when the observed item changes. Runs on the ``NSManagedObjectContext``'s queue.
+    ///
+    /// - Note: Use it if you need to do additional processing on the context's queue.
+    ///
+    /// - Returns: Returns the current state of items in the local database.
+    func startObserving(onContextDidChange: @escaping (StreamCollection<Item>) -> Void) throws -> StreamCollection<Item> {
         resultsDelegate = FetchedResultsDelegate(onDidChange: { [weak self] in
             guard let self else { return }
             // Runs on the NSManagedObjectContext's queue, therefore skip performAndWait
@@ -134,6 +145,7 @@ extension StateLayerDatabaseObserver where ResultType == ListResult {
         })
         frc.delegate = resultsDelegate
         try frc.performFetch()
+        return items
     }
     
     static func makeCollection(

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -11,7 +11,6 @@ public class ChannelList {
     private let stateBuilder: StateBuilder<ChannelListState>
     
     init(
-        initialChannels: [ChatChannel],
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)?,
         channelListUpdater: ChannelListUpdater,
@@ -22,7 +21,6 @@ public class ChannelList {
         self.query = query
         stateBuilder = StateBuilder {
             environment.stateBuilder(
-                initialChannels,
                 query,
                 dynamicFilter,
                 client.config,
@@ -69,7 +67,6 @@ public class ChannelList {
 extension ChannelList {
     struct Environment {
         var stateBuilder: @MainActor(
-            _ initialChannels: [ChatChannel],
             _ query: ChannelListQuery,
             _ dynamicFilter: ((ChatChannel) -> Bool)?,
             _ clientConfig: ChatClientConfig,
@@ -78,13 +75,12 @@ extension ChannelList {
             _ eventNotificationCenter: EventNotificationCenter
         ) -> ChannelListState = { @MainActor in
             ChannelListState(
-                initialChannels: $0,
-                query: $1,
-                dynamicFilter: $2,
-                clientConfig: $3,
-                channelListUpdater: $4,
-                database: $5,
-                eventNotificationCenter: $6
+                query: $0,
+                dynamicFilter: $1,
+                clientConfig: $2,
+                channelListUpdater: $3,
+                database: $4,
+                eventNotificationCenter: $5
             )
         }
     }

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -46,7 +46,7 @@ extension ChannelListState {
             let channelsDidChange: (StreamCollection<ChatChannel>) async -> Void
         }
         
-        @MainActor func start(with handlers: Handlers) -> StreamCollection<ChatChannel> {
+        func start(with handlers: Handlers) -> StreamCollection<ChatChannel> {
             /// When we receive events, we need to check if a channel should be added or removed from
             /// the current query depending on the following events:
             /// - Channel created: We analyse if the channel should be added to the current query.

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -7,7 +7,7 @@ import Foundation
 @available(iOS 13.0, *)
 extension ChannelListState {
     final class Observer {
-        let channelListObserver: StateLayerDatabaseObserver<ListResult, ChatChannel, ChannelDTO>
+        private let channelListObserver: StateLayerDatabaseObserver<ListResult, ChatChannel, ChannelDTO>
         private let clientConfig: ChatClientConfig
         private let channelListUpdater: ChannelListUpdater
         private let database: DatabaseContainer
@@ -46,7 +46,7 @@ extension ChannelListState {
             let channelsDidChange: (StreamCollection<ChatChannel>) async -> Void
         }
         
-        func start(with handlers: Handlers) {
+        @MainActor func start(with handlers: Handlers) -> StreamCollection<ChatChannel> {
             /// When we receive events, we need to check if a channel should be added or removed from
             /// the current query depending on the following events:
             /// - Channel created: We analyse if the channel should be added to the current query.
@@ -81,9 +81,10 @@ extension ChannelListState {
             ]
             
             do {
-                try channelListObserver.startObserving(didChange: handlers.channelsDidChange)
+                return try channelListObserver.startObserving(didChange: handlers.channelsDidChange)
             } catch {
                 log.error("Failed to start the channel list observer for query: \(query)")
+                return StreamCollection([])
             }
         }
         

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -11,7 +11,6 @@ import Foundation
     private let query: ChannelListQuery
     
     init(
-        initialChannels: [ChatChannel],
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)?,
         clientConfig: ChatClientConfig,
@@ -20,7 +19,6 @@ import Foundation
         eventNotificationCenter: EventNotificationCenter
     ) {
         self.query = query
-        channels = StreamCollection<ChatChannel>(initialChannels)
         observer = Observer(
             query: query,
             dynamicFilter: dynamicFilter,
@@ -29,12 +27,9 @@ import Foundation
             database: database,
             eventNotificationCenter: eventNotificationCenter
         )
-        observer.start(
+        channels = observer.start(
             with: .init(channelsDidChange: { [weak self] in self?.channels = $0 })
         )
-        if initialChannels.isEmpty {
-            channels = observer.channelListObserver.items
-        }
     }
     
     /// An array of channels for the specified ``ChannelListQuery``.

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -35,8 +35,8 @@ extension ChatClient {
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An instance of ``ChannelList`` which represents actions and the current state of the list.
     public func makeChannelList(with query: ChannelListQuery, dynamicFilter: ((ChatChannel) -> Bool)? = nil) async throws -> ChannelList {
-        let channels = try await channelListUpdater.update(channelListQuery: query)
-        let channelList = ChannelList(initialChannels: channels, query: query, dynamicFilter: dynamicFilter, channelListUpdater: channelListUpdater, client: self)
+        try await channelListUpdater.update(channelListQuery: query)
+        let channelList = ChannelList(query: query, dynamicFilter: dynamicFilter, channelListUpdater: channelListUpdater, client: self)
         syncRepository.trackChannelListQuery { [weak channelList] in channelList?.query }
         return channelList
     }
@@ -57,8 +57,8 @@ extension ChatClient {
     /// - Returns: An instance of ``UserList`` which represents actions and the current state of the list.
     public func makeUserList(with query: UserListQuery) async throws -> UserList {
         let userListUpdater = UserListUpdater(database: databaseContainer, apiClient: apiClient)
-        let users = try await userListUpdater.update(userListQuery: query)
-        return UserList(users: users, query: query, userListUpdater: userListUpdater, client: self)
+        try await userListUpdater.update(userListQuery: query)
+        return UserList(query: query, userListUpdater: userListUpdater, client: self)
     }
 }
 

--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -61,7 +61,14 @@ extension ChatState {
             let watchersDidChange: (StreamCollection<ChatUser>) async -> Void
         }
         
-        @MainActor func start(with handlers: Handlers) -> (channel: ChatChannel?, members: StreamCollection<ChatChannelMember>, messages: StreamCollection<ChatMessage>, watchers: StreamCollection<ChatUser>) {
+        @MainActor func start(
+            with handlers: Handlers
+        ) -> (
+            channel: ChatChannel?,
+            members: StreamCollection<ChatChannelMember>,
+            messages: StreamCollection<ChatMessage>,
+            watchers: StreamCollection<ChatUser>
+        ) {
             memberListObserver = memberListState.$members
                 .dropFirst()
                 .sink(receiveValue: { change in Task.mainActor { await handlers.membersDidChange(change) } })

--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -72,7 +72,7 @@ extension ChatState {
                 let watchers = try watchersObserver.startObserving(didChange: handlers.watchersDidChange)
                 return (channel, memberListState.members, messages, watchers)
             } catch {
-                log.error("Failed to start the sobserver for cid: \(cid) with error \(error)")
+                log.error("Failed to start the observers for cid: \(cid) with error \(error)")
                 return (nil, StreamCollection([]), StreamCollection([]), StreamCollection([]))
             }
         }

--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -61,25 +61,19 @@ extension ChatState {
             let watchersDidChange: (StreamCollection<ChatUser>) async -> Void
         }
         
-        @MainActor func start(with handlers: Handlers) {
+        @MainActor func start(with handlers: Handlers) -> (channel: ChatChannel?, members: StreamCollection<ChatChannelMember>, messages: StreamCollection<ChatMessage>, watchers: StreamCollection<ChatUser>) {
             memberListObserver = memberListState.$members
-                .dropFirst() // skip initial
-                .sink(receiveValue: { change in Task { await handlers.membersDidChange(change) } })
+                .dropFirst()
+                .sink(receiveValue: { change in Task.mainActor { await handlers.membersDidChange(change) } })
             
             do {
-                try channelObserver.startObserving(didChange: handlers.channelDidChange)
+                let channel = try channelObserver.startObserving(didChange: handlers.channelDidChange)
+                let messages = try messagesObserver.startObserving(didChange: handlers.messagesDidChange)
+                let watchers = try watchersObserver.startObserving(didChange: handlers.watchersDidChange)
+                return (channel, memberListState.members, messages, watchers)
             } catch {
-                log.error("Failed to start the channel observer for cid: \(cid)")
-            }
-            do {
-                try messagesObserver.startObserving(didChange: handlers.messagesDidChange)
-            } catch {
-                log.error("Failed to start the messages observer for cid: \(cid)")
-            }
-            do {
-                try watchersObserver.startObserving(didChange: handlers.watchersDidChange)
-            } catch {
-                log.error("Failed to start the watchers observer for cid: \(cid)")
+                log.error("Failed to start the sobserver for cid: \(cid) with error \(error)")
+                return (nil, StreamCollection([]), StreamCollection([]), StreamCollection([]))
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -39,7 +39,7 @@ import Foundation
             database: database,
             eventNotificationCenter: eventNotificationCenter
         )
-        observer.start(
+        let initial = observer.start(
             with: .init(
                 channelDidChange: { [weak self] in self?.channel = $0 },
                 membersDidChange: { [weak self] in self?.members = $0 },
@@ -47,10 +47,10 @@ import Foundation
                 watchersDidChange: { [weak self] in self?.watchers = $0 }
             )
         )
-        channel = observer.channelObserver.item
-        members = observer.memberListState.members
-        messages = observer.messagesObserver.items
-        watchers = observer.watchersObserver.items
+        channel = initial.channel
+        members = initial.members
+        messages = initial.messages
+        watchers = initial.watchers
     }
     
     // MARK: - Represented Channel

--- a/Sources/StreamChat/StateLayer/ConnectedUserState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUserState+Observer.swift
@@ -7,7 +7,7 @@ import Foundation
 @available(iOS 13.0, *)
 extension ConnectedUserState {
     struct Observer {
-        let userObserver: StateLayerDatabaseObserver<EntityResult, CurrentChatUser, CurrentUserDTO>
+        private let userObserver: StateLayerDatabaseObserver<EntityResult, CurrentChatUser, CurrentUserDTO>
         
         init(database: DatabaseContainer) {
             userObserver = StateLayerDatabaseObserver(
@@ -21,14 +21,16 @@ extension ConnectedUserState {
             let userDidChange: (CurrentChatUser) async -> Void
         }
         
-        func start(with handlers: Handlers) {
+        func start(with handlers: Handlers) -> CurrentChatUser? {
             do {
-                try userObserver.startObserving(onContextDidChange: { user in
+                let user = try userObserver.startObserving(didChange: { user in
                     guard let user else { return }
-                    Task.mainActor { await handlers.userDidChange(user) }
+                    await handlers.userDidChange(user)
                 })
+                return user
             } catch {
                 log.error("Failed to start the current user observer")
+                return nil
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/ConnectedUserState.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUserState.swift
@@ -13,12 +13,12 @@ import Foundation
     init(user: CurrentChatUser, database: DatabaseContainer) {
         self.observer = Observer(database: database)
         self.user = user
-        observer.start(
+        let initialUser = observer.start(
             with: .init(
                 userDidChange: { [weak self] in self?.user = $0 })
         )
-        if let user = observer.userObserver.item {
-            self.user = user
+        if let initialUser {
+            self.user = initialUser
         }
     }
     

--- a/Sources/StreamChat/StateLayer/MemberList.swift
+++ b/Sources/StreamChat/StateLayer/MemberList.swift
@@ -19,7 +19,6 @@ public final class MemberList {
         )
         stateBuilder = StateBuilder {
             environment.stateBuilder(
-                [],
                 query,
                 client.databaseContainer
             )
@@ -62,11 +61,10 @@ extension MemberList {
         ) -> ChannelMemberListUpdater = ChannelMemberListUpdater.init
         
         var stateBuilder: @MainActor(
-            _ initialMembers: [ChatChannelMember],
             _ query: ChannelMemberListQuery,
             _ database: DatabaseContainer
         ) -> MemberListState = { @MainActor in
-            MemberListState(initialMembers: $0, query: $1, database: $2)
+            MemberListState(query: $0, database: $1)
         }
     }
 }

--- a/Sources/StreamChat/StateLayer/MemberListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MemberListState+Observer.swift
@@ -7,7 +7,7 @@ import Foundation
 @available(iOS 13.0, *)
 extension MemberListState {
     struct Observer {
-        let memberListObserver: StateLayerDatabaseObserver<ListResult, ChatChannelMember, MemberDTO>
+        private let memberListObserver: StateLayerDatabaseObserver<ListResult, ChatChannelMember, MemberDTO>
         
         init(query: ChannelMemberListQuery, database: DatabaseContainer) {
             memberListObserver = StateLayerDatabaseObserver(
@@ -21,11 +21,12 @@ extension MemberListState {
             let membersDidChange: (StreamCollection<ChatChannelMember>) async -> Void
         }
         
-        func start(with handlers: Handlers) {
+        func start(with handlers: Handlers) -> StreamCollection<ChatChannelMember> {
             do {
-                try memberListObserver.startObserving(didChange: handlers.membersDidChange)
+                return try memberListObserver.startObserving(didChange: handlers.membersDidChange)
             } catch {
                 log.error("Failed to start the member list observer with error \(error)")
+                return StreamCollection([])
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/MemberListState.swift
+++ b/Sources/StreamChat/StateLayer/MemberListState.swift
@@ -9,15 +9,11 @@ import Foundation
 @MainActor public final class MemberListState: ObservableObject {
     private let observer: Observer
     
-    init(initialMembers: [ChatChannelMember], query: ChannelMemberListQuery, database: DatabaseContainer) {
-        members = StreamCollection(initialMembers)
+    init(query: ChannelMemberListQuery, database: DatabaseContainer) {
         observer = Observer(query: query, database: database)
-        observer.start(
+        members = observer.start(
             with: .init(membersDidChange: { [weak self] in self?.members = $0 })
         )
-        if initialMembers.isEmpty {
-            members = observer.memberListObserver.items
-        }
     }
     
     /// An array of members for the specified ``ChannelMemberListQuery``.

--- a/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
@@ -45,9 +45,8 @@ extension MessageSearchState {
                 )
                 do {
                     if let messagesObserver {
-                        try messagesObserver.startObserving(didChange: handlers.messagesDidChange)
-                        // Sending the initial value since we keep recreating the observer
-                        Task { await handlers.messagesDidChange(messagesObserver.items) }
+                        let messages = try messagesObserver.startObserving(didChange: handlers.messagesDidChange)
+                        Task.mainActor { await handlers.messagesDidChange(messages) }
                     }
                 } catch {
                     log.error("Failed to start the message result observer for query (\(query) with error \(error)")

--- a/Sources/StreamChat/StateLayer/MessageState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageState+Observer.swift
@@ -8,8 +8,8 @@ import Foundation
 extension MessageState {
     struct Observer {
         private let messageId: MessageId
-        let messageObserver: StateLayerDatabaseObserver<EntityResult, ChatMessage, MessageDTO>
-        let repliesObserver: StateLayerDatabaseObserver<ListResult, ChatMessage, MessageDTO>
+        private let messageObserver: StateLayerDatabaseObserver<EntityResult, ChatMessage, MessageDTO>
+        private let repliesObserver: StateLayerDatabaseObserver<ListResult, ChatMessage, MessageDTO>
         
         init(messageId: MessageId, messageOrder: MessageOrdering, database: DatabaseContainer, clientConfig: ChatClientConfig) {
             self.messageId = messageId
@@ -36,10 +36,10 @@ extension MessageState {
             let repliesDidChange: (StreamCollection<ChatMessage>) async -> Void
         }
         
-        func start(with handlers: Handlers) {
+        @MainActor func start(with handlers: Handlers) -> (message: ChatMessage?, reactions: [ChatMessageReaction], replies: StreamCollection<ChatMessage>) {
             do {
                 var lastSortedReactions: [ChatMessageReaction]?
-                try messageObserver.startObserving(onContextDidChange: { message in
+                let message = try messageObserver.startObserving(onContextDidChange: { message in
                     guard let message else { return }
                     let changedReactions: [ChatMessageReaction]?
                     let currentReactions = message.latestReactions.sorted(by: ChatMessageReaction.defaultSorting)
@@ -53,13 +53,12 @@ extension MessageState {
                         await handlers.messageDidChange((message, changedReactions))
                     }
                 })
+                let reactions = message?.latestReactions.sorted(by: ChatMessageReaction.defaultSorting) ?? []
+                let replies = try repliesObserver.startObserving(didChange: handlers.repliesDidChange)
+                return (message, reactions, replies)
             } catch {
-                log.error("Failed to start the messages observer for message: \(messageId)")
-            }
-            do {
-                try repliesObserver.startObserving(didChange: handlers.repliesDidChange)
-            } catch {
-                log.error("Failed to start the replies observer for message: \(messageId)")
+                log.error("Failed to start the observers for message: \(messageId) with error \(error)")
+                return (nil, [], StreamCollection([]))
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/MessageState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageState+Observer.swift
@@ -36,7 +36,7 @@ extension MessageState {
             let repliesDidChange: (StreamCollection<ChatMessage>) async -> Void
         }
         
-        @MainActor func start(with handlers: Handlers) -> (message: ChatMessage?, reactions: [ChatMessageReaction], replies: StreamCollection<ChatMessage>) {
+        func start(with handlers: Handlers) -> (message: ChatMessage?, reactions: [ChatMessageReaction], replies: StreamCollection<ChatMessage>) {
             do {
                 var lastSortedReactions: [ChatMessageReaction]?
                 let message = try messageObserver.startObserving(onContextDidChange: { message in

--- a/Sources/StreamChat/StateLayer/MessageState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageState+Observer.swift
@@ -36,7 +36,13 @@ extension MessageState {
             let repliesDidChange: (StreamCollection<ChatMessage>) async -> Void
         }
         
-        func start(with handlers: Handlers) -> (message: ChatMessage?, reactions: [ChatMessageReaction], replies: StreamCollection<ChatMessage>) {
+        func start(
+            with handlers: Handlers
+        ) -> (
+            message: ChatMessage?,
+            reactions: [ChatMessageReaction],
+            replies: StreamCollection<ChatMessage>
+        ) {
             do {
                 var lastSortedReactions: [ChatMessageReaction]?
                 let message = try messageObserver.startObserving(onContextDidChange: { message in

--- a/Sources/StreamChat/StateLayer/MessageState.swift
+++ b/Sources/StreamChat/StateLayer/MessageState.swift
@@ -28,7 +28,7 @@ import Foundation
             database: database,
             clientConfig: clientConfig
         )
-        observer.start(
+        let initial = observer.start(
             with: .init(
                 messageDidChange: { [weak self] message, changedReactions in
                     self?.message = message
@@ -39,8 +39,11 @@ import Foundation
                 repliesDidChange: { [weak self] in self?.replies = $0 }
             )
         )
-        reactions = message.latestReactions.sorted(by: ChatMessageReaction.defaultSorting)
-        replies = observer.repliesObserver.items
+        if let message = initial.message {
+            self.message = message
+        }
+        reactions = initial.reactions
+        replies = initial.replies
     }
     
     var replyPaginationState: MessagesPaginationState {

--- a/Sources/StreamChat/StateLayer/UserList.swift
+++ b/Sources/StreamChat/StateLayer/UserList.swift
@@ -10,11 +10,10 @@ public final class UserList {
     private let stateBuilder: StateBuilder<UserListState>
     private let userListUpdater: UserListUpdater
     
-    init(users: [ChatUser], query: UserListQuery, userListUpdater: UserListUpdater, client: ChatClient, environment: Environment = .init()) {
+    init(query: UserListQuery, userListUpdater: UserListUpdater, client: ChatClient, environment: Environment = .init()) {
         self.userListUpdater = userListUpdater
         stateBuilder = StateBuilder {
             environment.stateBuilder(
-                users,
                 query,
                 client.databaseContainer
             )
@@ -55,11 +54,10 @@ public final class UserList {
 extension UserList {
     struct Environment {
         var stateBuilder: @MainActor(
-            _ users: [ChatUser],
             _ query: UserListQuery,
             _ database: DatabaseContainer
-        ) -> UserListState = { @MainActor users, query, database in
-            UserListState(users: users, query: query, database: database)
+        ) -> UserListState = { @MainActor in
+            UserListState(query: $0, database: $1)
         }
     }
 }

--- a/Sources/StreamChat/StateLayer/UserListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/UserListState+Observer.swift
@@ -8,7 +8,7 @@ import Foundation
 extension UserListState {
     struct Observer {
         private let query: UserListQuery
-        let usersObserver: StateLayerDatabaseObserver<ListResult, ChatUser, UserDTO>
+        private let usersObserver: StateLayerDatabaseObserver<ListResult, ChatUser, UserDTO>
         
         init(query: UserListQuery, database: DatabaseContainer) {
             self.query = query
@@ -23,11 +23,12 @@ extension UserListState {
             let usersDidChange: (StreamCollection<ChatUser>) async -> Void
         }
         
-        func start(with handlers: Handlers) {
+        func start(with handlers: Handlers) -> StreamCollection<ChatUser> {
             do {
-                try usersObserver.startObserving(didChange: handlers.usersDidChange)
+                return try usersObserver.startObserving(didChange: handlers.usersDidChange)
             } catch {
                 log.error("Failed to start the user list observer for query: \(query)")
+                return StreamCollection([])
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/UserListState.swift
+++ b/Sources/StreamChat/StateLayer/UserListState.swift
@@ -9,16 +9,13 @@ import Foundation
 @MainActor public final class UserListState: ObservableObject {
     private let observer: Observer
     
-    init(users: [ChatUser], query: UserListQuery, database: DatabaseContainer) {
+    init(query: UserListQuery, database: DatabaseContainer) {
         observer = Observer(query: query, database: database)
         self.query = query
-        self.users = StreamCollection(users)
-        observer.start(
+        
+        users = observer.start(
             with: .init(usersDidChange: { [weak self] in self?.users = $0 })
         )
-        if users.isEmpty {
-            self.users = observer.usersObserver.items
-        }
     }
     
     /// The query specifying and filtering the list of users.

--- a/Sources/StreamChat/StateLayer/UserSearchState.swift
+++ b/Sources/StreamChat/StateLayer/UserSearchState.swift
@@ -46,7 +46,7 @@ extension UserSearchState {
             let sortValues = completedQuery.sort.map(\.sortValue)
             result = StreamCollection((incomingRemovedUsers + incomingUsers).sort(using: sortValues))
         }
-        self.users = result
+        users = result
     }
 }
 

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -236,7 +236,7 @@ extension ChannelListUpdater {
         }
     }
 
-    func update(channelListQuery: ChannelListQuery) async throws -> [ChatChannel] {
+    @discardableResult func update(channelListQuery: ChannelListQuery) async throws -> [ChatChannel] {
         try await withCheckedThrowingContinuation { continuation in
             update(channelListQuery: channelListQuery) { result in
                 continuation.resume(with: result)

--- a/Sources/StreamChat/Workers/UserListUpdater.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater.swift
@@ -69,7 +69,7 @@ enum UpdatePolicy {
 
 @available(iOS 13.0, *)
 extension UserListUpdater {
-    func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge) async throws -> [ChatUser] {
+    @discardableResult func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge) async throws -> [ChatUser] {
         try await withCheckedThrowingContinuation { continuation in
             update(userListQuery: userListQuery) { result in
                 continuation.resume(with: result)

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/ChannelList_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/ChannelList_Mock.swift
@@ -9,19 +9,16 @@ import Foundation
 public class ChannelList_Mock: ChannelList {
     
     public static func mock(
-        channels: [ChatChannel] = [],
         query: ChannelListQuery? = nil,
         client: ChatClient? = nil
     ) -> ChannelList_Mock {
         ChannelList_Mock(
-            channels: channels,
             query: query ?? .init(filter: .nonEmpty),
             client: client ?? .mock(bundle: Bundle(for: Self.self))
         )
     }
     
     init(
-        channels: [ChatChannel],
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)? = nil,
         client: ChatClient,
@@ -32,7 +29,6 @@ public class ChannelList_Mock: ChannelList {
             apiClient: APIClient_Spy()
         )
         super.init(
-            initialChannels: channels,
             query: query,
             dynamicFilter: dynamicFilter,
             channelListUpdater: channelListUpdater,

--- a/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
@@ -133,7 +133,7 @@ final class ConnectedUser_Tests: XCTestCase {
     
     // MARK: - Test Data
     
-    private func setUpConnectedUser(usesMockedUpdaters: Bool, initialDeviceCount: Int = 0) async throws {
+    @MainActor private func setUpConnectedUser(usesMockedUpdaters: Bool, loadState: Bool = true, initialDeviceCount: Int = 0) async throws {
         var user: CurrentChatUser!
         try await env.client.databaseContainer.write { session in
             user = try session.saveCurrentUser(payload: self.currentUserPayload(deviceCount: initialDeviceCount)).asModel()
@@ -146,6 +146,9 @@ final class ConnectedUser_Tests: XCTestCase {
                 usesMockedUpdaters: usesMockedUpdaters
             )
         )
+        if loadState {
+            _ = connectedUser.state
+        }
     }
     
     private func currentUserPayload(name: String = "InitialName", deviceCount: Int = 0) -> CurrentUserPayload {

--- a/Tests/StreamChatTests/StateLayer/MemberList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MemberList_Tests.swift
@@ -78,12 +78,15 @@ final class MemberList_Tests: XCTestCase {
 
     // MARK: - Test Data
     
-    @MainActor private func setUpMemberList(usesMockedUpdater: Bool) async throws {
+    @MainActor private func setUpMemberList(usesMockedUpdater: Bool, loadState: Bool = true) async throws {
         memberList = MemberList(
             query: query,
             client: env.client,
             environment: env.memberListEnvironment(usesMockedUpdater: usesMockedUpdater)
         )
+        if loadState {
+            _ = memberList.state
+        }
     }
     
     private func createChannel() async throws {

--- a/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MessageState_Tests.swift
@@ -11,10 +11,9 @@ final class MessageState_Tests: XCTestCase {
     private var channelId: ChannelId!
     private var env: TestEnvironment!
     private var messageId: MessageId!
+    private var messageState: MessageState!
     private var testError: TestError!
     private var unrelatedMessageId: MessageId!
-    // Main actor since message state mutates on the main actor and we want to read results on the main actor
-    @MainActor private var messageState: MessageState!
     
     override func setUpWithError() throws {
         channelId = .unique
@@ -28,7 +27,7 @@ final class MessageState_Tests: XCTestCase {
         }
     }
 
-    @MainActor override func tearDownWithError() throws {
+    override func tearDownWithError() throws {
         env.cleanUp()
         channelId = nil
         env = nil

--- a/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
@@ -30,7 +30,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeChannelObserver()
-        try observer.startObserving(onContextDidChange: { _ in
+        _ = try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
         })
@@ -60,7 +60,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeChannelObserver()
-        try observer.startObserving(onContextDidChange: { _ in
+        _ = try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
         })
@@ -86,7 +86,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeChannelObserver()
-        try observer.startObserving(onContextDidChange: { _ in
+        _ = try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
         })
@@ -125,7 +125,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(onContextDidChange: { _ in
+        _ = try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
         })
@@ -157,7 +157,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(onContextDidChange: { _ in
+        _ = try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
         })
@@ -192,7 +192,7 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
         let expectation = XCTestExpectation()
         var changeCount = 0
         let observer = makeMessagesListObserver()
-        try observer.startObserving(onContextDidChange: { _ in
+        _ = try observer.startObserving(onContextDidChange: { _ in
             changeCount += 1
             expectation.fulfill()
         })

--- a/Tests/StreamChatTests/StateLayer/UserSearch_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/UserSearch_Tests.swift
@@ -12,13 +12,15 @@ final class UserSearch_Tests: XCTestCase {
     private var testError: TestError!
     private var userSearch: UserSearch!
     
-    override func setUpWithError() throws {
+    @MainActor override func setUpWithError() throws {
         env = TestEnvironment()
         testError = TestError()
         userSearch = UserSearch(
             client: env.client,
             environment: env.userListEnvironment
         )
+        // Explicitly load the state
+        _ = userSearch.state
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Since `XYZState` is lazy var now (required by the `@MainActor` work) then there can be cases where:
```swift
let channelList = client.makeChannelList(…)
// which currently triggers fetching latest channels and
// passing the fetched channel list to the `ChannelListState` builder

// DB changed, but we haven't accessed `channelList.state`

let state = channelList.state

// Triggers lazy loaded property and `ChannelListState` is created
//  with `initialChannels` but these are not up to date anymore 
// since DB changed meanwhile
```
This PR tackles this and forces to handle initial states when starting the observer. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
