### PR TITLE
Discard any changes before we delete the persistent state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ _April 30, 2024_
 - Adds `firstReactionAt` and `lastReactionAt` to `ChatMessageReactionData` to be able to sort by dates in `Components.reactionsSorting` [#3158](https://github.com/GetStream/stream-chat-swift/pull/3158)
 - Add `ChatReactionListController` to query and filter reactions from a message [#3167](https://github.com/GetStream/stream-chat-swift/pull/3167)
 - Add `ChatClient.reactionListController()`  to create an instance of `ChatReactionListController` [#3167](https://github.com/GetStream/stream-chat-swift/pull/3167)
+### 🐞 Fixed
+- Reset managed object contexts before removing all the data on logout [#3170](https://github.com/GetStream/stream-chat-swift/pull/3170)
 
 # [4.52.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.52.0)
 _April 09, 2024_

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -228,6 +228,7 @@ class DatabaseContainer: NSPersistentContainer {
         allContext.forEach { context in
             context.perform {
                 context.invalidateCurrentUserCache()
+                context.reset()
             }
         }
 


### PR DESCRIPTION
### 🎯 Goal

Make sure that changed managed object contexts do not trigger adding new data in `removeAllData`

### 📝 Summary

In the state layer branch we have a case where channel was not properly deleted on logout. That branch also has additional managed object context which is aggressively merging changes from other contexts (this seems to be related).

1. Log in with A
2. Open channel with A and B
3. Logout and log in with B
4. Open channel with A and B → issue happens (assert telling multiple ChannelDTOs for the same cid)

### 🛠 Implementation

Reset contexts when we logout for making sure we discard any active changes and do not try to save them when later the code path calls `writableContext.save`.

### 🎨 Showcase

From: `feature/chat-state-layer`
![325224767-97655b0b-25bb-4976-9270-dabc040fe7e2](https://github.com/GetStream/stream-chat-swift/assets/1469907/d3b1f3f7-b4e4-4d9e-a55d-d3b197befa29)

### 🧪 Manual Testing Notes

Follow the steps above.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
