### PR TITLE
[ChatStateLayer] Reset contexts when logging out

### DIFF
--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -289,6 +289,7 @@ class DatabaseContainer: NSPersistentContainer {
         allContext.forEach { context in
             context.perform {
                 context.invalidateCurrentUserCache()
+                context.reset()
             }
         }
 


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Fix logout issue with duplicate channels in DB.

### 📝 Summary

While testing the new state in the SwiftUI SDK we found an issue:

1. Log in with A
2. Open channel with A and B
3. Logout and log in with B
4. Open channel with A and B → issue happens (assert telling multiple ChannelDTOs for the same cid)

![Simulator Screen Recording - iPhone 15 Pro - 2024-04-24 at 15 44 39](https://github.com/GetStream/stream-chat-swift/assets/1469907/97655b0b-25bb-4976-9270-dabc040fe7e2)

### 🛠 Implementation

It seems like when we flush the database on logout, open channel is not flushed. Not sure, but I think it is related to state layer's context which immediately reacts to changes.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)