### PR TITLE
[ChatStateLayer] Tests for waitForAPIRequest methods

### DIFF
--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -263,9 +263,9 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
             skipEnrichUrl: skipEnrichUrl,
             attachments: attachments,
             extraData: extraData
-        ) { error in
+        ) { result in
             self.callback {
-                completion?(error)
+                completion?(result.error)
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -282,6 +282,7 @@ public class Chat {
     /// - Parameter messageId: The id of the message to resend.
     ///
     /// - Throws: An error while sending a message to the Stream API.
+    /// - Returns: An instance of `ChatMessage` which was resent.
     @discardableResult public func resendMessage(_ messageId: MessageId) async throws -> ChatMessage {
         let messageSender = try client.backgroundWorker(of: MessageSender.self)
         try await messageUpdater.resendMessage(with: messageId)
@@ -293,7 +294,7 @@ public class Chat {
     /// - Parameter attachment: The id of the attachment.
     ///
     /// - Throws: An error while sending a message to the Stream API.
-    /// - Returns: Information about the uploaded attachment with remote and thumbnail URLs.
+    /// - Returns: The uploaded attachment with additional information like remote and thumbnail URLs.
     @discardableResult public func resendAttachment(_ attachment: AttachmentId) async throws -> UploadedAttachment {
         let attachmentQueueUploader = try client.backgroundWorker(of: AttachmentQueueUploader.self)
         try await messageUpdater.resendAttachment(with: attachment)
@@ -370,6 +371,7 @@ public class Chat {
     ///   - skipEnrichURL: If true, the url preview won't be attached to the message.
     ///
     /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An instance of `ChatMessage` which was updated.
     @discardableResult public func updateMessage(
         _ messageId: MessageId,
         text: String,
@@ -570,10 +572,11 @@ public class Chat {
     ///   - pinning: The pinning expiration information. Supports an infinite expiration, setting a date, or the amount of time a message is pinned.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func pinMessage(_ messageId: MessageId, pinning: MessagePinning) async throws {
+    /// - Returns: An instance of `ChatMessage` which was pinned.
+    @discardableResult public func pinMessage(_ messageId: MessageId, pinning: MessagePinning) async throws -> ChatMessage {
         let messageEditor = try client.backgroundWorker(of: MessageEditor.self)
         try await messageUpdater.pinMessage(messageId: messageId, pinning: pinning)
-        try await messageEditor.waitForAPIRequest(messageId: messageId)
+        return try await messageEditor.waitForAPIRequest(messageId: messageId)
     }
     
     /// Removes the message from the channel's pinned messages.
@@ -583,10 +586,11 @@ public class Chat {
     /// - Parameter messageId: The id of the message to unpin.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func unpinMessage(_ messageId: MessageId) async throws {
+    /// - Returns: An instance of `ChatMessage` which was unpinned.
+    @discardableResult public func unpinMessage(_ messageId: MessageId) async throws -> ChatMessage {
         let messageEditor = try client.backgroundWorker(of: MessageEditor.self)
         try await messageUpdater.unpinMessage(messageId: messageId)
-        try await messageEditor.waitForAPIRequest(messageId: messageId)
+        return try await messageEditor.waitForAPIRequest(messageId: messageId)
     }
     
     /// Loads pinned messages for the specified pagination options, sorting order, and limit.

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -283,9 +283,9 @@ public class Chat {
     ///
     /// - Throws: An error while sending a message to the Stream API.
     public func resendMessage(_ messageId: MessageId) async throws {
-        let messageEditor = try client.backgroundWorker(of: MessageEditor.self)
+        let messageSender = try client.backgroundWorker(of: MessageSender.self)
         try await messageUpdater.resendMessage(with: messageId)
-        try await messageEditor.waitForAPIRequest(messageId: messageId)
+        _ = try await messageSender.waitForAPIRequest(messageId: messageId)
     }
     
     /// Resends a failed attachment.

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -282,10 +282,10 @@ public class Chat {
     /// - Parameter messageId: The id of the message to resend.
     ///
     /// - Throws: An error while sending a message to the Stream API.
-    public func resendMessage(_ messageId: MessageId) async throws {
+    @discardableResult public func resendMessage(_ messageId: MessageId) async throws -> ChatMessage {
         let messageSender = try client.backgroundWorker(of: MessageSender.self)
         try await messageUpdater.resendMessage(with: messageId)
-        _ = try await messageSender.waitForAPIRequest(messageId: messageId)
+        return try await messageSender.waitForAPIRequest(messageId: messageId)
     }
     
     /// Resends a failed attachment.

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -293,10 +293,11 @@ public class Chat {
     /// - Parameter attachment: The id of the attachment.
     ///
     /// - Throws: An error while sending a message to the Stream API.
-    public func resendAttachment(_ attachment: AttachmentId) async throws {
+    /// - Returns: Information about the uploaded attachment with remote and thumbnail URLs.
+    @discardableResult public func resendAttachment(_ attachment: AttachmentId) async throws -> UploadedAttachment {
         let attachmentQueueUploader = try client.backgroundWorker(of: AttachmentQueueUploader.self)
         try await messageUpdater.resendAttachment(with: attachment)
-        try await attachmentQueueUploader.waitForAPIRequest(attachmentId: attachment)
+        return try await attachmentQueueUploader.waitForAPIRequest(attachmentId: attachment)
     }
     
     /// Sends a message to channel.

--- a/Sources/StreamChat/Workers/Background/MessageEditor.swift
+++ b/Sources/StreamChat/Workers/Background/MessageEditor.swift
@@ -75,30 +75,30 @@ class MessageEditor: Worker {
                 let dto = session.message(id: messageId),
                 dto.localMessageState == .pendingSync
             else {
-                self?.removeMessageIDAndContinue(messageId, error: ClientError.MessageDoesNotExist(messageId: messageId))
+                self?.removeMessageIDAndContinue(messageId, result: .failure(ClientError.MessageDoesNotExist(messageId: messageId)))
                 return
             }
 
             let requestBody = dto.asRequestBody() as MessageRequestBody
-            messageRepository?.updateMessage(withID: messageId, localState: .syncing) {
+            messageRepository?.updateMessage(withID: messageId, localState: .syncing) { _ in
                 self?.apiClient.request(endpoint: .editMessage(payload: requestBody, skipEnrichUrl: dto.skipEnrichUrl)) { result in
                     let newMessageState: LocalMessageState? = result.error == nil ? nil : .syncingFailed
 
                     messageRepository?.updateMessage(
                         withID: messageId,
                         localState: newMessageState
-                    ) {
-                        self?.removeMessageIDAndContinue(messageId, error: result.error)
+                    ) { updateResult in
+                        self?.removeMessageIDAndContinue(messageId, result: updateResult)
                     }
                 }
             }
         }
     }
 
-    private func removeMessageIDAndContinue(_ messageId: MessageId, error: Error?) {
+    private func removeMessageIDAndContinue(_ messageId: MessageId, result: Result<ChatMessage, Error>) {
         _pendingMessageIDs.mutate { $0.remove(messageId) }
         if #available(iOS 13.0, *) {
-            notifyAPIRequestFinished(for: messageId, error: error)
+            notifyAPIRequestFinished(for: messageId, result: result)
         }
         processNextMessage()
     }
@@ -121,26 +121,22 @@ private extension Array where Element == ListChange<MessageDTO> {
 
 @available(iOS 13.0, *)
 extension MessageEditor {
-    func waitForAPIRequest(messageId: MessageId) async throws {
+    func waitForAPIRequest(messageId: MessageId) async throws -> ChatMessage {
         try await withCheckedThrowingContinuation { continuation in
             registerContinuation(forMessage: messageId, continuation: continuation)
         }
     }
     
-    private func registerContinuation(forMessage messageId: MessageId, continuation: CheckedContinuation<Void, Error>) {
+    private func registerContinuation(forMessage messageId: MessageId, continuation: CheckedContinuation<ChatMessage, Error>) {
         continuationsQueue.async {
             self.continuations[messageId] = continuation
         }
     }
     
-    private func notifyAPIRequestFinished(for messageId: MessageId, error: Error?) {
+    private func notifyAPIRequestFinished(for messageId: MessageId, result: Result<ChatMessage, Error>) {
         continuationsQueue.async {
-            guard let continuation = self.continuations.removeValue(forKey: messageId) as? CheckedContinuation<Void, Error> else { return }
-            if let error {
-                continuation.resume(throwing: error)
-            } else {
-                continuation.resume(returning: ())
-            }
+            guard let continuation = self.continuations.removeValue(forKey: messageId) as? CheckedContinuation<ChatMessage, Error> else { return }
+            continuation.resume(with: result)
         }
     }
 }

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -104,15 +104,16 @@ class MessageUpdater: Worker {
     ///   - skipEnrichUrl: If true, the url preview won't be attached to the message.
     ///   - attachments: An array of the attachments for the message.
     ///   - extraData: Extra Data for the message.
-    ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
+    ///   - completion: The completion handler with the local updated message.
     func editMessage(
         messageId: MessageId,
         text: String,
         skipEnrichUrl: Bool,
         attachments: [AnyAttachmentPayload] = [],
         extraData: [String: RawJSON]? = nil,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<ChatMessage, Error>) -> Void)? = nil
     ) {
+        var message: ChatMessage?
         database.write({ session in
             let messageDTO = try session.messageEditableByCurrentUser(messageId)
 
@@ -148,6 +149,7 @@ class MessageUpdater: Worker {
 
             if messageDTO.isBounced {
                 try updateMessage(localState: .pendingSend)
+                message = try messageDTO.asModel()
                 return
             }
 
@@ -162,8 +164,15 @@ class MessageUpdater: Worker {
                     reason: "message is in `\(messageDTO.localMessageState!)` state"
                 )
             }
-        }, completion: {
-            completion?($0)
+            message = try messageDTO.asModel()
+        }, completion: { error in
+            if let error {
+                completion?(.failure(error))
+            } else if let message {
+                completion?(.success(message))
+            } else {
+                completion?(.failure(ClientError.MessageDoesNotExist(messageId: messageId)))
+            }
         })
     }
 
@@ -825,10 +834,10 @@ extension MessageUpdater {
         }
     }
     
-    func editMessage(messageId: MessageId, text: String, skipEnrichUrl: Bool, attachments: [AnyAttachmentPayload] = [], extraData: [String: RawJSON]? = nil) async throws {
+    func editMessage(messageId: MessageId, text: String, skipEnrichUrl: Bool, attachments: [AnyAttachmentPayload] = [], extraData: [String: RawJSON]? = nil) async throws -> ChatMessage {
         try await withCheckedThrowingContinuation { continuation in
-            editMessage(messageId: messageId, text: text, skipEnrichUrl: skipEnrichUrl, attachments: attachments, extraData: extraData) { error in
-                continuation.resume(with: error)
+            editMessage(messageId: messageId, text: text, skipEnrichUrl: skipEnrichUrl, attachments: attachments, extraData: extraData) { result in
+                continuation.resume(with: result)
             }
         }
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -17,6 +17,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
     var receivedGetMessageStore: Bool?
     var saveSuccessfullyDeletedMessageError: Error?
     var updatedMessageLocalState: LocalMessageState?
+    var updateMessageResult: Result<ChatMessage, Error>?
 
     override func sendMessage(
         with messageId: MessageId,
@@ -62,11 +63,11 @@ final class MessageRepository_Mock: MessageRepository, Spy {
     override func updateMessage(
         withID id: MessageId,
         localState: LocalMessageState?,
-        completion: @escaping () -> Void
+        completion: @escaping (Result<ChatMessage, any Error>) -> Void
     ) {
         record()
         updatedMessageLocalState = localState
-        completion()
+        updateMessageResult.map { completion($0) }
     }
 
     func clear() {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -63,7 +63,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
     override func updateMessage(
         withID id: MessageId,
         localState: LocalMessageState?,
-        completion: @escaping (Result<ChatMessage, any Error>) -> Void
+        completion: @escaping (Result<ChatMessage, Error>) -> Void
     ) {
         record()
         updatedMessageLocalState = localState

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -20,7 +20,7 @@ final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var editMessage_text: String?
     @Atomic var editMessage_skipEnrichUrl: Bool?
     @Atomic var editMessage_attachments: [AnyAttachmentPayload]?
-    @Atomic var editMessage_completion: ((Error?) -> Void)?
+    @Atomic var editMessage_completion: ((Result<ChatMessage, Error>) -> Void)?
     @Atomic var editMessage_extraData: [String: RawJSON]?
 
     @Atomic var createNewReply_cid: ChannelId?
@@ -211,14 +211,14 @@ final class MessageUpdater_Mock: MessageUpdater {
         deleteMessage_completion = completion
         deleteMessage_completion_result?.invoke(with: completion)
     }
-
+    
     override func editMessage(
         messageId: MessageId,
         text: String,
         skipEnrichUrl: Bool,
         attachments: [AnyAttachmentPayload] = [],
         extraData: [String: RawJSON]? = nil,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<ChatMessage, Error>) -> Void)? = nil
     ) {
         editMessage_messageId = messageId
         editMessage_text = text

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -35,6 +35,7 @@ final class APIClient_Spy: APIClient, Spy {
     @Atomic var uploadFile_attachment: AnyChatMessageAttachment?
     @Atomic var uploadFile_progress: ((Double) -> Void)?
     @Atomic var uploadFile_completion: ((Result<UploadedAttachment, Error>) -> Void)?
+    @Atomic var uploadFile_completion_result: Result<UploadedAttachment, Error>?
     @Atomic var uploadFile_callCount = 0
 
     @Atomic var init_sessionConfiguration: URLSessionConfiguration
@@ -62,6 +63,7 @@ final class APIClient_Spy: APIClient, Spy {
         uploadFile_attachment = nil
         uploadFile_progress = nil
         uploadFile_completion = nil
+        uploadFile_completion_result = nil
 
         flushRequestsQueue()
     }
@@ -151,6 +153,7 @@ final class APIClient_Spy: APIClient, Spy {
         uploadFile_attachment = attachment
         uploadFile_progress = progress
         uploadFile_completion = completion
+        uploadFile_completion_result?.invoke(with: completion)
         uploadFile_callCount += 1
         uploadRequest_expectation.fulfill()
     }

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -902,7 +902,7 @@ final class MessageController_Tests: XCTestCase {
 
         // Simulate network response with the error
         let networkError = TestError()
-        env.messageUpdater.editMessage_completion?(networkError)
+        env.messageUpdater.editMessage_completion?(.failure(networkError))
 
         // Assert error is propagated
         AssertAsync.willBeEqual(completionError as? TestError, networkError)
@@ -925,7 +925,7 @@ final class MessageController_Tests: XCTestCase {
         controller = nil
 
         // Simulate successful network response
-        env.messageUpdater.editMessage_completion?(nil)
+        env.messageUpdater.editMessage_completion?(.success(.mock()))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater.editMessage_completion = nil
 

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -445,7 +445,7 @@ final class MessageRepositoryTests: XCTestCase {
 
     private func runUpdateMessageLocalStateAndWait(id: MessageId, to state: LocalMessageState?) {
         let expectation = self.expectation(description: "Mark Message completes")
-        repository.updateMessage(withID: id, localState: state) {
+        repository.updateMessage(withID: id, localState: state) { _ in
             expectation.fulfill()
         }
         waitForExpectations(timeout: defaultTimeout, handler: nil)

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -211,10 +211,8 @@ final class Chat_Tests: XCTestCase {
             )
         )
         env.client.mockAPIClient.test_mockResponseResult(.success(apiResponse))
-        try await chat.resendMessage(messageId)
-        let message = try await MainActor.run {
-            try XCTUnwrap(chat.localMessage(for: messageId))
-        }
+        let message = try await chat.resendMessage(messageId)
+        
         XCTAssertEqual(text, message.text)
         await XCTAssertEqual(1, chat.state.messages.count)
         let messages = await chat.state.messages

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -197,7 +197,7 @@ final class Chat_Tests: XCTestCase {
         
         let attachmentMessage = try await MainActor.run { try XCTUnwrap(chat.state.messages.first) }
         let attachmentId = AttachmentId(cid: channelId, messageId: attachmentMessage.id, index: 0)
-        var uploadingState = try XCTUnwrap(attachmentMessage.attachment(with: attachmentId)?.uploadingState)
+        let uploadingState = try XCTUnwrap(attachmentMessage.attachment(with: attachmentId)?.uploadingState)
         XCTAssertEqual(LocalAttachmentState.uploadingFailed, uploadingState.state)
         
         env.client.mockAPIClient.uploadFile_completion_result = .success(.dummy())

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "defaultTestExecutionTimeAllowance" : 300,
+    "defaultTestExecutionTimeAllowance" : 180,
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "defaultTestExecutionTimeAllowance" : 60,
+    "defaultTestExecutionTimeAllowance" : 300,
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [
@@ -28,7 +28,6 @@
         "AttachmentQueueUploader_Tests\/test_uploader_whenHasFailedAttachments_doNotMarkMessagePendingSend()",
         "AttachmentQueueUploader_Tests\/test_uploader_whenPostProcessorAvailable_shouldChangeTheAttachmentPayload()",
         "AttachmentQueueUploader_Tests\/test_uploader_whenUploadFails_markMessageAsFailed()",
-        "DatabaseContainer_Tests\/test_removingAllData()",
         "ChannelController_Tests\/test_createCall_propagatesResultFromUpdater()",
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
@@ -36,6 +35,7 @@
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_filled()",
         "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
         "ChannelUpdater_Tests\/test_updateChannelQuery_successfulResponseData_areSavedToDB()",
+        "DatabaseContainer_Tests\/test_removingAllData()",
         "EventNotificationCenter_Tests\/test_measure_processMultipleNewMessageEvents()",
         "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",
         "MessageSender_Tests\/test_senderSendsMessage_withPendingSendLocalState_and_uploadedOrEmptyAttachments()",

--- a/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
@@ -15,7 +15,7 @@
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
       }
     ],
-    "defaultTestExecutionTimeAllowance" : 300,
+    "defaultTestExecutionTimeAllowance" : 180,
     "environmentVariableEntries" : [
       {
         "key" : "TEST_INVOCATIONS",

--- a/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
@@ -15,7 +15,7 @@
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
       }
     ],
-    "defaultTestExecutionTimeAllowance" : 60,
+    "defaultTestExecutionTimeAllowance" : 300,
     "environmentVariableEntries" : [
       {
         "key" : "TEST_INVOCATIONS",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -23,7 +23,7 @@
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
       }
     ],
-    "defaultTestExecutionTimeAllowance" : 60,
+    "defaultTestExecutionTimeAllowance" : 300,
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [
@@ -42,7 +42,6 @@
         "AttachmentQueueUploader_Tests\/test_uploader_whenHasFailedAttachments_doNotMarkMessagePendingSend()",
         "AttachmentQueueUploader_Tests\/test_uploader_whenPostProcessorAvailable_shouldChangeTheAttachmentPayload()",
         "AttachmentQueueUploader_Tests\/test_uploader_whenUploadFails_markMessageAsFailed()",
-        "DatabaseContainer_Tests\/test_removingAllData()",
         "ChannelController_Tests\/test_createCall_propagatesResultFromUpdater()",
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
@@ -50,6 +49,7 @@
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_filled()",
         "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
         "ChannelUpdater_Tests\/test_updateChannelQuery_successfulResponseData_areSavedToDB()",
+        "DatabaseContainer_Tests\/test_removingAllData()",
         "EventNotificationCenter_Tests\/test_measure_processMultipleNewMessageEvents()",
         "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",
         "MessageSender_Tests\/test_senderSendsMessage_withPendingSendLocalState_and_uploadedOrEmptyAttachments()",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -23,7 +23,7 @@
         "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
       }
     ],
-    "defaultTestExecutionTimeAllowance" : 300,
+    "defaultTestExecutionTimeAllowance" : 180,
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [

--- a/Tests/StreamChatTests/Workers/Background/MessageEditor_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageEditor_Tests.swift
@@ -22,6 +22,7 @@ final class MessageEditor_Tests: XCTestCase {
         apiClient = APIClient_Spy()
         database = DatabaseContainer_Spy()
         messageRepository = MessageRepository_Mock(database: database, apiClient: apiClient)
+        messageRepository.updateMessageResult = .success(.mock())
         editor = MessageEditor(messageRepository: messageRepository, database: database, apiClient: apiClient)
     }
 

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -273,8 +273,6 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             completionCalledError = $0
         }
 
-        apiClient.cleanUp()
-
         // Assert the completion is called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)
     }

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -61,12 +61,12 @@ final class MessageUpdater_Tests: XCTestCase {
 
     func test_editMessage_propagates_CurrentUserDoesNotExist_Error() throws {
         // Simulate `editMessage(messageId:, text:)` call
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.editMessage(messageId: .unique, text: .unique, skipEnrichUrl: false, completion: $0)
         }
 
         // Assert `CurrentUserDoesNotExist` is received
-        XCTAssertTrue(completionError is ClientError.CurrentUserDoesNotExist)
+        XCTAssertTrue(completionResult.error is ClientError.CurrentUserDoesNotExist)
     }
 
     func test_editMessage_propagates_MessageDoesNotExist_Error() throws {
@@ -74,12 +74,12 @@ final class MessageUpdater_Tests: XCTestCase {
         try database.createCurrentUser()
 
         // Simulate `editMessage(messageId:, text:)` call
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.editMessage(messageId: .unique, text: .unique, skipEnrichUrl: false, completion: $0)
         }
 
         // Assert `MessageDoesNotExist` is received
-        XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
+        XCTAssertTrue(completionResult.error is ClientError.MessageDoesNotExist)
     }
 
     func test_editMessage_updatesLocalMessageCorrectly() throws {
@@ -127,7 +127,7 @@ final class MessageUpdater_Tests: XCTestCase {
             try database.createMessage(id: quotingMessageId, authorId: currentUserId, quotedMessageId: messageId)
 
             // Edit created message with new text
-            let completionError = try waitFor {
+            let completionResult = try waitFor {
                 messageUpdater.editMessage(messageId: messageId, text: updatedText, skipEnrichUrl: true, completion: $0)
             }
 
@@ -138,7 +138,7 @@ final class MessageUpdater_Tests: XCTestCase {
             let quotingMessage = try XCTUnwrap(database.viewContext.message(id: quotingMessageId))
 
             // Assert completion is called without any error
-            XCTAssertNil(completionError)
+            XCTAssertNil(completionResult.error)
             // Assert message still has expected local state
             XCTAssertEqual(message.localMessageState, expectedState)
             // Assert message text is updated correctly
@@ -192,15 +192,15 @@ final class MessageUpdater_Tests: XCTestCase {
         let message = try XCTUnwrap(database.viewContext.message(id: messageId))
 
         // Edit created message with new text
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.editMessage(messageId: messageId, text: updatedText, skipEnrichUrl: false, completion: $0)
         }
 
         // Load the edited message
-        let editedMessage = try XCTUnwrap(database.viewContext.message(id: messageId))
+        _ = try XCTUnwrap(database.viewContext.message(id: messageId))
 
         // Assert completion is called without any error
-        XCTAssertNil(completionError)
+        XCTAssertNil(completionResult.error)
         // Assert message still has expected local state
         XCTAssertEqual(message.localMessageState, .pendingSend)
         // Assert message text is updated correctly
@@ -237,7 +237,7 @@ final class MessageUpdater_Tests: XCTestCase {
             try database.createMessage(id: messageId, authorId: currentUserId, text: initialText, localState: state)
 
             // Edit created message with new text
-            let completionError = try waitFor {
+            let completionResult = try waitFor {
                 messageUpdater.editMessage(messageId: messageId, text: updatedText, skipEnrichUrl: false, completion: $0)
             }
 
@@ -249,7 +249,7 @@ final class MessageUpdater_Tests: XCTestCase {
             )
 
             // Assert `MessageEditing` error is received
-            XCTAssertTrue(completionError is ClientError.MessageEditing)
+            XCTAssertTrue(completionResult.error is ClientError.MessageEditing)
             // Assert message stays in the same state
             XCTAssertEqual(message.localMessageState, state)
             // Assert message's text stays the same
@@ -281,7 +281,7 @@ final class MessageUpdater_Tests: XCTestCase {
         XCTAssertEqual(encodedCreatedExtraData, extraData)
 
         // Edit created message with new text
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.editMessage(
                 messageId: messageId,
                 text: updatedText,
@@ -299,7 +299,7 @@ final class MessageUpdater_Tests: XCTestCase {
         )
 
         // Assert completion is called without any error
-        XCTAssertNil(completionError)
+        XCTAssertNil(completionResult.error)
         // Assert message's extra data is updated
         XCTAssertEqual(encodedExtraData, updatedExtraData)
     }
@@ -325,7 +325,7 @@ final class MessageUpdater_Tests: XCTestCase {
         XCTAssertEqual(encodedCreatedExtraData, extraData)
 
         // Edit created message with new text
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.editMessage(
                 messageId: messageId,
                 text: updatedText,
@@ -343,7 +343,7 @@ final class MessageUpdater_Tests: XCTestCase {
         )
 
         // Assert completion is called without any error
-        XCTAssertNil(completionError)
+        XCTAssertNil(completionResult.error)
         // Assert message's extra data is updated
         XCTAssertEqual(encodedExtraData, extraData)
     }
@@ -370,7 +370,7 @@ final class MessageUpdater_Tests: XCTestCase {
         XCTAssertEqual(databaseAttachmentTypes.sorted { $0.rawValue < $1.rawValue }, originalAttachmentTypes.sorted { $0.rawValue < $1.rawValue })
 
         // Edit created message with new attaachments
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.editMessage(
                 messageId: messageId,
                 text: updatedText,
@@ -385,7 +385,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let updatedDatabaseAttachmentTypes = message.attachments.map(\.attachmentType)
 
         // Assert completion is called without any error
-        XCTAssertNil(completionError)
+        XCTAssertNil(completionResult.error)
         // Assert message's attachments are updated
         XCTAssertEqual(updatedDatabaseAttachmentTypes.sorted { $0.rawValue < $1.rawValue }, updatedAttachmentsTypes.sorted { $0.rawValue < $1.rawValue })
     }
@@ -782,7 +782,7 @@ final class MessageUpdater_Tests: XCTestCase {
         }
 
         // Load the message
-        let message = try XCTUnwrap(database.viewContext.message(id: secondMessageId))
+        _ = try XCTUnwrap(database.viewContext.message(id: secondMessageId))
 
         // Delete second message
         let expectation = expectation(description: "deleteMessage completes")


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Cover methods which use the waitForAPIRequest approach.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
