### PR TITLE
[ChatState] Reset watchers and members in Chat when triggering get()

### DIFF
--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -71,7 +71,8 @@ public class Chat {
     
     /// Fetches the most recent state from the server and updates the local store.
     ///
-    /// - Important: Loaded messages in ``ChatState.messages`` are reset.
+    /// - Important: Resets ``ChatState/messages``, ``ChatState/members``, and ``ChatState/watchers`` in ``ChatState``.
+    ///
     /// - Note: When watching is enabled for the channel, then channel updates are delivered
     ///  through websocket events and there is no need to call ``get(watch:)`` for fetching
     ///  the latest state multiple times during the app's lifetime.
@@ -82,7 +83,8 @@ public class Chat {
     /// - Throws: An error while communicating with the Stream API.
     public func get(watch: Bool) async throws {
         let query = await state.channelQuery.withOptions(forWatching: watch)
-        let payload = try await channelUpdater.update(channelQuery: query)
+        let payload = try await channelUpdater.update(channelQuery: query, memberSorting: state.memberSorting)
+        // cid is retrieved from the server when we are creating new channels or there is no local state present
         guard query.cid != payload.channel.cid else { return }
         await state.setChannelId(payload.channel.cid)
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -271,11 +271,11 @@ final class ChannelUpdater_Mock: ChannelUpdater {
     override var paginationState: MessagesPaginationState {
         mockPaginationState
     }
-
     override func update(
         channelQuery: ChannelQuery,
         isInRecoveryMode: Bool,
         onChannelCreated: ((ChannelId) -> Void)? = nil,
+        actions: ChannelUpdateActions? = nil,
         completion: ((Result<ChannelPayload, Error>) -> Void)? = nil
     ) {
         update_channelQuery = channelQuery


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

After we added `get()` to Chat which resets `ChatState.messages` I realised that since we have `ChatState.members` and `ChatState.watchers` then it should also reset these as well. Otherwise users load 10000 members and there is no way to reset the whole state.

### 📝 Summary

* `ChatState.members` is internally driven by `MemberList`, therefore I need to make sure we associate channel payload members with `ChannelMemberListQuery`. 
* Watchers needs to be reset before channel payload is saved

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)