### PR TITLE
[ChatStateLayer] Add get() to ChannelList, MemberList, and UserList with unit-tests co…

### DIFF
--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -38,11 +38,21 @@ public class ChannelList {
     /// An observable object representing the current state of the channel list.
     @MainActor public lazy var state: ChannelListState = stateBuilder.build()
     
+    /// Fetches the most recent state from the server and updates the local store.
+    ///
+    /// - Important: Loaded channels in ``ChannelListState/channels`` are reset.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func get() async throws {
+        let pagination = Pagination(pageSize: .channelsPageSize)
+        try await loadChannels(with: pagination)
+    }
+    
     // MARK: - Channel List Pagination
     
     /// Loads channels for the specified pagination parameters and updates ``ChannelListState/channels``.
     ///
-    /// - Important: If pagination offset is 0 and cursor is nil, the list of loaded channels is reset.
+    /// - Important: If pagination offset is 0 and cursor is nil, then loaded channels are reset.
     ///
     /// - Parameter pagination: The pagination configuration which includes limit and cursor.
     ///

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -69,9 +69,12 @@ public class Chat {
     /// An observable object representing the current state of the channel.
     @MainActor public lazy var state: ChatState = stateBuilder.build()
     
-    /// Fetches the state from the server and updates the local store.
+    /// Fetches the most recent state from the server and updates the local store.
     ///
-    /// - Important: Loaded messages in ``ChatState.messages`` is reset to a batch of most recent messages.
+    /// - Important: Loaded messages in ``ChatState.messages`` are reset.
+    /// - Note: When watching is enabled for the channel, then channel updates are delivered
+    ///  through websocket events and there is no need to call ``get(watch:)`` for fetching
+    ///  the latest state multiple times during the app's lifetime.
     ///
     /// - Parameter watch: True, if server-side events should be enabled in addition
     /// to fetching state from the server. See ``watch()`` for more information
@@ -375,6 +378,7 @@ public class Chat {
     
     /// Loads messages for the specified pagination parameters and updates ``ChatState/messages``.
     ///
+    /// - Important: If `pagination.parameter` is nil, then loaded messages are reset.
     /// - Important: Calling ``get(watch:)`` resets ``ChatState/messages``.
     ///
     /// - Parameters:

--- a/Sources/StreamChat/StateLayer/MemberList.swift
+++ b/Sources/StreamChat/StateLayer/MemberList.swift
@@ -28,7 +28,19 @@ public final class MemberList {
     /// An observable object representing the current state of the member list.
     @MainActor public lazy var state: MemberListState = stateBuilder.build()
     
+    /// Fetches the most recent state from the server and updates the local store.
+    ///
+    /// - Important: Loaded members in ``MemberListState/members`` are reset.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func get() async throws {
+        let pagination = Pagination(pageSize: .channelMembersPageSize)
+        try await loadMembers(with: pagination)
+    }
+    
     /// Loads channel members for the specified pagination parameters and updates ``MemberListState/members``.
+    ///
+    /// - Important: If pagination offset is 0 and cursor is nil, then loaded members are reset.
     ///
     /// - Parameter pagination: The pagination configuration which includes a limit and an offset or a cursor.
     ///

--- a/Sources/StreamChat/StateLayer/UserList.swift
+++ b/Sources/StreamChat/StateLayer/UserList.swift
@@ -26,9 +26,19 @@ public final class UserList {
     /// An observable object representing the current state of the users list.
     @MainActor public lazy var state: UserListState = stateBuilder.build()
     
-    // MARK: - User List Pagination
+    /// Fetches the most recent state from the server and updates the local store.
+    ///
+    /// - Important: Loaded users in ``UserListState/users`` are reset.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func get() async throws {
+        let pagination = Pagination(pageSize: .usersPageSize)
+        try await loadUsers(with: pagination)
+    }
     
     /// Loads users for the specified pagination parameters and updates ``UserListState/users``.
+    ///
+    /// - Important: If pagination offset is 0 and cursor is nil, then loaded users are reset.
     ///
     /// - Parameter pagination: The pagination configuration which includes a limit and an offset or a cursor.
     ///

--- a/Sources/StreamChat/Workers/UserListUpdater.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater.swift
@@ -71,7 +71,7 @@ enum UpdatePolicy {
 extension UserListUpdater {
     @discardableResult func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge) async throws -> [ChatUser] {
         try await withCheckedThrowingContinuation { continuation in
-            update(userListQuery: userListQuery) { result in
+            update(userListQuery: userListQuery, policy: policy) { result in
                 continuation.resume(with: result)
             }
         }
@@ -87,7 +87,8 @@ extension UserListUpdater {
     }
     
     func loadUsers(_ userListQuery: UserListQuery, pagination: Pagination) async throws -> [ChatUser] {
-        try await update(userListQuery: userListQuery.withPagination(pagination), policy: .merge)
+        let policy: UpdatePolicy = pagination.offset == 0 && pagination.cursor == nil ? .replace : .merge
+        return try await update(userListQuery: userListQuery.withPagination(pagination), policy: policy)
     }
     
     func loadNextUsers(_ userListQuery: UserListQuery, limit: Int, offset: Int) async throws -> [ChatUser] {


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add `get()` to `ChannelList`, `MemberList`, and `UserList`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)