### PR TITLE
[ChatStateLayer ] Use thread-safe storage for Spy protocol

### DIFF
--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
@@ -18,7 +18,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
         static let handleConnectionUpdate = "handleConnectionUpdate(state:onExpiredToken:)"
     }
 
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     var connectResult: Result<Void, Error>?
 
     var disconnectSource: WebSocketConnectionState.DisconnectionSource?

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelListController_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelListController_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 public class ChatChannelListController_Mock: ChatChannelListController, Spy {
-    public var recordedFunctions: [String] = []
+    public let spyState = SpyState()
     public var loadNextChannelsIsCalled = false
     public var loadNextChannelsCallCount = 0
     public var resetChannelsQueryResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>?

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
@@ -18,7 +18,7 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
         static let provideToken = "provideToken(timeout:completion:)"
     }
 
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     var mockedToken: Token?
     var mockedCurrentUserId: UserId?
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 final class MessageRepository_Mock: MessageRepository, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     var sendMessageIds: [MessageId] {
         Array(sendMessageCalls.keys)
     }
@@ -71,7 +71,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
     }
 
     func clear() {
-        recordedFunctions.removeAll()
+        spyState.clear()
         sendMessageCalls.removeAll()
         sendMessageResult = nil
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/OfflineRequestsRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/OfflineRequestsRepository_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 final class OfflineRequestsRepository_Mock: OfflineRequestsRepository, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     convenience init() {
         let apiClient = APIClient_Spy()

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
@@ -10,7 +10,7 @@ final class SyncRepository_Mock: SyncRepository, Spy {
         static let cancelRecoveryFlow = "cancelRecoveryFlow()"
     }
 
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     var syncMissingEventsResult: Result<[ChannelId], SyncError>?
 
     convenience init() {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/VoiceRecording/MockAVURLAsset.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/VoiceRecording/MockAVURLAsset.swift
@@ -7,7 +7,7 @@ import AVFoundation
 @dynamicMemberLookup
 public final class MockAVURLAsset: AVURLAsset, Spy, Stub {
 
-    public var recordedFunctions: [String] = []
+    public let spyState = SpyState()
     public var stubbedProperties: [String: Any] = [:]
 
     public var statusOfValueResultMap: [String: AVKeyValueStatus] = [:]
@@ -23,7 +23,7 @@ public final class MockAVURLAsset: AVURLAsset, Spy, Stub {
         forKey key: String,
         error outError: NSErrorPointer
     ) -> AVKeyValueStatus {
-        recordedFunctions.append("statusOfValue(\(key))")
+        spyState.record("statusOfValue(\(key))")
         outError?.pointee = statusOfValueErrorMap[key] as? NSError
         return statusOfValueResultMap[key] ?? super.statusOfValue(forKey: key, error: outError)
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/VoiceRecording/MockAppStateObserver.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/VoiceRecording/MockAppStateObserver.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 public class MockAppStateObserver: AppStateObserving, Spy {
-    public var recordedFunctions: [String] = []
+    public let spyState = SpyState()
 
     public private(set) var subscribeWasCalledWithSubscriber: AppStateObserverDelegate?
     public private(set) var unsubscribeWasCalledWithSubscriber: AppStateObserverDelegate?

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/VoiceRecording/MockAudioSessionConfigurator.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/VoiceRecording/MockAudioSessionConfigurator.swift
@@ -9,7 +9,7 @@ public final class MockAudioSessionConfigurator: Stub, Spy, AudioSessionConfigur
 
     // MARK: - Stub & Spy requirements
     public var stubbedProperties: [String : Any] = [:]
-    public var recordedFunctions: [String] = []
+    public let spyState = SpyState()
 
     // MARK: - Recorded function parameters
     public private(set) var requestRecordPermissionCompletionHandler: ((Bool) -> Void)?

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -11,7 +11,7 @@ final class APIClient_Spy: APIClient, Spy {
     enum Signature {
         static let flushRequestsQueue = "flushRequestsQueue()"
     }
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     /// The last endpoint `request` function was called with.
     @Atomic var request_endpoint: AnyEndpoint?

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/AttachmentUploader_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/AttachmentUploader_Spy.swift
@@ -6,7 +6,7 @@ import Foundation
 import StreamChat
 
 final class AttachmentUploader_Spy: AttachmentUploader, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     var uploadAttachmentProgress: Double?
     var uploadAttachmentResult: Result<UploadedAttachment, Error>?

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/CDNClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/CDNClient_Spy.swift
@@ -6,7 +6,7 @@ import StreamChat
 import Foundation
 
 final class CDNClient_Spy: CDNClient, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     static var maxAttachmentSize: Int64 { .max }
     var uploadAttachmentProgress: Double?

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
@@ -7,7 +7,7 @@ import XCTest
 
 /// Mock implementation of ChannelListUpdater
 final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Result<[ChatChannel], Error>) -> Void)?

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ChatChannelController_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ChatChannelController_Spy.swift
@@ -7,7 +7,7 @@ import Foundation
 
 final class ChatChannelController_Spy: ChatChannelController, Spy {
     var watchActiveChannelError: Error?
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     init(client: ChatClient_Mock) {
         super.init(channelQuery: .init(cid: .unique), channelListQuery: nil, client: client)

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // A concrete `ConnectionDetailsProviderDelegate` implementation allowing capturing the delegate calls
 final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDelegate, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     var provideTokenResult: Result<Token, Error>?
     @Atomic var tokenWaiters: [String: (Token?) -> Void] = [:]
@@ -16,7 +16,7 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
     @Atomic var connectionWaiters: [String: (ConnectionId?) -> Void] = [:]
 
     func clear() {
-        recordedFunctions.removeAll()
+        spyState.clear()
         tokenWaiters.removeAll()
     }
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -8,7 +8,7 @@ import XCTest
 
 /// A testable subclass of DatabaseContainer allowing response simulation.
 public final class DatabaseContainer_Spy: DatabaseContainer, Spy {
-    @Atomic public var recordedFunctions: [String] = []
+    public let spyState = SpyState()
 
     /// If set, the `write` completion block is called with this value.
     @Atomic var write_errorResponse: Error?

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/Logger_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/Logger_Spy.swift
@@ -6,8 +6,8 @@ import Foundation
 @testable import StreamChat
 
 final class Logger_Spy: Logger, Spy {
+    let spyState = SpyState()
     var originalLogger: Logger?
-    var recordedFunctions: [String] = []
     var failedAsserts: Int = 0
 
     func injectMock() {

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/RequestDecoder_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/RequestDecoder_Spy.swift
@@ -7,7 +7,7 @@ import Foundation
 import XCTest
 
 final class RequestDecoder_Spy: RequestDecoder, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     var decodeRequestResponse: Result<Any, Error>?
     var decodeRequestDelay: TimeInterval?
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/RequestEncoder_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/RequestEncoder_Spy.swift
@@ -7,7 +7,7 @@ import Foundation
 import XCTest
 
 final class RequestEncoder_Spy: RequestEncoder, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     let init_baseURL: URL
     let init_apiKey: APIKey
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/RetryStrategy_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/RetryStrategy_Spy.swift
@@ -12,7 +12,7 @@ final class RetryStrategy_Spy: RetryStrategy, Spy {
         static let resetConsecutiveFailures = "resetConsecutiveFailures()"
     }
 
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
     var consecutiveFailuresCount: Int = 0
 
     lazy var mock_incrementConsecutiveFailures = MockFunc.mock(for: incrementConsecutiveFailures)

--- a/Tests/StreamChatTests/Audio/StreamAppStateObserver_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAppStateObserver_Tests.swift
@@ -120,7 +120,7 @@ private final class StubNotificationCenter: NotificationCenter {
 }
 
 private final class SpyAppStateObserverDelegate: AppStateObserverDelegate, Spy {
-    var recordedFunctions: [String] = []
+    let spyState = SpyState()
 
     func applicationDidMoveToBackground() {
         record()

--- a/Tests/StreamChatTests/Audio/StreamAudioRecorder_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAudioRecorder_Tests.swift
@@ -179,7 +179,7 @@ final class StreamAudioRecorder_Tests: XCTestCase {
 
     func test_resumeRecording_audioRecorderIsRecording_doesNotDoAnything() {
         simulateIsRecording()
-        audioSessionConfigurator.recordedFunctions = []
+        audioSessionConfigurator.clear()
         stubAVAudioRecorder.recordWasCalled = false
 
         subject.resumeRecording()
@@ -191,7 +191,7 @@ final class StreamAudioRecorder_Tests: XCTestCase {
     func test_resumeRecording_audioRecorderIsNotRecording_callsActivateRecordingSessionWhichFails_callsDidFailOnDelegate() {
         simulateIsRecording()
         subject.pauseRecording()
-        audioSessionConfigurator.recordedFunctions = []
+        audioSessionConfigurator.clear()
         stubAVAudioRecorder.recordWasCalled = false
         stubAVAudioRecorder.stubProperty(\.isRecording, with: false)
         audioSessionConfigurator.activateRecordingSessionThrowsError = genericError
@@ -205,7 +205,7 @@ final class StreamAudioRecorder_Tests: XCTestCase {
     func test_resumeRecording_audioRecorderIsNotRecording_failsToStartRecording_callsDidFailOnDelegate() {
         simulateIsRecording()
         subject.pauseRecording()
-        audioSessionConfigurator.recordedFunctions = []
+        audioSessionConfigurator.clear()
         stubAVAudioRecorder.recordWasCalled = false
         stubAVAudioRecorder.stubProperty(\.isRecording, with: false)
         stubAVAudioRecorder.recordResult = false

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -734,7 +734,7 @@ extension SyncRepository_Tests {
 
     private func waitForSyncLocalStateRun(requestResult: Result<MissingEventsPayload, Error>? = nil) {
         database.writeSessionCounter = 0
-        apiClient.recordedFunctions.removeAll()
+        apiClient.clear()
 
         let expectation = self.expectation(description: "syncLocalState completion")
         repository.syncLocalState {


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

I keep seeing tests failing randomly and mostly seems to be related to reading the state from the `Spy` protocol.

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)