### PR TITLE
Make  `ChatMessageContentView.prepareForReuse()` open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Reset managed object contexts before removing all the data on logout [#3170](https://github.com/GetStream/stream-chat-swift/pull/3170)
 
+## StreamChatUI
+### ✅ Added
+- Make `ChatMessageContentView.prepareForReuse()` open [#3176](https://github.com/GetStream/stream-chat-swift/pull/3176)
+
 # [4.53.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.53.0)
 _April 30, 2024_
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -748,7 +748,7 @@ open class ChatMessageContentView: _View, ThemeProvider, UITextViewDelegate {
 
     /// Cleans up the view so it is ready to display another message.
     /// We don't need to reset `content` because all subviews are always updated.
-    func prepareForReuse() {
+    open func prepareForReuse() {
         defer { attachmentViewInjector?.contentViewDidPrepareForReuse() }
 
         delegate = nil


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/809

### 🎯 Goal
Make `ChatMessageContentView` open so that it can be overridable by customers.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
