### PR TITLE
Fix crash in @Cached property value when computeValue was called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `reason` parameter to `flagMessage()` [#3173](https://github.com/GetStream/stream-chat-swift/issues/3173)
 ### 🐞 Fixed
 - Reset managed object contexts before removing all the data on logout [#3170](https://github.com/GetStream/stream-chat-swift/pull/3170)
+- Rare crash when `@Cached` property triggered fetching a new value with `computeValue` closure [#3174](https://github.com/GetStream/stream-chat-swift/pull/3174)
 ### 🔄 Changed
 - Replace message update request to partial update on message pinning [#3166](https://github.com/GetStream/stream-chat-swift/pull/3166)
 

--- a/Tests/StreamChatTests/StreamChatStressTests/Cached_StressTests.swift
+++ b/Tests/StreamChatTests/StreamChatStressTests/Cached_StressTests.swift
@@ -7,6 +7,7 @@ import StreamChatTestTools
 import XCTest
 
 final class Cached_Tests: StressTestCase {
+    let queue = DispatchQueue(label: "io.getstream.tests.cached")
     var counter: Int!
     @Cached var value: Int!
 
@@ -18,8 +19,11 @@ final class Cached_Tests: StressTestCase {
 
         _value.computeValue = { [unowned self] in
             // Return the current counter value and increase the counter
-            defer { self.counter += 1 }
-            return self.counter
+            queue.sync {
+                let value = counter
+                counter += 1
+                return value
+            }
         }
     }
 
@@ -64,5 +68,50 @@ final class Cached_Tests: StressTestCase {
             }
         }
         group.wait()
+    }
+    
+    func test_resetAndRead_whenRunningConcurrently() {
+        _value.computeValue = { Int.max }
+        DispatchQueue.concurrentPerform(iterations: 10) { _ in
+            self._value.reset()
+            _ = self.value
+        }
+        XCTAssertEqual(value, Int.max)
+    }
+    
+    func test_exclusiveAccess_whenComputeValueTriggersReset() throws {
+        // 1. `EntityDatabaseObserver.item` was accessed but since the cached value was nil, `computeValue` was called
+        // 2. Compute value for the `EntityDatabaseObserver.item` triggered CoreData object change
+        // 3. CoreData change was picked up by the `EntityDatabaseObserver` which ended up calling `item.reset()`
+        // Result: Crash because computeValue was called from the Atomic's mutate function and therefore all the code was
+        // triggered from the mutate. `item.reset()` triggered another mutate and then Swift's runtime crashed the app
+        // because it requires exclusive access (`mutate` uses inout parameters!).
+        // This test would crash if `computeValue` is called within `mutate`.
+        let loader = ExclusiveAccessTriggeringLoader(computeValueResult: 1)
+        let result = loader.readValue()
+        XCTAssertEqual(result, 1)
+    }
+}
+
+private extension Cached_Tests {
+    /// Triggers crash if `computeValue` is called from `mutate(_:)`.
+    final class ExclusiveAccessTriggeringLoader {
+        @Cached private var value: Int?
+
+        init(computeValueResult: Int) {
+            _value.computeValue = { [weak self] in
+                self?.simulateComputeValueTriggeringCoreDataChangeWhichLeadsToCallingResetOnTheSameProperty()
+                return computeValueResult
+            }
+        }
+
+        func readValue() -> Int? {
+            value
+        }
+
+        private func simulateComputeValueTriggeringCoreDataChangeWhichLeadsToCallingResetOnTheSameProperty() {
+            // Simulates the case of a CoreData change which in turn ended up calling reset on the item
+            _value.reset()
+        }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/805](https://github.com/GetStream/ios-issues-tracking/issues/805)

### 🎯 Goal

Fix issues related to `computeValue` callback in `@Cached`

### 📝 Summary

* Do not call `computeValue` from the closure passed into `mutate` since it can trigger side-effects leading to crashes
* If multiple threads are accessing the property at the same time, and the cached value is nil, we might run `computeValue` multiple times. Old: `computeValue` was always called once, but in rare cases crashed.
* If cached value is nil, we now need to acquire a lock twice (first: reading the current value, second: setting a new value fetched from `computeValue`). Old: lock was acquired once, but in rare cases crashed.

### 🛠 Implementation

The `computeValue` callback which is passed into mutate's closure (locked region) can trigger side-effects. An example is CoreData context change which leads to reentrancy (exclusive access assert in Swift runtime). Another case we have seen is a deadlock.

### 🧪 Manual Testing Notes

No specific steps rather than just playing around with the demo app a bit. Logging out, logging in etc.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)