### PR TITLE
[ChatStateLayer] Wait depends on the localMessageState

### DIFF
--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -646,7 +646,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     public func pin(_ pinning: MessagePinning, completion: ((Error?) -> Void)? = nil) {
         messageUpdater.pinMessage(messageId: messageId, pinning: pinning) { result in
             self.callback {
-                completion?(result)
+                completion?(result.error)
             }
         }
     }
@@ -657,7 +657,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     public func unpin(completion: ((Error?) -> Void)? = nil) {
         messageUpdater.unpinMessage(messageId: messageId) { result in
             self.callback {
-                completion?(result)
+                completion?(result.error)
             }
         }
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -73,12 +73,12 @@ final class MessageUpdater_Mock: MessageUpdater {
 
     @Atomic var pinMessage_messageId: MessageId?
     @Atomic var pinMessage_pinning: MessagePinning?
-    @Atomic var pinMessage_completion: ((Error?) -> Void)?
-    @Atomic var pinMessage_completion_result: Result<Void, Error>?
+    @Atomic var pinMessage_completion: ((Result<ChatMessage, Error>) -> Void)?
+    @Atomic var pinMessage_completion_result: Result<ChatMessage, Error>?
 
     @Atomic var unpinMessage_messageId: MessageId?
-    @Atomic var unpinMessage_completion: ((Error?) -> Void)?
-    @Atomic var unpinMessage_completion_result: Result<Void, Error>?
+    @Atomic var unpinMessage_completion: ((Result<ChatMessage, Error>) -> Void)?
+    @Atomic var unpinMessage_completion_result: Result<ChatMessage, Error>?
 
     @Atomic var restartFailedAttachmentUploading_id: AttachmentId?
     @Atomic var restartFailedAttachmentUploading_completion: ((Error?) -> Void)?
@@ -334,15 +334,14 @@ final class MessageUpdater_Mock: MessageUpdater {
         deleteReaction_completion = completion
         deleteReaction_completion_result?.invoke(with: completion)
     }
-
-    override func pinMessage(messageId: MessageId, pinning: MessagePinning, completion: ((Error?) -> Void)? = nil) {
+    override func pinMessage(messageId: MessageId, pinning: MessagePinning, completion: ((Result<ChatMessage, any Error>) -> Void)? = nil) {
         pinMessage_messageId = messageId
         pinMessage_pinning = pinning
         pinMessage_completion = completion
         pinMessage_completion_result?.invoke(with: completion)
     }
 
-    override func unpinMessage(messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
+    override func unpinMessage(messageId: MessageId, completion: ((Result<ChatMessage, any Error>) -> Void)? = nil) {
         unpinMessage_messageId = messageId
         unpinMessage_completion = completion
         unpinMessage_completion_result?.invoke(with: completion)

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -5102,7 +5102,7 @@ final class ChannelController_Tests: XCTestCase {
         completion(.failure(testError))
 
         // Error is propagated to completion
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: defaultTimeout)
         XCTAssertEqual(completionError as? TestError, testError)
     }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -5084,22 +5084,26 @@ final class ChannelController_Tests: XCTestCase {
         AssertAsync.willBeTrue(completionError != nil)
     }
 
-    func test_createCall_propagatesErrorFromUpdater() {
+    func test_createCall_propagatesErrorFromUpdater() throws {
         let id: String = .unique
         let type: String = "video"
         var completionError: Error?
 
         // Set completion handler
+        let expectation = XCTestExpectation()
         controller.createCall(id: id, type: type) { result in
             completionError = result.error
+            expectation.fulfill()
         }
 
         // Simulate failed update
         let testError = TestError()
-        env.channelUpdater!.createCall_completion!(.failure(testError))
+        let completion = try XCTUnwrap(env.channelUpdater?.createCall_completion)
+        completion(.failure(testError))
 
         // Error is propagated to completion
-        AssertAsync.willBeEqual(completionError as? TestError, testError)
+        wait(for: [expectation])
+        XCTAssertEqual(completionError as? TestError, testError)
     }
 
     func test_createCall_propagatesResultFromUpdater() {

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -1982,7 +1982,7 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater?.pinMessage_pinning, pinning)
 
         // Simulate successful update
-        env.messageUpdater?.pinMessage_completion?(nil)
+        env.messageUpdater?.pinMessage_completion?(.success(.mock()))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater!.pinMessage_completion = nil
 
@@ -2002,7 +2002,7 @@ final class MessageController_Tests: XCTestCase {
 
         // Simulate failed update
         let testError = TestError()
-        env.messageUpdater!.pinMessage_completion?(testError)
+        env.messageUpdater!.pinMessage_completion?(.failure(testError))
 
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
@@ -2029,7 +2029,7 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater?.unpinMessage_messageId, messageId)
 
         // Simulate successful update
-        env.messageUpdater?.unpinMessage_completion?(nil)
+        env.messageUpdater?.unpinMessage_completion?(.success(.mock()))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater!.unpinMessage_completion = nil
 
@@ -2049,7 +2049,7 @@ final class MessageController_Tests: XCTestCase {
 
         // Simulate failed update
         let testError = TestError()
-        env.messageUpdater!.unpinMessage_completion?(testError)
+        env.messageUpdater!.unpinMessage_completion?(.failure(testError))
 
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1987,14 +1987,14 @@ final class MessageUpdater_Tests: XCTestCase {
             )
 
             // Edit created message with new text
-            let completionError = try waitFor {
+            let completionResult = try waitFor {
                 messageUpdater.unpinMessage(messageId: messageId, completion: $0)
             }
 
             // Load the message
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
 
-            XCTAssertTrue(completionError is ClientError.MessageEditing)
+            XCTAssertTrue(completionResult.error is ClientError.MessageEditing)
             XCTAssertEqual(message.localMessageState, state)
             XCTAssertEqual(message.pinned, true)
             XCTAssertNotNil(message.pinExpires)

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1833,14 +1833,14 @@ final class MessageUpdater_Tests: XCTestCase {
             // Create a new message in the database
             try database.createMessage(id: messageId, authorId: currentUserId, localState: initialState)
 
-            let completionError = try waitFor {
+            let completionResult = try waitFor {
                 messageUpdater.pinMessage(messageId: messageId, pinning: pin, completion: $0)
             }
 
             // Load the message
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
 
-            XCTAssertNil(completionError)
+            XCTAssertNil(completionResult.error)
             XCTAssertEqual(message.localMessageState, expectedState)
             XCTAssertEqual(message.pinned, true)
             XCTAssertEqual(message.pinExpires?.bridgeDate, pin.expirationDate)
@@ -1939,14 +1939,14 @@ final class MessageUpdater_Tests: XCTestCase {
                 localState: initialState
             )
 
-            let completionError = try waitFor {
+            let completionResult = try waitFor {
                 messageUpdater.unpinMessage(messageId: messageId, completion: $0)
             }
 
             // Load the message
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
 
-            XCTAssertNil(completionError)
+            XCTAssertNil(completionResult.error)
             XCTAssertEqual(message.localMessageState, expectedState)
             XCTAssertEqual(message.pinned, false)
             XCTAssertNil(message.pinExpires)

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -545,16 +545,20 @@ final class MessageUpdater_Tests: XCTestCase {
             try database.createMessage(id: messageId, authorId: currentUserId)
 
             // Simulate `deleteMessage(messageId:)` call
-            messageUpdater.deleteMessage(messageId: messageId, hard: false)
-
+            let expectation = XCTestExpectation()
+            messageUpdater.deleteMessage(messageId: messageId, hard: false) { _ in
+                expectation.fulfill()
+            }
+            // Assert message's local state becomes `deleting` after waiting the first DB call to finish
+            AssertAsync.willBeTrue(apiClient.request_completion != nil)
+            
             // Load the message
-            let message = try XCTUnwrap(database.viewContext.message(id: messageId))
-
-            // Assert message's local state becomes `deleting`
-            AssertAsync.willBeEqual(message.localMessageState, .deleting)
-
+            AssertAsync.willBeEqual(.deleting, database.writableContext.message(id: messageId)?.localMessageState)
+            
             // Simulate API response
             apiClient.test_simulateResponse(networkResult)
+
+            wait(for: [expectation], timeout: defaultTimeout)
 
             // Assert message's local state becomes expected
             if expectedState == nil {
@@ -1794,11 +1798,11 @@ final class MessageUpdater_Tests: XCTestCase {
     func test_pinMessage_propagates_MessageDoesNotExist_Error() throws {
         try database.createCurrentUser()
 
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.pinMessage(messageId: .unique, pinning: .expirationDate(.unique), completion: $0)
         }
 
-        XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
+        XCTAssertTrue(completionResult.error is ClientError.MessageDoesNotExist)
     }
 
     func test_pinMessage_updatesLocalMessageCorrectly() throws {
@@ -1873,14 +1877,14 @@ final class MessageUpdater_Tests: XCTestCase {
             // Create a new message in the database
             try database.createMessage(id: messageId, authorId: currentUserId, text: initialText, localState: state)
 
-            let completionError = try waitFor {
+            let completionResult = try waitFor {
                 messageUpdater.pinMessage(messageId: messageId, pinning: MessagePinning(expirationDate: .unique), completion: $0)
             }
 
             // Load the message
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
 
-            XCTAssertTrue(completionError is ClientError.MessageEditing)
+            XCTAssertTrue(completionResult.error is ClientError.MessageEditing)
             XCTAssertEqual(message.localMessageState, state)
             XCTAssertEqual(message.text, initialText)
             XCTAssertEqual(message.pinned, false)
@@ -1893,11 +1897,11 @@ final class MessageUpdater_Tests: XCTestCase {
     func test_unpinMessage_propogates_MessageDoesNotExist_Error() throws {
         try database.createCurrentUser()
 
-        let completionError = try waitFor {
+        let completionResult = try waitFor {
             messageUpdater.unpinMessage(messageId: .unique, completion: $0)
         }
 
-        XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
+        XCTAssertTrue(completionResult.error is ClientError.MessageDoesNotExist)
     }
 
     func test_unpinMessage_updatesLocalMessageCorrectly() throws {


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Depending on the message's localMessageState we need to wait in different workers

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)