### PR TITLE
[ChatStateLayer] Add ReactionList

### DIFF
--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -238,6 +238,22 @@ extension ChatClient {
     }
 }
 
+// MARK: - Factory Methods for Creating Message Reaction Lists
+
+@available(iOS 13.0, *)
+extension ChatClient {
+    /// Creates an instance of ``ReactionList`` which represents an array of message reactions matching to the specified ``ReactionListQuery``.
+    ///
+    /// - Note: Call the paginated load methods for loading the list of message reactions.
+    ///
+    /// - Parameter query: The query which defines a message and filter.
+    ///
+    /// - Returns: An instance of ``ReactionList`` which represents actions and the current state of the list.
+    public func makeReactionList(with query: ReactionListQuery) -> ReactionList {
+        ReactionList(query: query, client: self)
+    }
+}
+
 // MARK: - Factory Methods for Searching Messages
 
 @available(iOS 13.0, *)

--- a/Sources/StreamChat/StateLayer/MemberList.swift
+++ b/Sources/StreamChat/StateLayer/MemberList.swift
@@ -30,8 +30,6 @@ public final class MemberList {
     
     /// Fetches the most recent state from the server and updates the local store.
     ///
-    /// - Important: Loaded members in ``MemberListState/members`` are reset.
-    ///
     /// - Throws: An error while communicating with the Stream API.
     public func get() async throws {
         let pagination = Pagination(pageSize: .channelMembersPageSize)
@@ -39,8 +37,6 @@ public final class MemberList {
     }
     
     /// Loads channel members for the specified pagination parameters and updates ``MemberListState/members``.
-    ///
-    /// - Important: If pagination offset is 0 and cursor is nil, then loaded members are reset.
     ///
     /// - Parameter pagination: The pagination configuration which includes a limit and an offset or a cursor.
     ///

--- a/Sources/StreamChat/StateLayer/MemberListState.swift
+++ b/Sources/StreamChat/StateLayer/MemberListState.swift
@@ -10,11 +10,15 @@ import Foundation
     private let observer: Observer
     
     init(query: ChannelMemberListQuery, database: DatabaseContainer) {
+        self.query = query
         observer = Observer(query: query, database: database)
         members = observer.start(
             with: .init(membersDidChange: { [weak self] in self?.members = $0 })
         )
     }
+    
+    /// The query specifying and filtering the list of channel members.
+    public let query: ChannelMemberListQuery
     
     /// An array of members for the specified ``ChannelMemberListQuery``.
     @Published public private(set) var members = StreamCollection<ChatChannelMember>([])

--- a/Sources/StreamChat/StateLayer/ReactionList.swift
+++ b/Sources/StreamChat/StateLayer/ReactionList.swift
@@ -1,0 +1,87 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object which represents a list of `ChatMessageReaction` for the specified query.
+@available(iOS 13.0, *)
+public final class ReactionList {
+    private let query: ReactionListQuery
+    private let reactionListUpdater: ReactionListUpdater
+    private let stateBuilder: StateBuilder<ReactionListState>
+    
+    init(query: ReactionListQuery, client: ChatClient, environment: Environment = .init()) {
+        self.query = query
+        reactionListUpdater = environment.reactionListUpdaterBuilder(
+            client.databaseContainer,
+            client.apiClient
+        )
+        stateBuilder = StateBuilder {
+            environment.stateBuilder(
+                query,
+                client.databaseContainer
+            )
+        }
+    }
+    
+    /// An observable object representing the current state of the reaction list.
+    @MainActor public lazy var state: ReactionListState = stateBuilder.build()
+    
+    /// Fetches the most recent state from the server and updates the local store.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    public func get() async throws {
+        let pagination = Pagination(pageSize: 25)
+        try await loadReactions(with: pagination)
+    }
+    
+    /// Loads reactions for the specified pagination parameters and updates ``ReactionListState/reactions``.
+    ///
+    /// - Parameter pagination: The pagination configuration which includes a limit and an offset or a cursor.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of message reaction for the pagination.
+    @discardableResult public func loadReactions(with pagination: Pagination) async throws -> [ChatMessageReaction] {
+        let query = query.withPagination(pagination)
+        return try await reactionListUpdater.loadReactions(query: query)
+    }
+    
+    /// Loads more message reactions and updates ``MemberListState/members``.
+    ///
+    /// - Parameters
+    ///   - limit: The limit for the page size. The default limit is 25.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of message reactions.
+    @discardableResult public func loadMoreReactions(limit: Int? = nil) async throws -> [ChatMessageReaction] {
+        let pageSize = limit ?? 25
+        let pagination = Pagination(pageSize: pageSize, offset: await state.reactions.count)
+        return try await loadReactions(with: pagination)
+    }
+}
+
+@available(iOS 13.0, *)
+extension ReactionList {
+    struct Environment {
+        var reactionListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> ReactionListUpdater = ReactionListUpdater.init
+        
+        var stateBuilder: @MainActor(
+            _ query: ReactionListQuery,
+            _ database: DatabaseContainer
+        ) -> ReactionListState = { @MainActor in
+            ReactionListState(query: $0, database: $1)
+        }
+    }
+}
+
+private extension ReactionListQuery {
+    func withPagination(_ pagination: Pagination) -> Self {
+        var result = self
+        result.pagination = pagination
+        return result
+    }
+}

--- a/Sources/StreamChat/StateLayer/ReactionListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ReactionListState+Observer.swift
@@ -1,0 +1,33 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+extension ReactionListState {
+    struct Observer {
+        private let reactionListObserver: StateLayerDatabaseObserver<ListResult, ChatMessageReaction, MessageReactionDTO>
+        
+        init(query: ReactionListQuery, database: DatabaseContainer) {
+            reactionListObserver = StateLayerDatabaseObserver(
+                databaseContainer: database,
+                fetchRequest: MessageReactionDTO.reactionListFetchRequest(query: query),
+                itemCreator: { try $0.asModel() }
+            )
+        }
+        
+        struct Handlers {
+            let reactionsDidChange: (StreamCollection<ChatMessageReaction>) async -> Void
+        }
+        
+        func start(with handlers: Handlers) -> StreamCollection<ChatMessageReaction> {
+            do {
+                return try reactionListObserver.startObserving(didChange: handlers.reactionsDidChange)
+            } catch {
+                log.error("Failed to start the reaction list observer with error \(error)")
+                return StreamCollection([])
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/StateLayer/ReactionListState.swift
+++ b/Sources/StreamChat/StateLayer/ReactionListState.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a list of reactions matching to the specified query.
+@available(iOS 13.0, *)
+@MainActor public final class ReactionListState: ObservableObject {
+    private let observer: Observer
+    
+    init(query: ReactionListQuery, database: DatabaseContainer) {
+        self.query = query
+        observer = Observer(query: query, database: database)
+        reactions = observer.start(
+            with: .init(reactionsDidChange: { [weak self] in self?.reactions = $0 })
+        )
+    }
+    
+    /// The query specifying and filtering the list of reactions.
+    public let query: ReactionListQuery
+    
+    /// An array of reactions for the specified ``ReactionListQuery``.
+    @Published public private(set) var reactions = StreamCollection<ChatMessageReaction>([])
+}

--- a/Sources/StreamChat/Workers/ReactionListUpdater.swift
+++ b/Sources/StreamChat/Workers/ReactionListUpdater.swift
@@ -29,4 +29,13 @@ class ReactionListUpdater: Worker {
             }
         }
     }
+    
+    @available(iOS 13.0, *)
+    func loadReactions(query: ReactionListQuery) async throws -> [ChatMessageReaction] {
+        try await withCheckedThrowingContinuation { continuation in
+            loadReactions(query: query) { completion in
+                continuation.resume(with: completion)
+            }
+        }
+    }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -250,6 +250,13 @@
 		4F14F1272BBBDD7400B1074E /* StateLayerDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1252BBBDD7400B1074E /* StateLayerDatabaseObserver.swift */; };
 		4F14F1282BBD2D8700B1074E /* ChannelList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5758F02BB45B2F00D89A94 /* ChannelList_Tests.swift */; };
 		4F14F12A2BBE8C1900B1074E /* MessageSearch_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F14F1292BBE8C1900B1074E /* MessageSearch_Tests.swift */; };
+		4F1BEE762BE384ED00B6685C /* ReactionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE752BE384ED00B6685C /* ReactionList.swift */; };
+		4F1BEE772BE384ED00B6685C /* ReactionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE752BE384ED00B6685C /* ReactionList.swift */; };
+		4F1BEE792BE384FE00B6685C /* ReactionListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE782BE384FE00B6685C /* ReactionListState.swift */; };
+		4F1BEE7A2BE384FE00B6685C /* ReactionListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE782BE384FE00B6685C /* ReactionListState.swift */; };
+		4F1BEE7C2BE3851200B6685C /* ReactionListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE7B2BE3851200B6685C /* ReactionListState+Observer.swift */; };
+		4F1BEE7D2BE3851200B6685C /* ReactionListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE7B2BE3851200B6685C /* ReactionListState+Observer.swift */; };
+		4F1BEE7F2BE38B5500B6685C /* ReactionList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE7E2BE38B5500B6685C /* ReactionList_Tests.swift */; };
 		4F427F662BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F672BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F692BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
@@ -3039,6 +3046,10 @@
 		4F14F1232BBA9CEF00B1074E /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		4F14F1252BBBDD7400B1074E /* StateLayerDatabaseObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateLayerDatabaseObserver.swift; sourceTree = "<group>"; };
 		4F14F1292BBE8C1900B1074E /* MessageSearch_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSearch_Tests.swift; sourceTree = "<group>"; };
+		4F1BEE752BE384ED00B6685C /* ReactionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionList.swift; sourceTree = "<group>"; };
+		4F1BEE782BE384FE00B6685C /* ReactionListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionListState.swift; sourceTree = "<group>"; };
+		4F1BEE7B2BE3851200B6685C /* ReactionListState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReactionListState+Observer.swift"; sourceTree = "<group>"; };
+		4F1BEE7E2BE38B5500B6685C /* ReactionList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionList_Tests.swift; sourceTree = "<group>"; };
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
@@ -5064,6 +5075,9 @@
 				4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
+				4F1BEE752BE384ED00B6685C /* ReactionList.swift */,
+				4F1BEE782BE384FE00B6685C /* ReactionListState.swift */,
+				4F1BEE7B2BE3851200B6685C /* ReactionListState+Observer.swift */,
 				4F97F2662BA83146001C4D66 /* UserList.swift */,
 				4F97F2692BA83150001C4D66 /* UserListState.swift */,
 				4FE6E1AC2BAC7A1B00C80AF1 /* UserListState+Observer.swift */,
@@ -5082,6 +5096,7 @@
 				4FCCACE32BC939EB009D23E1 /* MemberList_Tests.swift */,
 				4F14F1292BBE8C1900B1074E /* MessageSearch_Tests.swift */,
 				4F5151992BC57C40001B7152 /* MessageState_Tests.swift */,
+				4F1BEE7E2BE38B5500B6685C /* ReactionList_Tests.swift */,
 				4F072F022BC008D9006A66CA /* StateLayerDatabaseObserver_Tests.swift */,
 				4F5151972BC407ED001B7152 /* UserList_Tests.swift */,
 				4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */,
@@ -10946,6 +10961,7 @@
 				40789D2F29F6AC500018C2BB /* AudioRecordingDelegate.swift in Sources */,
 				4FE6E1AA2BAC79F400C80AF1 /* MemberListState+Observer.swift in Sources */,
 				790A4C55252F25DA001F4A23 /* DeviceDTO.swift in Sources */,
+				4F1BEE792BE384FE00B6685C /* ReactionListState.swift in Sources */,
 				79C5CBE825F66DBD00D98001 /* ChatChannelWatcherListController.swift in Sources */,
 				8A62706E24BF45360040BFD6 /* BanEnabling.swift in Sources */,
 				7985BDAA252B1E53002B8C30 /* MainQueue+Synchronous.swift in Sources */,
@@ -11111,6 +11127,7 @@
 				DA0BB1612513B5F200CAEFBD /* StringInterpolation+Extensions.swift in Sources */,
 				64C8C86E26934C6100329F82 /* UserInfo.swift in Sources */,
 				C1FFD9F927ECC7C7008A6848 /* Filter+ChatChannel.swift in Sources */,
+				4F1BEE7C2BE3851200B6685C /* ReactionListState+Observer.swift in Sources */,
 				C1FC2F962742579D0062530F /* Transport.swift in Sources */,
 				C1FC2F9A2742579D0062530F /* WSEngine.swift in Sources */,
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
@@ -11270,6 +11287,7 @@
 				8A0D64A724E57A520017A3C0 /* GuestUserTokenRequestPayload.swift in Sources */,
 				AD6E32A42BBC502D0073831B /* ThreadQuery.swift in Sources */,
 				888E8C39252B2ABB00195E03 /* UserController+Combine.swift in Sources */,
+				4F1BEE762BE384ED00B6685C /* ReactionList.swift in Sources */,
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */,
 				AD78568C298B268F00C2FEAD /* ChannelControllerDelegate.swift in Sources */,
@@ -11554,6 +11572,7 @@
 				4042968F29FBCE1D0089126D /* AudioSamplesExtractor_Tests.swift in Sources */,
 				40789D3F29F6AFC40018C2BB /* Debouncer_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
+				4F1BEE7F2BE38B5500B6685C /* ReactionList_Tests.swift in Sources */,
 				40B345F729C46AE500B96027 /* StreamPlayerObserver_Tests.swift in Sources */,
 				796CBC1C25F7CD58003299B0 /* UserChannelBanEventsMiddleware_Tests.swift in Sources */,
 				DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */,
@@ -11785,6 +11804,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F1BEE7D2BE3851200B6685C /* ReactionListState+Observer.swift in Sources */,
 				40789D1C29F6AC500018C2BB /* AudioPlaybackState.swift in Sources */,
 				AD8C7C612BA3DF2800260715 /* AppSettings.json in Sources */,
 				C121E804274544AC00023E4C /* ChatClient.swift in Sources */,
@@ -11899,12 +11919,14 @@
 				C121E84B274544AE00023E4C /* Endpoint.swift in Sources */,
 				C121E84C274544AE00023E4C /* GuestEndpoints.swift in Sources */,
 				C121E84D274544AE00023E4C /* DeviceEndpoints.swift in Sources */,
+				4F1BEE7A2BE384FE00B6685C /* ReactionListState.swift in Sources */,
 				C121E84E274544AE00023E4C /* ChannelEndpoints.swift in Sources */,
 				C121E84F274544AE00023E4C /* UserEndpoints.swift in Sources */,
 				C121E850274544AE00023E4C /* SyncEndpoint.swift in Sources */,
 				4F97F26B2BA83150001C4D66 /* UserListState.swift in Sources */,
 				84D5BC70277B61A000A65C75 /* PinnedMessagesSortingKey.swift in Sources */,
 				C121E851274544AE00023E4C /* MessageEndpoints.swift in Sources */,
+				4F1BEE772BE384ED00B6685C /* ReactionList.swift in Sources */,
 				C121E852274544AE00023E4C /* ModerationEndpoints.swift in Sources */,
 				C121E853274544AE00023E4C /* WebSocketConnectEndpoint.swift in Sources */,
 				4F73F39F2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */,

--- a/TestTools/StreamChatTestTools/TestData/DummyData/MessageReactionPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/MessageReactionPayload.swift
@@ -9,6 +9,7 @@ extension MessageReactionPayload {
     static func dummy(
         type: MessageReactionType = .init(rawValue: .unique),
         messageId: String,
+        createdAt: Date = .unique,
         updatedAt: Date = .unique,
         user: UserPayload,
         extraData: [String: RawJSON] = [:]
@@ -17,7 +18,7 @@ extension MessageReactionPayload {
             type: type,
             score: .random(in: 0...10),
             messageId: messageId,
-            createdAt: .unique,
+            createdAt: createdAt,
             updatedAt: updatedAt,
             user: user,
             extraData: extraData

--- a/Tests/StreamChatTests/StateLayer/MemberList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/MemberList_Tests.swift
@@ -160,7 +160,6 @@ final class MemberList_Tests: XCTestCase {
 extension MemberList_Tests {
     final class TestEnvironment {
         let client: ChatClient_Mock
-        private(set) var state: UserListState!
         private(set) var memberListUpdater: ChannelMemberListUpdater!
         private(set) var memberListUpdaterMock: ChannelMemberListUpdater_Mock!
         

--- a/Tests/StreamChatTests/StateLayer/ReactionList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ReactionList_Tests.swift
@@ -1,0 +1,229 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+@available(iOS 13.0, *)
+final class ReactionList_Tests: XCTestCase {
+    private var channelId: ChannelId!
+    private var messageId: MessageId!
+    private var reactionList: ReactionList!
+    private var env: TestEnvironment!
+    private var query: ReactionListQuery!
+    
+    override func setUpWithError() throws {
+        channelId = .unique
+        messageId = .unique
+        env = TestEnvironment()
+        query = ReactionListQuery(messageId: messageId)
+    }
+
+    override func tearDownWithError() throws {
+        env.cleanUp()
+        env = nil
+        reactionList = nil
+        query = nil
+    }
+    
+    // MARK: - Restoring State
+
+    func test_restoreState_whenDatabaseHasItems_thenStateIsUpToDate() async throws {
+        try await createChannel()
+        let initialPayload = makeMessageReactionsPayload(
+            reactionCount: 5,
+            offset: 0,
+            messageId: messageId
+        )
+        try await env.client.databaseContainer.write { session in
+            session.saveReactions(payload: initialPayload, query: self.query)
+        }
+        try await setUpReactionList()
+        await XCTAssertEqual(
+            initialPayload.reactions.map(\.type.rawValue),
+            reactionList.state.reactions.map(\.type.rawValue)
+        )
+    }
+
+    // MARK: - Get
+    
+    func test_get_whenLocalStoreHasReactions_thenGetResetsReactions() async throws {
+        // Existing state
+        try await createChannel()
+        let initialPayload = makeMessageReactionsPayload(
+            reactionCount: 3,
+            offset: 0,
+            messageId: messageId
+        )
+        try await env.client.databaseContainer.write { session in
+            session.saveReactions(payload: initialPayload, query: self.query)
+        }
+        
+        try await setUpReactionList()
+        await XCTAssertEqual(3, reactionList.state.reactions.count)
+        
+        let nextPayload = makeMessageReactionsPayload(
+            reactionCount: 2,
+            offset: 0,
+            messageId: messageId
+        )
+        env.client.mockAPIClient.test_mockResponseResult(.success(nextPayload))
+        try await reactionList.get()
+        
+        // TODO: Reset is not implemented (if it is, the result should be 2)
+        await XCTAssertEqual(5, reactionList.state.reactions.count)
+//        await XCTAssertEqual(
+//            nextPayload.reactions.map(\.type.rawValue),
+//            reactionList.state.reactions.map(\.type.rawValue)
+//        )
+    }
+    
+    func test_get_whenLocalStoreHasReactions_thenGetFetchesFirstPageOfReactions() async throws {
+        try await createChannel()
+        try await setUpReactionList()
+        await XCTAssertEqual(0, reactionList.state.reactions.count)
+        
+        let nextPayload = makeMessageReactionsPayload(
+            reactionCount: 3,
+            offset: 0,
+            messageId: messageId
+        )
+        env.client.mockAPIClient.test_mockResponseResult(.success(nextPayload))
+        try await reactionList.get()
+        
+        await XCTAssertEqual(3, reactionList.state.reactions.count)
+        await XCTAssertEqual(
+            nextPayload.reactions.map(\.type.rawValue),
+            reactionList.state.reactions.map(\.type.rawValue)
+        )
+    }
+    
+    // MARK: - Pagination
+    
+    func test_loadReactions_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+        try await createChannel()
+        try await setUpReactionList()
+        
+        let apiResult = makeMessageReactionsPayload(
+            reactionCount: 10,
+            offset: 0,
+            messageId: messageId
+        )
+        env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
+        let pagination = Pagination(pageSize: 10)
+        let result = try await reactionList.loadReactions(with: pagination)
+        XCTAssertEqual(
+            apiResult.reactions.map(\.type.rawValue),
+            result.map(\.type.rawValue)
+        )
+        await XCTAssertEqual(
+            apiResult.reactions.map(\.type.rawValue),
+            reactionList.state.reactions.map(\.type.rawValue)
+        )
+    }
+    
+    func test_loadMoreReactions_whenAPIRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+        try await createChannel()
+        try await setUpReactionList()
+        
+        let initialPayload = makeMessageReactionsPayload(
+            reactionCount: 5,
+            offset: 3,
+            messageId: messageId
+        )
+        try await env.client.databaseContainer.write { session in
+            session.saveReactions(payload: initialPayload, query: self.query)
+        }
+        
+        let apiResult = makeMessageReactionsPayload(
+            reactionCount: 3,
+            offset: 0,
+            messageId: messageId
+        )
+        env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
+        let result = try await reactionList.loadMoreReactions(limit: 3)
+        XCTAssertEqual(apiResult.reactions.map(\.type.rawValue), result.map(\.type.rawValue))
+        
+        let allExpectedIds = (initialPayload.reactions + apiResult.reactions).map(\.type.rawValue)
+        await XCTAssertEqual(allExpectedIds, reactionList.state.reactions.map(\.type.rawValue))
+    }
+
+    // MARK: - Test Data
+    
+    @MainActor private func setUpReactionList(loadState: Bool = true) async throws {
+        reactionList = ReactionList(
+            query: query,
+            client: env.client,
+            environment: env.reactionListEnvironment()
+        )
+        if loadState {
+            _ = reactionList.state
+        }
+    }
+    
+    private func createChannel() async throws {
+        try await env.client.databaseContainer.write { session in
+            try session.saveChannel(
+                payload: ChannelPayload.dummy(
+                    channel: .dummy(cid: self.channelId),
+                    messages: [
+                        .dummy(messageId: self.messageId)
+                    ]
+                )
+            )
+        }
+    }
+    
+    private func makeMessageReactionsPayload(
+        reactionCount: Int,
+        offset: Int,
+        messageId: MessageId
+    ) -> MessageReactionsPayload {
+        let reactions = (0..<reactionCount)
+            .map { $0 + offset }
+            .reversed() // last updated ones first
+            .map {
+                MessageReactionPayload.dummy(
+                    messageId: messageId,
+                    createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0)),
+                    updatedAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0)),
+                    user: .dummy(userId: .unique)
+                )
+            }
+        return MessageReactionsPayload(reactions: reactions)
+    }
+}
+
+@available(iOS 13.0, *)
+extension ReactionList_Tests {
+    final class TestEnvironment {
+        let client: ChatClient_Mock
+        private(set) var reactionListUpdater: ReactionListUpdater!
+        
+        func cleanUp() {
+            client.cleanUp()
+        }
+        
+        init() {
+            client = ChatClient_Mock(
+                config: ChatClient_Mock.defaultMockedConfig
+            )
+        }
+        
+        func reactionListEnvironment() -> ReactionList.Environment {
+            ReactionList.Environment(
+                reactionListUpdaterBuilder: { [unowned self] in
+                    self.reactionListUpdater = ReactionListUpdater(
+                        database: $0,
+                        apiClient: $1
+                    )
+                    return reactionListUpdater
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add `ReactionList` for querying reactions using a filter.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
