### PR TITLE
Do not retry rate-limited requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
 ### 🔄 Changed
+- Do not retry rate-limited requests [#3182](https://github.com/GetStream/stream-chat-swift/pull/3182)
 
 # [4.54.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.54.0)
 _May 06, 2024_

--- a/Sources/StreamChat/APIClient/RequestDecoder.swift
+++ b/Sources/StreamChat/APIClient/RequestDecoder.swift
@@ -116,10 +116,6 @@ extension ClientError {
             return true
         }
 
-        if error.isRateLimitError {
-            return true
-        }
-
         return false
     }
 }

--- a/Tests/StreamChatTests/Errors/ClientError_Tests.swift
+++ b/Tests/StreamChatTests/Errors/ClientError_Tests.swift
@@ -43,7 +43,7 @@ final class ClientError_Tests: XCTestCase {
         XCTAssertFalse(clientError.isInvalidTokenError)
     }
 
-    func test_rateLimitError_isEphemeralError() {
+    func test_rateLimitError_isNotEphemeralError() {
         let errorPayload = ErrorPayload(
             code: 9,
             message: .unique,
@@ -52,9 +52,8 @@ final class ClientError_Tests: XCTestCase {
 
         let error = ClientError(with: errorPayload)
 
-        // Assert `isRateLimitError` returns true
         XCTAssertTrue(error.isRateLimitError)
-        XCTAssertTrue(ClientError.isEphemeral(error: error))
+        XCTAssertFalse(ClientError.isEphemeral(error: error))
     }
 
     func test_temporaryErrors_areEphemeralError() {


### PR DESCRIPTION
### 🔗 Issue Links
Relates to https://github.com/GetStream/ios-issues-tracking/issues/800

### 🎯 Goal
Do not retry rate-limited requests.

The requests will 100% fail, so it does not make sense to retry them. 

### 🧪 Manual Testing Notes
1. Open Proxyman
2. Use the rewrite tool
3. Select one of the requests to rewrite
4. Change the status code to: `HTTP/1.1 429 Too Many Requests`
5. Change the response to:
```
{
  "StatusCode": 429,
  "code": 0,
  "details": [
    0
  ],
  "duration": "string",
  "exception_fields": {
    "additionalProp1": "string",
    "additionalProp2": "string",
    "additionalProp3": "string"
  },
  "message": "string",
  "more_info": "string"
}
```
6. When the response fails, it should not retry.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
