### PR TITLE
[ChatStateLayer] Sync factory methods and get()

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -7,6 +7,8 @@
 --disable extensionAccessControl
 --disable andOperator
 
+--disable redundantGet # it removes get async throws from getters
+
 # Rules inferred from Swift Standard Library:
 --disable anyObjectProtocol, wrapMultilineStatementBraces
 --indent 4

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -9,6 +9,7 @@ import Foundation
 public class ChannelList {
     private let channelListUpdater: ChannelListUpdater
     private let stateBuilder: StateBuilder<ChannelListState>
+    let query: ChannelListQuery
     
     init(
         query: ChannelListQuery,
@@ -30,9 +31,6 @@ public class ChannelList {
             )
         }
     }
-    
-    /// The query specifying and filtering the list of channels.
-    public let query: ChannelListQuery
     
     /// An observable object representing the current state of the channel list.
     @MainActor public lazy var state: ChannelListState = stateBuilder.build()

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -8,7 +8,6 @@ import Foundation
 @available(iOS 13.0, *)
 @MainActor public final class ChannelListState: ObservableObject {
     private let observer: Observer
-    private let query: ChannelListQuery
     
     init(
         query: ChannelListQuery,
@@ -31,6 +30,9 @@ import Foundation
             with: .init(channelsDidChange: { [weak self] in self?.channels = $0 })
         )
     }
+    
+    /// The query specifying and filtering the list of channels.
+    public let query: ChannelListQuery
     
     /// An array of channels for the specified ``ChannelListQuery``.
     @Published public internal(set) var channels = StreamCollection<ChatChannel>([])

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -1109,18 +1109,24 @@ public class Chat {
 @available(iOS 13.0, *)
 extension Chat {
     @MainActor var cid: ChannelId {
-        guard let cid = state.channelQuery.cid else { throw ClientError.ChannelNotCreatedYet() }
-        return cid
+        get throws {
+            guard let cid = state.channelQuery.cid else { throw ClientError.ChannelNotCreatedYet() }
+            return cid
+        }
     }
     
     var memberList: MemberList {
-        guard let memberList = await state.memberList else { throw ClientError.ChannelNotCreatedYet() }
-        return memberList
+        get async throws {
+            guard let memberList = await state.memberList else { throw ClientError.ChannelNotCreatedYet() }
+            return memberList
+        }
     }
     
     var readStateSender: ReadStateSender {
-        guard let sender = await state.readStateSender else { throw ClientError.ChannelNotCreatedYet() }
-        return sender
+        get async throws {
+            guard let sender = await state.readStateSender else { throw ClientError.ChannelNotCreatedYet() }
+            return sender
+        }
     }
 }
 

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -131,7 +131,7 @@ extension ChatClient {
     ///   - channelListQuery: The channel list query the channel belongs to.
     ///   - extraData: Extra data for the new channel.
     ///
-    /// - Throws: An error while communicating with the Stream API.
+    /// - Throws: An error if no user is currently logged-in.
     /// - Returns: An instance of `Chat` representing the channel.
     public func makeChat(
         with cid: ChannelId,
@@ -185,7 +185,7 @@ extension ChatClient {
     ///   - channelListQuery: The channel list query the channel belongs to.
     ///   - extraData: Extra data for the new channel.
     ///
-    /// - Throws: An error while communicating with the Stream API.
+    /// - Throws: An error if no user is currently logged-in.
     /// - Returns: An instance of `Chat` representing the channel.
     public func makeDirectMessageChat(
         with members: [UserId],

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -23,7 +23,7 @@ extension ChatClient {
 extension ChatClient {
     /// Creates an instance of ``ChannelList`` which represents an array of channels matching to the specified ``ChannelListQuery``.
     ///
-    /// Loaded channels are stored in ``ChannelListState/channels``. Use pagination methods in ``ChannelList`` for loading more matching channels to the observable state.
+    /// Loaded channels are stored in ``ChannelListState/channels``. Use pagination methods in ``ChannelList`` for refreshing or loading more matching channels to the observable state.
     /// Refer to [querying channels in Stream documentation](https://getstream.io/chat/docs/ios-swift/query_channels/?language=swift) for additional details.
     ///
     /// - Note: Only channels that the user can read are returned, therefore, make sure that the query uses a filter that includes such logic. It is recommended to include a members filter which includes the currently logged in user (e.g. `.containMembers(userIds: ["thierry"])`).
@@ -32,11 +32,9 @@ extension ChatClient {
     ///   - query: The query specifies which channels are part of the list and how channels are sorted.
     ///   - dynamicFilter: A filter block for filtering by channel's extra data fields or as a manual filter when ``ChatClientConfig/isChannelAutomaticFilteringEnabled`` is false ([read more](https://getstream.io/chat/docs/sdk/ios/client/controllers/channels/)).
     ///
-    /// - Throws: An error while communicating with the Stream API.
-    /// - Returns: An instance of ``ChannelList`` which represents actions and the current state of the list.
-    public func makeChannelList(with query: ChannelListQuery, dynamicFilter: ((ChatChannel) -> Bool)? = nil) async throws -> ChannelList {
-        try await channelListUpdater.update(channelListQuery: query)
-        let channelList = ChannelList(query: query, dynamicFilter: dynamicFilter, channelListUpdater: channelListUpdater, client: self)
+    /// - Returns: An instance of ``ChannelList`` which represents actions and the state of the list.
+    public func makeChannelList(with query: ChannelListQuery, dynamicFilter: ((ChatChannel) -> Bool)? = nil) -> ChannelList {
+        let channelList = ChannelList(query: query, dynamicFilter: dynamicFilter, client: self)
         syncRepository.trackChannelListQuery { [weak channelList] in channelList?.query }
         return channelList
     }
@@ -48,17 +46,14 @@ extension ChatClient {
 extension ChatClient {
     /// Creates an instance of ``UserList`` which represents an array of users matching to the specified ``UserListQuery``.
     ///
-    /// Loaded users are stored in ``UserListState/users``. Use pagination methods in ``UserList`` for loading more matching users to the observable state.
+    /// Loaded users are stored in ``UserListState/users``. Use pagination methods in ``UserList`` for refreshing or loading more matching users to the observable state.
     /// Refer to [querying users in Stream documentation](https://getstream.io/chat/docs/ios-swift/query_users/?language=swift) for additional details.
     ///
     /// - Parameter query: The query specifies which users are part of the list and how users are sorted.
     ///
-    /// - Throws: An error while communicating with the Stream API.
-    /// - Returns: An instance of ``UserList`` which represents actions and the current state of the list.
-    public func makeUserList(with query: UserListQuery) async throws -> UserList {
-        let userListUpdater = UserListUpdater(database: databaseContainer, apiClient: apiClient)
-        try await userListUpdater.update(userListQuery: query)
-        return UserList(query: query, userListUpdater: userListUpdater, client: self)
+    /// - Returns: An instance of ``UserList`` which represents actions and the state of the list.
+    public func makeUserList(with query: UserListQuery) -> UserList {
+        UserList(query: query, client: self)
     }
 }
 

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -7,56 +7,44 @@ import Foundation
 /// Represents a ``ChatChannel`` and its state.
 @available(iOS 13.0, *)
 @MainActor public final class ChatState: ObservableObject {
-    private let authenticationRepository: AuthenticationRepository
-    private let cid: ChannelId
-    private var channelObserver: EntityDatabaseObserverWrapper<ChatChannel, ChannelDTO>?
+    private let channelUpdater: ChannelUpdater
     private let dataStore: DataStore
-    private let paginationStateHandler: MessagesPaginationStateHandling
-    private let observer: Observer
+    private let environment: Chat.Environment
+    private var observer: Observer?
+    private(set) var memberList: MemberList?
+    private(set) var readStateSender: Chat.ReadStateSender?
     
     init(
-        cid: ChannelId,
         channelQuery: ChannelQuery,
-        clientConfig: ChatClientConfig,
         messageOrder: MessageOrdering,
-        memberListState: MemberListState,
-        authenticationRepository: AuthenticationRepository,
-        database: DatabaseContainer,
-        eventNotificationCenter: EventNotificationCenter,
-        paginationStateHandler: MessagesPaginationStateHandling
+        memberSorting: [Sorting<ChannelMemberListSortingKey>],
+        channelUpdater: ChannelUpdater,
+        client: ChatClient,
+        environment: Chat.Environment
     ) {
-        self.authenticationRepository = authenticationRepository
-        self.cid = cid
-        dataStore = DataStore(database: database)
+        self.channelQuery = channelQuery
+        self.channelUpdater = channelUpdater
+        self.client = client
+        dataStore = DataStore(database: client.databaseContainer)
+        self.environment = environment
+        self.memberSorting = memberSorting
         self.messageOrder = messageOrder
-        self.paginationStateHandler = paginationStateHandler
-        observer = Observer(
-            cid: cid,
-            channelQuery: channelQuery,
-            clientConfig: clientConfig,
-            messageOrder: messageOrder,
-            memberListState: memberListState,
-            database: database,
-            eventNotificationCenter: eventNotificationCenter
-        )
-        let initial = observer.start(
-            with: .init(
-                channelDidChange: { [weak self] in self?.channel = $0 },
-                membersDidChange: { [weak self] in self?.members = $0 },
-                messagesDidChange: { [weak self] in self?.messages = $0 },
-                watchersDidChange: { [weak self] in self?.watchers = $0 }
-            )
-        )
-        channel = initial.channel
-        members = initial.members
-        messages = initial.messages
-        watchers = initial.watchers
+        
+        if let cid = channelQuery.cid {
+            observe(cid)
+        }
     }
     
-    // MARK: - Represented Channel
+    /// The client instance the ``Chat`` was created with.
+    public let client: ChatClient
+    
+    // MARK: - Represented Channel and Query
     
     /// The represented ``ChatChannel``.
     @Published public internal(set) var channel: ChatChannel?
+    
+    /// The channel query used for looking up the channel.
+    public private(set) var channelQuery: ChannelQuery
     
     // MARK: - Members
     
@@ -64,6 +52,9 @@ import Foundation
     ///
     /// Use load members in ``Chat`` for loading more members.
     @Published public private(set) var members = StreamCollection<ChatChannelMember>([])
+    
+    /// The sorting order for channel members (the default sorting is by created at in ascending order).
+    let memberSorting: [Sorting<ChannelMemberListSortingKey>]
     
     // MARK: - Messages
     
@@ -85,7 +76,7 @@ import Foundation
     ///
     /// - Returns: An instance of the locally available chat message
     public func localMessage(for messageId: MessageId) -> ChatMessage? {
-        if let message = dataStore.message(id: messageId), message.cid == cid {
+        if let message = dataStore.message(id: messageId), message.cid == channelQuery.cid {
             return message
         }
         return nil
@@ -93,34 +84,34 @@ import Foundation
     
     /// A Boolean value that returns whether the oldest messages have all been loaded or not.
     public var hasLoadedAllPreviousMessages: Bool {
-        paginationStateHandler.state.hasLoadedAllPreviousMessages
+        channelUpdater.paginationStateHandler.state.hasLoadedAllPreviousMessages
     }
     
     /// A Boolean value that returns whether the newest messages have all been loaded or not.
     public var hasLoadedAllNextMessages: Bool {
-        paginationStateHandler.state.hasLoadedAllNextMessages || messages.isEmpty
+        channelUpdater.paginationStateHandler.state.hasLoadedAllNextMessages || messages.isEmpty
     }
 
     /// A Boolean value that returns whether the channel is currently in a mid-page.
     /// The value is false if the channel has the first page loaded.
     /// The value is true if the channel is in a mid fragment and didn't load the first page yet.
     public var isJumpingToMessage: Bool {
-        paginationStateHandler.state.isJumpingToMessage
+        channelUpdater.paginationStateHandler.state.isJumpingToMessage
     }
 
     /// A Boolean value that returns whether the channel is currently loading a page around a message.
     public var isLoadingMiddleMessages: Bool {
-        paginationStateHandler.state.isLoadingMiddleMessages
+        channelUpdater.paginationStateHandler.state.isLoadingMiddleMessages
     }
 
     /// A Boolean value that returns whether the channel is currently loading next (new) messages.
     public var isLoadingNextMessages: Bool {
-        paginationStateHandler.state.isLoadingNextMessages
+        channelUpdater.paginationStateHandler.state.isLoadingNextMessages
     }
 
     /// A Boolean value that returns whether the channel is currently loading previous (old) messages.
     public var isLoadingPreviousMessages: Bool {
-        paginationStateHandler.state.isLoadingPreviousMessages
+        channelUpdater.paginationStateHandler.state.isLoadingPreviousMessages
     }
     
     // MARK: - Message Reading
@@ -128,7 +119,7 @@ import Foundation
     /// The id of the message which the current user last read.
     public var lastReadMessageId: MessageId? {
         guard let channel else { return nil }
-        guard let userId = authenticationRepository.currentUserId else { return nil }
+        guard let userId = client.authenticationRepository.currentUserId else { return nil }
         return channel.lastReadMessageId(userId: userId)
     }
     
@@ -141,7 +132,7 @@ import Foundation
     /// * Last read message is unreachable (e.g. channel was truncated): oldest message if all the messages have been paginated, otherwise nil
     /// * Next message after the last read message id not from the current user
     public var firstUnreadMessageId: MessageId? {
-        guard let userId = authenticationRepository.currentUserId else { return nil }
+        guard let userId = client.authenticationRepository.currentUserId else { return nil }
         return UnreadMessageLookup.firstUnreadMessage(in: self, userId: userId)
     }
 
@@ -166,4 +157,54 @@ import Foundation
     ///
     /// Use load watchers method in ``Chat`` for populating this array.
     @Published public internal(set) var watchers = StreamCollection<ChatUser>([])
+}
+
+// MARK: - Internal
+
+@available(iOS 13.0, *)
+extension ChatState {
+    func setChannelId(_ channelId: ChannelId) {
+        channelQuery = ChannelQuery(cid: channelId, channelQuery: channelQuery)
+        observe(channelId)
+    }
+    
+    func observe(_ channelId: ChannelId) {
+        let memberList = MemberList(
+            query: ChannelMemberListQuery(
+                cid: channelId,
+                sort: memberSorting
+            ),
+            client: client
+        )
+        self.memberList = memberList
+        readStateSender = environment.readStateSenderBuilder(
+            channelId,
+            channelUpdater,
+            client.authenticationRepository,
+            client.messageRepository
+        )
+        observer = Observer(
+            cid: channelId,
+            channelQuery: channelQuery,
+            clientConfig: client.config,
+            messageOrder: messageOrder,
+            memberListState: memberList.state,
+            database: client.databaseContainer,
+            eventNotificationCenter: client.eventNotificationCenter
+        )
+        if let observer {
+            let initial = observer.start(
+                with: .init(
+                    channelDidChange: { [weak self] in self?.channel = $0 },
+                    membersDidChange: { [weak self] in self?.members = $0 },
+                    messagesDidChange: { [weak self] in self?.messages = $0 },
+                    watchersDidChange: { [weak self] in self?.watchers = $0 }
+                )
+            )
+            channel = initial.channel
+            members = initial.members
+            messages = initial.messages
+            watchers = initial.watchers
+        }
+    }
 }

--- a/Sources/StreamChat/StateLayer/UserList.swift
+++ b/Sources/StreamChat/StateLayer/UserList.swift
@@ -10,8 +10,11 @@ public final class UserList {
     private let stateBuilder: StateBuilder<UserListState>
     private let userListUpdater: UserListUpdater
     
-    init(query: UserListQuery, userListUpdater: UserListUpdater, client: ChatClient, environment: Environment = .init()) {
-        self.userListUpdater = userListUpdater
+    init(query: UserListQuery, client: ChatClient, environment: Environment = .init()) {
+        userListUpdater = environment.userListUpdater(
+            client.databaseContainer,
+            client.apiClient
+        )
         stateBuilder = StateBuilder {
             environment.stateBuilder(
                 query,
@@ -53,6 +56,11 @@ public final class UserList {
 @available(iOS 13.0, *)
 extension UserList {
     struct Environment {
+        var userListUpdater: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> UserListUpdater = UserListUpdater.init
+        
         var stateBuilder: @MainActor(
             _ query: UserListQuery,
             _ database: DatabaseContainer

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -882,9 +882,10 @@ extension ChannelUpdater {
         }
     }
 
-    @discardableResult func update(channelQuery: ChannelQuery, isInRecoveryMode: Bool) async throws -> ChannelPayload {
-        try await withCheckedThrowingContinuation { continuation in
-            update(channelQuery: channelQuery, isInRecoveryMode: isInRecoveryMode, onChannelCreated: nil) { result in
+    @discardableResult func update(channelQuery: ChannelQuery) async throws -> ChannelPayload {
+        let useCreateEndpoint: ((ChannelId) -> Void)? = channelQuery.cid == nil ? { _ in } : nil
+        return try await withCheckedThrowingContinuation { continuation in
+            update(channelQuery: channelQuery, isInRecoveryMode: false, onChannelCreated: useCreateEndpoint) { result in
                 continuation.resume(with: result)
             }
         }
@@ -917,7 +918,7 @@ extension ChannelUpdater {
     // MARK: -
     
     func loadMessages(with channelQuery: ChannelQuery, pagination: MessagesPagination) async throws -> [ChatMessage] {
-        let payload = try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
+        let payload = try await update(channelQuery: channelQuery.withPagination(pagination))
         guard let cid = channelQuery.cid else { return [] }
         guard let fromDate = payload.messages.first?.createdAt else { return [] }
         guard let toDate = payload.messages.last?.createdAt else { return [] }
@@ -926,7 +927,7 @@ extension ChannelUpdater {
     
     func loadMessagesFirstPage(with channelQuery: ChannelQuery) async throws {
         let pagination = MessagesPagination(pageSize: channelQuery.pagination?.pageSize ?? .messagesPageSize)
-        try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
+        try await update(channelQuery: channelQuery.withPagination(pagination))
     }
     
     func loadMessages(before messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
@@ -938,7 +939,7 @@ extension ChannelUpdater {
         }
         let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .lessThan(messageId))
-        try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
+        try await update(channelQuery: channelQuery.withPagination(pagination))
     }
 
     func loadMessages(after messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
@@ -949,14 +950,14 @@ extension ChannelUpdater {
         }
         let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .greaterThan(messageId))
-        try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
+        try await update(channelQuery: channelQuery.withPagination(pagination))
     }
         
     func loadMessages(around messageId: MessageId, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingMiddleMessages else { return }
         let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .around(messageId))
-        try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
+        try await update(channelQuery: channelQuery.withPagination(pagination))
     }
 }
 
@@ -971,10 +972,16 @@ extension CheckedContinuation where T == Void, E == Error {
     }
 }
 
-private extension ChannelQuery {
+extension ChannelQuery {
     func withPagination(_ pagination: MessagesPagination) -> Self {
         var result = self
         result.pagination = pagination
+        return result
+    }
+    
+    func withOptions(forWatching watch: Bool) -> Self {
+        var result = self
+        result.options = options
         return result
     }
 }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -981,7 +981,7 @@ extension ChannelQuery {
     
     func withOptions(forWatching watch: Bool) -> Self {
         var result = self
-        result.options = options
+        result.options = watch ? .all : .state
         return result
     }
 }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/ChannelList_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/ChannelList_Mock.swift
@@ -18,20 +18,15 @@ public class ChannelList_Mock: ChannelList {
         )
     }
     
-    init(
+    override init(
         query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)? = nil,
         client: ChatClient,
         environment: ChannelList.Environment = .init()
     ) {
-        let channelListUpdater = ChannelListUpdater(
-            database: .init(kind: .inMemory, bundle: Bundle(for: Self.self)),
-            apiClient: APIClient_Spy()
-        )
         super.init(
             query: query,
             dynamicFilter: dynamicFilter,
-            channelListUpdater: channelListUpdater,
             client: client,
             environment: environment
         )

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/Chat_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/Chat_Mock.swift
@@ -15,16 +15,10 @@ public class Chat_Mock: Chat {
         channelQuery: ChannelQuery,
         channelListQuery: ChannelListQuery?
     ) {
-        let channelUpdater = chatClient.makeChannelUpdater()
-        channelUpdater.paginationStateHandler.end(pagination: .init(pageSize: 25), with: .success([]))
         super.init(
-            cid: Self.cid,
             channelQuery: channelQuery,
-            channelListQuery: channelListQuery,
-            memberSorting: [.init(key: .createdAt)], 
-            channelUpdater: channelUpdater,
-            client: chatClient,
-            environment: .init()
+            memberSorting: [.init(key: .createdAt)],
+            client: chatClient
         )
     }
     


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Make all the factory methods synchronous and add `get()` to `Chat` for triggering the server sync

### 📝 Summary

- Factory methods are sync
- `Chat` has `get(watch:)` for triggering server sync which retrieves `cid` if required
- Chat does not have non-optional access to `cid`
   - Requires changes how we set up dependencies and observing when `cid` changes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
