### PR TITLE
[ChatStateLayer] Use non-optional limit arguments in pagination methods

### DIFF
--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -68,13 +68,11 @@ public class ChannelList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
-    @discardableResult public func loadMoreChannels(limit: Int? = nil) async throws -> [ChatChannel] {
-        let limit = limit ?? query.pagination.pageSize
-        let count = await state.channels.count
-        return try await channelListUpdater.loadNextChannels(
+    @discardableResult public func loadMoreChannels(limit: Int = 20) async throws -> [ChatChannel] {
+        try await channelListUpdater.loadNextChannels(
             query: query,
             limit: limit,
-            loadedChannelsCount: count
+            loadedChannelsCount: state.channels.count
         )
     }
 }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -223,7 +223,7 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of channel members for the pagination request.
-    @discardableResult public func loadMoreMembers(limit: Int? = nil) async throws -> [ChatChannelMember] {
+    @discardableResult public func loadMoreMembers(limit: Int = 30) async throws -> [ChatChannelMember] {
         try await memberList.loadMoreMembers(limit: limit)
     }
     
@@ -468,7 +468,7 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadMessages(before messageId: MessageId?, limit: Int? = nil) async throws {
+    public func loadMessages(before messageId: MessageId?, limit: Int = 25) async throws {
         try await channelUpdater.loadMessages(
             before: messageId,
             limit: limit,
@@ -484,7 +484,7 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadMessages(after messageId: MessageId?, limit: Int? = nil) async throws {
+    public func loadMessages(after messageId: MessageId?, limit: Int = 25) async throws {
         try await channelUpdater.loadMessages(
             after: messageId,
             limit: limit,
@@ -504,7 +504,7 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadMessages(around messageId: MessageId, limit: Int? = nil) async throws {
+    public func loadMessages(around messageId: MessageId, limit: Int = 25) async throws {
         try await channelUpdater.loadMessages(
             around: messageId,
             limit: limit,
@@ -518,7 +518,7 @@ public class Chat {
     /// - Parameter limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadOlderMessages(limit: Int? = nil) async throws {
+    public func loadOlderMessages(limit: Int = 25) async throws {
         try await loadMessages(before: nil, limit: limit)
     }
     
@@ -527,7 +527,7 @@ public class Chat {
     /// - Parameter limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadNewerMessages(limit: Int? = nil) async throws {
+    public func loadNewerMessages(limit: Int = 25) async throws {
         try await loadMessages(after: nil, limit: limit)
     }
     
@@ -644,7 +644,7 @@ public class Chat {
     public func loadPinnedMessages(
         with pagination: PinnedMessagesPagination? = nil,
         sort: [Sorting<PinnedMessagesSortingKey>] = [],
-        limit: Int = .messagesPageSize
+        limit: Int = 25
     ) async throws -> [ChatMessage] {
         let query = PinnedMessagesQuery(
             pageSize: limit,
@@ -726,10 +726,10 @@ public class Chat {
     /// - Returns: An array of reactions for the next page.
     @discardableResult public func loadMoreReactions(
         for messageId: MessageId,
-        limit: Int? = nil
+        limit: Int = 25
     ) async throws -> [ChatMessageReaction] {
         let offset = try await messageState(for: messageId).reactions.count
-        let pagination = Pagination(pageSize: limit ?? 25, offset: offset)
+        let pagination = Pagination(pageSize: limit, offset: offset)
         return try await messageUpdater.loadReactions(
             cid: cid,
             messageId: messageId,
@@ -855,7 +855,7 @@ public class Chat {
     public func loadReplies(
         before replyId: MessageId?,
         for parentMessageId: MessageId,
-        limit: Int? = nil
+        limit: Int = 25
     ) async throws {
         let messageState = try await messageState(for: parentMessageId)
         return try await messageUpdater.loadReplies(
@@ -878,7 +878,7 @@ public class Chat {
     public func loadReplies(
         after replyId: MessageId?,
         for parentMessageId: MessageId,
-        limit: Int? = nil
+        limit: Int = 25
     ) async throws {
         let messageState = try await messageState(for: parentMessageId)
         return try await messageUpdater.loadReplies(
@@ -903,7 +903,7 @@ public class Chat {
     public func loadReplies(
         around replyId: MessageId,
         for parentMessageId: MessageId,
-        limit: Int? = nil
+        limit: Int = 25
     ) async throws {
         let messageState = try await messageState(for: parentMessageId)
         return try await messageUpdater.loadReplies(
@@ -922,7 +922,7 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadOlderReplies(for parentMessageId: MessageId, limit: Int? = nil) async throws {
+    public func loadOlderReplies(for parentMessageId: MessageId, limit: Int = 25) async throws {
         try await loadReplies(before: nil, for: parentMessageId, limit: limit)
     }
     
@@ -933,7 +933,7 @@ public class Chat {
     ///   - limit: The limit for the page size. The default limit is 25.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func loadNewerReplies(for parentMessageId: MessageId, limit: Int? = nil) async throws {
+    public func loadNewerReplies(for parentMessageId: MessageId, limit: Int = 25) async throws {
         try await loadReplies(after: nil, for: parentMessageId, limit: limit)
     }
     
@@ -1293,9 +1293,9 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded watchers.
-    @discardableResult public func loadMoreWatchers(limit: Int? = nil) async throws -> [ChatUser] {
+    @discardableResult public func loadMoreWatchers(limit: Int = 30) async throws -> [ChatUser] {
         let count = await state.watchers.count
-        let pagination = Pagination(pageSize: limit ?? .channelWatchersPageSize, offset: count)
+        let pagination = Pagination(pageSize: limit, offset: count)
         return try await loadWatchers(with: pagination)
     }
 }

--- a/Sources/StreamChat/StateLayer/MemberList.swift
+++ b/Sources/StreamChat/StateLayer/MemberList.swift
@@ -53,9 +53,8 @@ public final class MemberList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of channel members.
-    @discardableResult public func loadMoreMembers(limit: Int? = nil) async throws -> [ChatChannelMember] {
-        let pageSize = limit ?? Int.channelMembersPageSize
-        let pagination = Pagination(pageSize: pageSize, offset: await state.members.count)
+    @discardableResult public func loadMoreMembers(limit: Int = 30) async throws -> [ChatChannelMember] {
+        let pagination = Pagination(pageSize: limit, offset: await state.members.count)
         return try await loadMembers(with: pagination)
     }
 }

--- a/Sources/StreamChat/StateLayer/MessageSearch.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearch.swift
@@ -70,9 +70,8 @@ public class MessageSearch {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: A next page of chat messages matching to the last query.
-    @discardableResult public func loadMoreMessages(limit: Int? = nil) async throws -> [ChatMessage] {
+    @discardableResult public func loadMoreMessages(limit: Int = 25) async throws -> [ChatMessage] {
         guard let query = await state.query else { throw ClientError("Call search() before calling for next page") }
-        let limit = (limit ?? query.pagination?.pageSize) ?? Int.messagesPageSize
         let pagination: Pagination = await {
             if !query.sort.isEmpty, let nextPageCursor = await state.nextPageCursor {
                 return Pagination(pageSize: limit, cursor: nextPageCursor)

--- a/Sources/StreamChat/StateLayer/ReactionList.swift
+++ b/Sources/StreamChat/StateLayer/ReactionList.swift
@@ -54,9 +54,8 @@ public final class ReactionList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of message reactions.
-    @discardableResult public func loadMoreReactions(limit: Int? = nil) async throws -> [ChatMessageReaction] {
-        let pageSize = limit ?? 25
-        let pagination = Pagination(pageSize: pageSize, offset: await state.reactions.count)
+    @discardableResult public func loadMoreReactions(limit: Int = 25) async throws -> [ChatMessageReaction] {
+        let pagination = Pagination(pageSize: limit, offset: await state.reactions.count)
         return try await loadReactions(with: pagination)
     }
 }

--- a/Sources/StreamChat/StateLayer/UserList.swift
+++ b/Sources/StreamChat/StateLayer/UserList.swift
@@ -55,11 +55,14 @@ public final class UserList {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
-    @discardableResult public func loadMoreUsers(limit: Int? = nil) async throws -> [ChatUser] {
+    @discardableResult public func loadMoreUsers(limit: Int = 30) async throws -> [ChatUser] {
         let state = await self.state
-        let limit = (limit ?? state.query.pagination?.pageSize) ?? Int.usersPageSize
         let offset = await state.users.count
-        return try await userListUpdater.loadNextUsers(state.query, limit: limit, offset: offset)
+        return try await userListUpdater.loadNextUsers(
+            state.query,
+            limit: limit,
+            offset: offset
+        )
     }
 }
 

--- a/Sources/StreamChat/StateLayer/UserSearch.swift
+++ b/Sources/StreamChat/StateLayer/UserSearch.swift
@@ -50,9 +50,8 @@ public class UserSearch {
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of loaded channels.
-    @discardableResult public func loadMoreUsers(limit: Int? = nil) async throws -> [ChatUser] {
+    @discardableResult public func loadMoreUsers(limit: Int = 30) async throws -> [ChatUser] {
         guard let query = await state.query else { throw ClientError("Call search() before calling for next page") }
-        let limit = (limit ?? query.pagination?.pageSize) ?? .usersPageSize
         let offset = await state.users.count
         let pagination = Pagination(pageSize: limit, offset: offset)
         return try await search(query: query, pagination: pagination)

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -952,32 +952,29 @@ extension ChannelUpdater {
         return try await messageRepository.messages(from: fromDate, to: toDate, in: cid)
     }
     
-    func loadMessages(before messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
+    func loadMessages(before messageId: MessageId?, limit: Int, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingPreviousMessages else { return }
         guard !paginationState.hasLoadedAllPreviousMessages else { return }
         let lastLocalMessageId: () -> MessageId? = { loaded.last { !$0.isLocalOnly }?.id }
         guard let messageId = messageId ?? paginationState.oldestFetchedMessage?.id ?? lastLocalMessageId() else {
             throw ClientError.ChannelEmptyMessages()
         }
-        let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .lessThan(messageId))
         try await update(channelQuery: channelQuery.withPagination(pagination))
     }
 
-    func loadMessages(after messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
+    func loadMessages(after messageId: MessageId?, limit: Int, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingNextMessages else { return }
         guard !paginationState.hasLoadedAllNextMessages else { return }
         guard let messageId = messageId ?? paginationState.newestFetchedMessage?.id ?? loaded.first?.id else {
             throw ClientError.ChannelEmptyMessages()
         }
-        let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .greaterThan(messageId))
         try await update(channelQuery: channelQuery.withPagination(pagination))
     }
         
-    func loadMessages(around messageId: MessageId, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
+    func loadMessages(around messageId: MessageId, limit: Int, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingMiddleMessages else { return }
-        let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .around(messageId))
         try await update(channelQuery: channelQuery.withPagination(pagination))
     }

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -971,39 +971,59 @@ extension MessageUpdater {
     
     // MARK: -
     
-    func loadReplies(for parentMessageId: MessageId, pagination: MessagesPagination, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws -> [ChatMessage] {
+    func loadReplies(
+        for parentMessageId: MessageId,
+        pagination: MessagesPagination,
+        cid: ChannelId,
+        paginationStateHandler: MessagesPaginationStateHandling
+    ) async throws -> [ChatMessage] {
         let payload = try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
         guard let fromDate = payload.messages.first?.createdAt else { return [] }
         guard let toDate = payload.messages.last?.createdAt else { return [] }
         return try await repository.replies(from: fromDate, to: toDate, in: parentMessageId)
     }
     
-    func loadReplies(for parentMessageId: MessageId, before replyId: MessageId?, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
+    func loadReplies(
+        for parentMessageId: MessageId,
+        before replyId: MessageId?,
+        limit: Int,
+        cid: ChannelId,
+        paginationStateHandler: MessagesPaginationStateHandling
+    ) async throws {
         guard !paginationStateHandler.state.hasLoadedAllPreviousMessages else { return }
         guard !paginationStateHandler.state.isLoadingPreviousMessages else { return }
         guard let replyId = replyId ?? paginationStateHandler.state.oldestFetchedMessage?.id else {
             throw ClientError.MessageEmptyReplies()
         }
-        let pageSize = limit ?? .messagesPageSize
-        let pagination = MessagesPagination(pageSize: pageSize, parameter: .lessThan(replyId))
+        let pagination = MessagesPagination(pageSize: limit, parameter: .lessThan(replyId))
         try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
     }
     
-    func loadReplies(for parentMessageId: MessageId, after replyId: MessageId?, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
+    func loadReplies(
+        for parentMessageId: MessageId,
+        after replyId: MessageId?,
+        limit: Int,
+        cid: ChannelId,
+        paginationStateHandler: MessagesPaginationStateHandling
+    ) async throws {
         guard !paginationStateHandler.state.hasLoadedAllNextMessages else { return }
         guard !paginationStateHandler.state.isLoadingNextMessages else { return }
         guard let replyId = replyId ?? paginationStateHandler.state.newestFetchedMessage?.id else {
             throw ClientError.MessageEmptyReplies()
         }
-        let pageSize = limit ?? .messagesPageSize
-        let pagination = MessagesPagination(pageSize: pageSize, parameter: .greaterThan(replyId))
+        let pagination = MessagesPagination(pageSize: limit, parameter: .greaterThan(replyId))
         try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
     }
     
-    func loadReplies(for parentMessageId: MessageId, around replyId: MessageId, limit: Int?, cid: ChannelId, paginationStateHandler: MessagesPaginationStateHandling) async throws {
+    func loadReplies(
+        for parentMessageId: MessageId,
+        around replyId: MessageId,
+        limit: Int,
+        cid: ChannelId,
+        paginationStateHandler: MessagesPaginationStateHandling
+    ) async throws {
         guard !paginationStateHandler.state.isLoadingMiddleMessages else { return }
-        let pageSize = limit ?? .messagesPageSize
-        let pagination = MessagesPagination(pageSize: pageSize, parameter: .around(replyId))
+        let pagination = MessagesPagination(pageSize: limit, parameter: .around(replyId))
         try await loadReplies(cid: cid, messageId: parentMessageId, pagination: pagination, paginationStateHandler: paginationStateHandler)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

A proposal to use non-optionals for `limit`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
