### PR TITLE
[ChatStateLayer] Send message action assertion on cancel

### DIFF
--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -588,32 +588,33 @@ class MessageUpdater: Worker {
                 )
             }
 
-            guard action.isCancel == false else {
-                // For ephemeral messages we don't change `state` to `.deleted`
-                messageDTO.deletedAt = DBDate()
-                messageDTO.previewOfChannel?.previewMessage = session.preview(for: cid)
-                completion?(nil)
-                return
-            }
+            guard action.isCancel else { return }
+            // For ephemeral messages we don't change `state` to `.deleted`
+            messageDTO.deletedAt = DBDate()
+            messageDTO.previewOfChannel?.previewMessage = session.preview(for: cid)
         }, completion: { error in
             if let error {
                 completion?(error)
             } else {
-                let endpoint: Endpoint<MessagePayload.Boxed> = .dispatchEphemeralMessageAction(
-                    cid: cid,
-                    messageId: messageId,
-                    action: action
-                )
-                self.apiClient.request(endpoint: endpoint) {
-                    switch $0 {
-                    case let .success(payload):
-                        self.database.write({ session in
-                            try session.saveMessage(payload: payload.message, for: cid, syncOwnReactions: true, cache: nil)
-                        }, completion: { error in
+                if action.isCancel {
+                    completion?(nil)
+                } else {
+                    let endpoint: Endpoint<MessagePayload.Boxed> = .dispatchEphemeralMessageAction(
+                        cid: cid,
+                        messageId: messageId,
+                        action: action
+                    )
+                    self.apiClient.request(endpoint: endpoint) {
+                        switch $0 {
+                        case let .success(payload):
+                            self.database.write({ session in
+                                try session.saveMessage(payload: payload.message, for: cid, syncOwnReactions: true, cache: nil)
+                            }, completion: { error in
+                                completion?(error)
+                            })
+                        case let .failure(error):
                             completion?(error)
-                        })
-                    case let .failure(error):
-                        completion?(error)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

[Crash] Double completion handler: open giphy and cancel

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
