### PR TITLE
[ChatStateLayer] Rename pagination methods and add new convenience methods

### DIFF
--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -59,7 +59,7 @@ public class ChannelList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
-    @discardableResult public func loadNextChannels(limit: Int? = nil) async throws -> [ChatChannel] {
+    @discardableResult public func loadMoreChannels(limit: Int? = nil) async throws -> [ChatChannel] {
         let limit = limit ?? query.pagination.pageSize
         let count = await state.channels.count
         return try await channelListUpdater.loadNextChannels(query: query, limit: limit, loadedChannelsCount: count)

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -373,7 +373,7 @@ public class Chat {
     
     /// Loads messages for the specified pagination parameters and updates ``ChatState/messages``.
     ///
-    /// - Important: Loading messages for the pagination index 0 resets ``ChatState/messages``.
+    /// - Important: Loading messages for the pagination with parameter nil resets ``ChatState/messages``. Example `chat.loadMessages(with: MessagesPagination(pageSize: 30, parameter: nil))`.
     ///
     /// - Parameters:
     ///   - message: The parent message id which has replies.
@@ -685,9 +685,9 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of messages for the pagination.
-    @discardableResult public func loadReplies(of messageId: MessageId, pagination: MessagesPagination) async throws -> [ChatMessage] {
+    @discardableResult public func loadReplies(for messageId: MessageId, pagination: MessagesPagination) async throws -> [ChatMessage] {
         let messageState = try await messageState(for: messageId)
-        return try await messageUpdater.loadReplies(of: messageId, pagination: pagination, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+        return try await messageUpdater.loadReplies(for: messageId, pagination: pagination, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
     }
 
     // MARK: -
@@ -700,9 +700,9 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadReplies(before replyId: MessageId?, of parentMessageId: MessageId, limit: Int? = nil) async throws {
+    public func loadReplies(before replyId: MessageId?, for parentMessageId: MessageId, limit: Int? = nil) async throws {
         let messageState = try await messageState(for: parentMessageId)
-        return try await messageUpdater.loadReplies(of: parentMessageId, before: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+        return try await messageUpdater.loadReplies(for: parentMessageId, before: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
     }
     
     /// Loads more replies after the specified reply id and updates ``MessageState/replies``.
@@ -713,9 +713,9 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadReplies(after replyId: MessageId?, of parentMessageId: MessageId, limit: Int? = nil) async throws {
+    public func loadReplies(after replyId: MessageId?, for parentMessageId: MessageId, limit: Int? = nil) async throws {
         let messageState = try await messageState(for: parentMessageId)
-        return try await messageUpdater.loadReplies(of: parentMessageId, after: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+        return try await messageUpdater.loadReplies(for: parentMessageId, after: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
     }
     
     /// Loads replies around the specified reply id to ``MessageState/replies``.
@@ -728,9 +728,9 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadReplies(around replyId: MessageId, of parentMessageId: MessageId, limit: Int? = nil) async throws {
+    public func loadReplies(around replyId: MessageId, for parentMessageId: MessageId, limit: Int? = nil) async throws {
         let messageState = try await messageState(for: parentMessageId)
-        return try await messageUpdater.loadReplies(of: parentMessageId, around: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+        return try await messageUpdater.loadReplies(for: parentMessageId, around: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
     }
     
     /// Loads more older replies and updates ``MessageState/replies``.
@@ -740,8 +740,8 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadOlderReplies(of parentMessageId: MessageId, limit: Int? = nil) async throws {
-        try await loadReplies(before: nil, of: parentMessageId, limit: limit)
+    public func loadOlderReplies(for parentMessageId: MessageId, limit: Int? = nil) async throws {
+        try await loadReplies(before: nil, for: parentMessageId, limit: limit)
     }
     
     /// Loads more newer replies and updates ``MessageState/replies``.
@@ -751,8 +751,8 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadNewerReplies(of parentMessageId: MessageId, limit: Int? = nil) async throws {
-        try await loadReplies(after: nil, of: parentMessageId, limit: limit)
+    public func loadNewerReplies(for parentMessageId: MessageId, limit: Int? = nil) async throws {
+        try await loadReplies(after: nil, for: parentMessageId, limit: limit)
     }
     
     // MARK: - Message State Observing

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -179,7 +179,7 @@ public class Chat {
         try await channelUpdater.removeMembers(currentUserId: currentUserId, cid: cid, userIds: Set(members), message: systemMessage)
     }
     
-    /// Loads an array of members for the specified query and updates ``ChatState/members``.
+    /// Loads channel members for the specified pagination parameters and updates ``ChatState/members``.
     ///
     /// - Note: Channel member sorting keys are set when creating the ``Chat`` instance.
     /// It is also possible to create separate ``MemberList`` objects if needed with different filtering options. See ``ChatClient/makeMemberList(with:)``.
@@ -187,9 +187,19 @@ public class Chat {
     /// - Parameter pagination: The pagination configuration which includes a limit and an offset or a cursor.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    /// - Returns: An array of paginated channel members for the query.
+    /// - Returns: An array of channel members for the pagination request.
     @discardableResult public func loadMembers(with pagination: Pagination) async throws -> [ChatChannelMember] {
         try await memberList.loadMembers(with: pagination)
+    }
+    
+    /// Loads more channel members and updates ``ChatState/members``.
+    ///
+    /// - Parameter limit: The limit for the page size. The default limit is 30.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of channel members for the pagination request.
+    @discardableResult public func loadMoreMembers(limit: Int? = nil) async throws -> [ChatChannelMember] {
+        try await memberList.loadMoreMembers(limit: limit)
     }
     
     // MARK: - Member Moderation
@@ -363,64 +373,47 @@ public class Chat {
     
     /// Loads messages for the specified pagination parameters and updates ``ChatState/messages``.
     ///
+    /// - Important: Loading messages for the pagination index 0 resets ``ChatState/messages``.
+    ///
     /// - Parameters:
     ///   - message: The parent message id which has replies.
     ///   - pagination: The pagination configuration which includes a limit and a cursor.
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of messages for the pagination.
-    public func loadMessages(with pagination: MessagesPagination) async throws -> [ChatMessage] {
+    @discardableResult public func loadMessages(with pagination: MessagesPagination) async throws -> [ChatMessage] {
         try await channelUpdater.loadMessages(with: state.channelQuery, pagination: pagination)
     }
     
     // MARK: -
     
-    /// Loads messages for the first page and updates ``ChatState/messages``.
-    ///
-    /// - Note: Loading the first page resets the ``ChatState/messages``.
-    ///
-    /// - Throws: An error while communicating with the Stream API.
-    public func loadMessagesFirstPage() async throws {
-        try await channelUpdater.loadMessagesFirstPage(with: state.channelQuery)
-    }
-    
-    /// Loads more messages before the specified message to ``ChatState/messages``.
+    /// Loads older messages before the specified message to ``ChatState/messages``.
     ///
     /// - Parameters:
-    ///   - messageId: The message id of the message from which older messages are loaded.
+    ///   - messageId: The message id of the message from which older messages are loaded. If nil, the id of the oldest loaded message in ``ChatState/messages`` is used.
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadPreviousMessages(before messageId: MessageId? = nil, limit: Int? = nil) async throws {
-        try await channelUpdater.loadMessages(
-            before: messageId,
-            limit: limit,
-            channelQuery: state.channelQuery,
-            loaded: state.messages
-        )
+    public func loadMessages(before messageId: MessageId?, limit: Int? = nil) async throws {
+        try await channelUpdater.loadMessages(before: messageId, limit: limit, channelQuery: state.channelQuery, loaded: state.messages)
     }
     
-    /// Loads more messages after the specified message to ``ChatState/messages``.
+    /// Loads newer messages after the specified message to ``ChatState/messages``.
     ///
     /// - Parameters:
-    ///   - messageId: The message id of the message from which newer messages are loaded.
+    ///   - messageId: The message id of the message from which newer messages are loaded.  If nil, the id of the newest loaded message in ``ChatState/messages`` is used.
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadNextMessages(_ messageId: MessageId? = nil, limit: Int? = nil) async throws {
-        try await channelUpdater.loadMessages(
-            after: messageId,
-            limit: limit,
-            channelQuery: state.channelQuery,
-            loaded: state.messages
-        )
+    public func loadMessages(after messageId: MessageId?, limit: Int? = nil) async throws {
+        try await channelUpdater.loadMessages(after: messageId, limit: limit, channelQuery: state.channelQuery, loaded: state.messages)
     }
     
     /// Loads messages around the given message id to ``ChatState/messages``.
     ///
     /// Useful for jumping to a message which hasn't been loaded yet.
     ///
-    /// - Note: Jumping to a messages resets the ``ChatState/messages``.
+    /// - Important: Jumping to a message resets the ``ChatState/messages``.
     ///
     /// - Parameters:
     ///   - messageId: The message id of the middle message in the loaded list of messages.
@@ -434,6 +427,24 @@ public class Chat {
             channelQuery: state.channelQuery,
             loaded: state.messages
         )
+    }
+    
+    /// Loads more older messages and updates ``ChatState/messages``.
+    ///
+    /// - Parameter limit: The limit for the page size. The default limit is 25.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func loadOlderMessages(limit: Int? = nil) async throws {
+        try await loadMessages(before: nil, limit: limit)
+    }
+    
+    /// Loads more newer messages and updates ``ChatState/messages``.
+    ///
+    /// - Parameter limit: The limit for the page size. The default limit is 25.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func loadNewerMessages(limit: Int? = nil) async throws {
+        try await loadMessages(after: nil, limit: limit)
     }
     
     // MARK: - Message Attachment Actions
@@ -520,7 +531,11 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of pinned messages for the specified pagination.
-    public func loadPinnedMessages(for pagination: PinnedMessagesPagination? = nil, sort: [Sorting<PinnedMessagesSortingKey>] = [], limit: Int = .messagesPageSize) async throws -> [ChatMessage] {
+    public func loadPinnedMessages(
+        with pagination: PinnedMessagesPagination? = nil,
+        sort: [Sorting<PinnedMessagesSortingKey>] = [],
+        limit: Int = .messagesPageSize
+    ) async throws -> [ChatMessage] {
         let query = PinnedMessagesQuery(pageSize: limit, sorting: sort, pagination: pagination)
         return try await channelUpdater.loadPinnedMessages(in: cid, query: query)
     }
@@ -573,7 +588,7 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of reactions for the next page.
-    @discardableResult public func loadNextReactions(of messageId: MessageId, limit: Int? = nil) async throws -> [ChatMessageReaction] {
+    @discardableResult public func loadMoreReactions(of messageId: MessageId, limit: Int? = nil) async throws -> [ChatMessageReaction] {
         let offset = try await messageState(for: messageId).reactions.count
         let pagination = Pagination(pageSize: limit ?? 25, offset: offset)
         return try await messageUpdater.loadReactions(cid: cid, messageId: messageId, pagination: pagination)
@@ -662,7 +677,7 @@ public class Chat {
         return try await messageSender.waitForAPIRequest(messageId: message.id)
     }
     
-    /// Loads replies for the specified message and pagination parameters and updates ``MessageState/replies``.
+    /// Loads replies of the specified message and pagination parameters and updates ``MessageState/replies``.
     ///
     /// - Parameters:
     ///   - messageId: The parent message id which has replies.
@@ -677,57 +692,67 @@ public class Chat {
 
     // MARK: -
     
-    /// Loads replies for the first page of the specified message and updates ``MessageState/replies``.
-    ///
-    /// - Note: Loading the first page resets the ``MessageState/replies``.
-    ///
-    /// - Parameters:
-    ///   - message: The parent message id which has replies.
-    ///   - limit: The limit for the page size. The default limit is 25.
-    ///
-    /// - Throws: An error while communicating with the Stream API.
-    public func loadRepliesFirstPage(of messageId: MessageId, limit: Int? = nil) async throws {
-        let messageState = try await messageState(for: messageId)
-        return try await messageUpdater.loadRepliesFirstPage(of: messageId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
-    }
-    
-    /// Loads more replies before the specified reply id to ``MessageState/replies``.
+    /// Loads more replies before the specified reply id and updates ``MessageState/replies``.
     ///
     /// - Parameters:
     ///   - replyId: The message id of the reply from which older messages are loaded. If nil, the oldest currently loaded message id in ``MessageState/replies`` is used.
-    ///   - messageId: The parent message id which has replies.
+    ///   - parentMessageId: The parent message id which has replies.
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadReplies(before replyId: MessageId? = nil, of messageId: MessageId, limit: Int? = nil) async throws {
-        let messageState = try await messageState(for: messageId)
-        return try await messageUpdater.loadReplies(of: messageId, before: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+    public func loadReplies(before replyId: MessageId?, of parentMessageId: MessageId, limit: Int? = nil) async throws {
+        let messageState = try await messageState(for: parentMessageId)
+        return try await messageUpdater.loadReplies(of: parentMessageId, before: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
     }
     
-    /// Loads more replies after the specified reply id to ``MessageState/replies``.
+    /// Loads more replies after the specified reply id and updates ``MessageState/replies``.
     ///
     /// - Parameters:
     ///   - replyId: The message id of the reply from which newer messages are loaded. If nil, the newest currently loaded message id in ``MessageState/replies`` is used.
-    ///   - messageId: The parent message id which has replies.
+    ///   - parentMessageId: The parent message id which has replies.
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadReplies(after replyId: MessageId? = nil, of messageId: MessageId, limit: Int? = nil) async throws {
-        let messageState = try await messageState(for: messageId)
-        return try await messageUpdater.loadReplies(of: messageId, after: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+    public func loadReplies(after replyId: MessageId?, of parentMessageId: MessageId, limit: Int? = nil) async throws {
+        let messageState = try await messageState(for: parentMessageId)
+        return try await messageUpdater.loadReplies(of: parentMessageId, after: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
     }
     
     /// Loads replies around the specified reply id to ``MessageState/replies``.
     ///
+    /// - Note: Passing in the parent message id as replyId loads oldest replies.
+    ///
     /// - Parameters:
     ///   - replyId: The message id of the reply around which older and newer messages are loaded.
-    ///   - messageId: The parent message id which has replies.
+    ///   - parentMessageId: The parent message id which has replies.
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadReplies(around replyId: MessageId, of messageId: MessageId, limit: Int? = nil) async throws {
-        let messageState = try await messageState(for: messageId)
-        return try await messageUpdater.loadReplies(of: messageId, around: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+    public func loadReplies(around replyId: MessageId, of parentMessageId: MessageId, limit: Int? = nil) async throws {
+        let messageState = try await messageState(for: parentMessageId)
+        return try await messageUpdater.loadReplies(of: parentMessageId, around: replyId, limit: limit, cid: cid, paginationStateHandler: messageState.replyPaginationHandler)
+    }
+    
+    /// Loads more older replies and updates ``MessageState/replies``.
+    ///
+    /// - Parameters:
+    ///   - parentMessageId: The parent message id which has replies.
+    ///   - limit: The limit for the page size. The default limit is 25.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func loadOlderReplies(of parentMessageId: MessageId, limit: Int? = nil) async throws {
+        try await loadReplies(before: nil, of: parentMessageId, limit: limit)
+    }
+    
+    /// Loads more newer replies and updates ``MessageState/replies``.
+    ///
+    /// - Parameters:
+    ///   - parentMessageId: The parent message id which has replies.
+    ///   - limit: The limit for the page size. The default limit is 25.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func loadNewerReplies(of parentMessageId: MessageId, limit: Int? = nil) async throws {
+        try await loadReplies(after: nil, of: parentMessageId, limit: limit)
     }
     
     // MARK: - Message State Observing
@@ -1078,7 +1103,7 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded watchers.
-    @discardableResult public func loadNextWatchers(limit: Int? = nil) async throws -> [ChatUser] {
+    @discardableResult public func loadMoreWatchers(limit: Int? = nil) async throws -> [ChatUser] {
         let count = await state.watchers.count
         let pagination = Pagination(pageSize: limit ?? .channelWatchersPageSize, offset: count)
         return try await loadWatchers(with: pagination)

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -71,6 +71,8 @@ public class Chat {
     
     /// Fetches the state from the server and updates the local store.
     ///
+    /// - Important: Loaded messages in ``ChatState.messages`` is reset to a batch of most recent messages.
+    ///
     /// - Parameter watch: True, if server-side events should be enabled in addition
     /// to fetching state from the server. See ``watch()`` for more information
     ///
@@ -373,7 +375,7 @@ public class Chat {
     
     /// Loads messages for the specified pagination parameters and updates ``ChatState/messages``.
     ///
-    /// - Important: Loading messages for the pagination with parameter nil resets ``ChatState/messages``. Example `chat.loadMessages(with: MessagesPagination(pageSize: 30, parameter: nil))`.
+    /// - Important: Calling ``get(watch:)`` resets ``ChatState/messages``.
     ///
     /// - Parameters:
     ///   - message: The parent message id which has replies.

--- a/Sources/StreamChat/StateLayer/MemberList.swift
+++ b/Sources/StreamChat/StateLayer/MemberList.swift
@@ -45,7 +45,7 @@ public final class MemberList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of channel members.
-    @discardableResult public func loadNextMembers(limit: Int? = nil) async throws -> [ChatChannelMember] {
+    @discardableResult public func loadMoreMembers(limit: Int? = nil) async throws -> [ChatChannelMember] {
         let pageSize = limit ?? Int.channelMembersPageSize
         let pagination = Pagination(pageSize: pageSize, offset: await state.members.count)
         return try await loadMembers(with: pagination)

--- a/Sources/StreamChat/StateLayer/MessageSearch.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearch.swift
@@ -69,7 +69,7 @@ public class MessageSearch {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: A next page of chat messages matching to the last query.
-    @discardableResult public func loadNextMessages(limit: Int? = nil) async throws -> [ChatMessage] {
+    @discardableResult public func loadMoreMessages(limit: Int? = nil) async throws -> [ChatMessage] {
         guard let query = await state.query else { throw ClientError("Call search() before calling for next page") }
         let limit = (limit ?? query.pagination?.pageSize) ?? Int.messagesPageSize
         let pagination: Pagination = await {

--- a/Sources/StreamChat/StateLayer/UserList.swift
+++ b/Sources/StreamChat/StateLayer/UserList.swift
@@ -45,7 +45,7 @@ public final class UserList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
-    @discardableResult public func loadNextUsers(limit: Int? = nil) async throws -> [ChatUser] {
+    @discardableResult public func loadMoreUsers(limit: Int? = nil) async throws -> [ChatUser] {
         let state = await self.state
         let limit = (limit ?? state.query.pagination?.pageSize) ?? Int.usersPageSize
         let offset = await state.users.count

--- a/Sources/StreamChat/StateLayer/UserSearch.swift
+++ b/Sources/StreamChat/StateLayer/UserSearch.swift
@@ -50,7 +50,7 @@ public class UserSearch {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
-    @discardableResult public func loadNextUsers(limit: Int? = nil) async throws -> [ChatUser] {
+    @discardableResult public func loadMoreUsers(limit: Int? = nil) async throws -> [ChatUser] {
         guard let query = await state.query else { throw ClientError("Call search() before calling for next page") }
         let limit = (limit ?? query.pagination?.pageSize) ?? .usersPageSize
         let offset = await state.users.count

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -925,11 +925,6 @@ extension ChannelUpdater {
         return try await messageRepository.messages(from: fromDate, to: toDate, in: cid)
     }
     
-    func loadMessagesFirstPage(with channelQuery: ChannelQuery) async throws {
-        let pagination = MessagesPagination(pageSize: channelQuery.pagination?.pageSize ?? .messagesPageSize)
-        try await update(channelQuery: channelQuery.withPagination(pagination))
-    }
-    
     func loadMessages(before messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingPreviousMessages else { return }
         guard !paginationState.hasLoadedAllPreviousMessages else { return }

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -915,19 +915,14 @@ extension MessageUpdater {
     
     // MARK: -
     
-    func loadReplies(of messageId: MessageId, pagination: MessagesPagination, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws -> [ChatMessage] {
-        let payload = try await loadReplies(cid: cid, messageId: messageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
+    func loadReplies(for parentMessageId: MessageId, pagination: MessagesPagination, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws -> [ChatMessage] {
+        let payload = try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
         guard let fromDate = payload.messages.first?.createdAt else { return [] }
         guard let toDate = payload.messages.last?.createdAt else { return [] }
-        return try await repository.replies(from: fromDate, to: toDate, in: messageId)
+        return try await repository.replies(from: fromDate, to: toDate, in: parentMessageId)
     }
     
-    func loadRepliesFirstPage(of messageId: MessageId, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
-        let pageSize = limit ?? .messagesPageSize
-        try await loadReplies(cid: cid, messageId: messageId, pagination: MessagesPagination(pageSize: pageSize), paginationStateHandler: paginationStateHandler)
-    }
-    
-    func loadReplies(of messageId: MessageId, before replyId: MessageId?, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
+    func loadReplies(for parentMessageId: MessageId, before replyId: MessageId?, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
         guard !paginationStateHandler.state.hasLoadedAllPreviousMessages else { return }
         guard !paginationStateHandler.state.isLoadingPreviousMessages else { return }
         guard let replyId = replyId ?? paginationStateHandler.state.oldestFetchedMessage?.id else {
@@ -935,10 +930,10 @@ extension MessageUpdater {
         }
         let pageSize = limit ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: pageSize, parameter: .lessThan(replyId))
-        try await loadReplies(cid: cid, messageId: messageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
+        try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
     }
     
-    func loadReplies(of messageId: MessageId, after replyId: MessageId?, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
+    func loadReplies(for parentMessageId: MessageId, after replyId: MessageId?, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
         guard !paginationStateHandler.state.hasLoadedAllNextMessages else { return }
         guard !paginationStateHandler.state.isLoadingNextMessages else { return }
         guard let replyId = replyId ?? paginationStateHandler.state.newestFetchedMessage?.id else {
@@ -946,13 +941,13 @@ extension MessageUpdater {
         }
         let pageSize = limit ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: pageSize, parameter: .greaterThan(replyId))
-        try await loadReplies(cid: cid, messageId: messageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
+        try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
     }
     
-    func loadReplies(of messageId: MessageId, around replyId: MessageId, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
+    func loadReplies(for parentMessageId: MessageId, around replyId: MessageId, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
         guard !paginationStateHandler.state.isLoadingMiddleMessages else { return }
         let pageSize = limit ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: pageSize, parameter: .around(replyId))
-        try await loadReplies(cid: cid, messageId: messageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
+        try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
     }
 }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/ChannelList_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/ChannelList_Mock.swift
@@ -37,7 +37,7 @@ public class ChannelList_Mock: ChannelList {
     }
     
     public var loadNextChannelsIsCalled = false
-    public override func loadNextChannels(limit: Int? = nil) async throws -> [ChatChannel] {
+    public override func loadMoreChannels(limit: Int? = nil) async throws -> [ChatChannel] {
         loadNextChannelsIsCalled = true
         return await MainActor.run {
             Array(state.channels)

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/Chat_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/Chat_Mock.swift
@@ -64,8 +64,6 @@ public class Chat_Mock: Chat {
         createNewMessageCallCount += 1
         return ChatMessage.mock()
     }
-
-    public override func loadMessagesFirstPage() async throws {}
     
     public var loadPageAroundMessageIdCallCount = 0
     public override func loadMessages(around messageId: MessageId, limit: Int? = nil) async throws {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/MessageSearch_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/MessageSearch_Mock.swift
@@ -22,7 +22,7 @@ public class MessageSearch_Mock: MessageSearch {
     }
 
     var loadNextMessagesCallCount = 0
-    public override func loadNextMessages(limit: Int? = nil) async throws -> [ChatMessage] {
+    public override func loadMoreMessages(limit: Int? = nil) async throws -> [ChatMessage] {
         loadNextMessagesCallCount += 1
         return await Array(state.messages)
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/UserSearch_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/UserSearch_Mock.swift
@@ -18,7 +18,7 @@ public class UserSearch_Mock: UserSearch {
         self.state.users = StreamCollection(users)
     }
     
-    public override func loadNextUsers(limit: Int? = nil) async throws -> [ChatUser] {
+    public override func loadMoreUsers(limit: Int? = nil) async throws -> [ChatUser] {
         await Array(state.users)
     }
 

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -163,7 +163,7 @@ final class Chat_Tests: XCTestCase {
         // Load the first page which should reset the state
         let channelPayload = makeChannelPayload(messageCount: 3, createdAtOffset: 5)
         env.client.mockAPIClient.test_mockResponseResult(.success(channelPayload))
-        try await chat.loadMessagesFirstPage()
+        try await chat.loadMessages(with: MessagesPagination(pageSize: 3, parameter: nil))
         
         await MainActor.run {
             XCTAssertEqual(channelPayload.messages.map(\.id), chat.state.messages.map(\.id))
@@ -176,7 +176,7 @@ final class Chat_Tests: XCTestCase {
         }
     }
     
-    func test_loadPreviousMessages_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+    func test_loadOlderMessages_whenAPIRequestSucceeds_thenStateUpdates() async throws {
         // DB has some messages loaded
         let initialChannelPayload = makeChannelPayload(messageCount: 5, createdAtOffset: 5)
         try await env.client.mockDatabaseContainer.write { session in
@@ -188,7 +188,7 @@ final class Chat_Tests: XCTestCase {
         // Load older
         let channelPayload = makeChannelPayload(messageCount: 5, createdAtOffset: 0)
         env.client.mockAPIClient.test_mockResponseResult(.success(channelPayload))
-        try await chat.loadPreviousMessages()
+        try await chat.loadOlderMessages()
         
         let expectedIds = (channelPayload.messages + initialChannelPayload.messages).map(\.id)
         await MainActor.run {
@@ -202,7 +202,7 @@ final class Chat_Tests: XCTestCase {
         }
     }
     
-    func test_loadNextMessages_whenAPIRequestSucceeds_thenStateUpdates() async throws {
+    func test_loadNewerMessages_whenAPIRequestSucceeds_thenStateUpdates() async throws {
         await setUpChat(usesMockedChannelUpdater: false)
         
         // Reset has loaded state since we always load newest messages
@@ -213,7 +213,7 @@ final class Chat_Tests: XCTestCase {
         // Load newer
         let channelPayload = makeChannelPayload(messageCount: 3, createdAtOffset: 5)
         env.client.mockAPIClient.test_mockResponseResult(.success(channelPayload))
-        try await chat.loadNextMessages()
+        try await chat.loadNewerMessages()
         
         let expectedIds = (initialChannelPayload.messages + channelPayload.messages).map(\.id)
         await MainActor.run {
@@ -1335,12 +1335,12 @@ final class Chat_Tests: XCTestCase {
     }
     
     // TODO: not done
-    public func test_loadNextWatchersAction_whenAPIRequestSucceeds_thenLoadNextWatchersActionSucceeds() async throws {
+    public func test_loadMoreWatchersAction_whenAPIRequestSucceeds_thenLoadNextWatchersActionSucceeds() async throws {
         // loadNextWatchers(limit: Int? = nil)
     }
     
     // TODO: not done
-    public func test_loadNextWatchersAction_whenAPIRequestFails_thenLoadNextWatchersActionSucceeds() async throws {
+    public func test_loadMoreWatchersAction_whenAPIRequestFails_thenLoadNextWatchersActionSucceeds() async throws {
         // loadNextWatchers(limit: Int? = nil)
     }
     

--- a/Tests/StreamChatTests/StateLayer/MemberList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MemberList_Tests.swift
@@ -55,7 +55,7 @@ final class MemberList_Tests: XCTestCase {
         await XCTAssertEqual(apiResult.members.map(\.user?.id), memberList.state.members.map(\.id))
     }
     
-    func test_loadNextMembers_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+    func test_loadMoreMembers_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
         try await createChannel()
         try await setUpMemberList(usesMockedUpdater: false)
         
@@ -70,7 +70,7 @@ final class MemberList_Tests: XCTestCase {
         
         let apiResult = makeMemberListPayload(count: 3, offset: 5)
         env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
-        let result = try await memberList.loadNextMembers(limit: 3)
+        let result = try await memberList.loadMoreMembers(limit: 3)
         XCTAssertEqual(apiResult.members.map(\.user?.id), result.map(\.id))
         let allExpectedIds = (initialPayload.members + apiResult.members).map(\.user?.id)
         await XCTAssertEqual(allExpectedIds, memberList.state.members.map(\.id))

--- a/Tests/StreamChatTests/StateLayer/MessageSearch_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MessageSearch_Tests.swift
@@ -74,7 +74,7 @@ final class MessageSearch_Tests: XCTestCase {
     
     // MARK: - Results Pagination
     
-    func test_loadNextMessages_whenMoreResultsAreAvailable_thenResultsAndStateAreUpdated() async throws {
+    func test_loadMoreMessages_whenMoreResultsAreAvailable_thenResultsAndStateAreUpdated() async throws {
         await setUpMessageSearch(usesMockedMessageUpdater: false)
         let apiResponse = makeMatchingResponse(messageCount: 25, createdAtOffset: 0, next: "A")
         env.client.mockAuthenticationRepository.mockedCurrentUserId = currentUserId
@@ -84,7 +84,7 @@ final class MessageSearch_Tests: XCTestCase {
         
         let apiResponse2 = makeMatchingResponse(messageCount: 25, createdAtOffset: 25, next: "B")
         env.client.mockAPIClient.test_mockResponseResult(.success(apiResponse2))
-        let nextMessagesResult = try await messageSearch.loadNextMessages()
+        let nextMessagesResult = try await messageSearch.loadMoreMessages()
         await MainActor.run {
             XCTAssertEqual(messageSearch.state.nextPageCursor, "B")
             XCTAssertEqual(apiResponse2.results.map(\.message.id), nextMessagesResult.map(\.id))

--- a/Tests/StreamChatTests/StateLayer/UserList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/UserList_Tests.swift
@@ -47,7 +47,7 @@ final class UserList_Tests: XCTestCase {
         await XCTAssertEqual(apiResult.users.map(\.id), userList.state.users.map(\.id))
     }
     
-    func test_loadNextUsers_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+    func test_loadMoreUsers_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
         await setUpUserList(usesMockedUpdater: false)
         
         let initialPayload = makeUserListPayload(count: 5, offset: 0)
@@ -57,7 +57,7 @@ final class UserList_Tests: XCTestCase {
         
         let apiResult = makeUserListPayload(count: 3, offset: 5)
         env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
-        let result = try await userList.loadNextUsers(limit: 3)
+        let result = try await userList.loadMoreUsers(limit: 3)
         XCTAssertEqual(apiResult.users.map(\.id), result.map(\.id))
         let allExpectedIds = (initialPayload.users + apiResult.users).map(\.id)
         await XCTAssertEqual(allExpectedIds, userList.state.users.map(\.id))

--- a/Tests/StreamChatTests/StateLayer/UserSearch_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/UserSearch_Tests.swift
@@ -111,14 +111,14 @@ final class UserSearch_Tests: XCTestCase {
     
     // MARK: - Results Pagination
     
-    func test_loadNextUsers_whenMoreResultsAreAvailable_thenResultsAndStateAreUpdated() async throws {
+    func test_loadMoreUsers_whenMoreResultsAreAvailable_thenResultsAndStateAreUpdated() async throws {
         let fetchResult1 = makeUsers(name: "name", count: Int.usersPageSize, offset: 0)
         env.userListUpdaterMock.fetch_completion_result = .success(fetchResult1)
         try await userSearch.search(term: "name")
         
         let fetchResult2 = makeUsers(name: "name", count: 5, offset: Int.usersPageSize)
         env.userListUpdaterMock.fetch_completion_result = .success(fetchResult2)
-        try await userSearch.loadNextUsers(limit: 10)
+        try await userSearch.loadMoreUsers(limit: 10)
         
         let expectedIds = (fetchResult1.users + fetchResult2.users).map(\.id)
         await XCTAssertEqual(expectedIds, userSearch.state.users.map(\.id))


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Rename pagination methods based on what we discussed:

- Use `more` instead of `next`
- Use `older` and `newer` instead of `previous` and `next` for messages

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)