### PR TITLE
Improve channel list performance by enabling reconfigure cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix triggering user query calls whenever a new user was added in `UserListController` [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)
 - Fix duplicated watching channel calls when reconnecting [#3187](https://github.com/GetStream/stream-chat-swift/pull/3187)
 - Fix `/sync` call failing because of surpassing the 255 channels limit [#3188](https://github.com/GetStream/stream-chat-swift/pull/3188)
+- Improve channel list performance by enabling reconfigure cells [#3186](https://github.com/GetStream/stream-chat-swift/pull/3186)
 ### 🔄 Changed
 - Do not retry rate-limited requests [#3182](https://github.com/GetStream/stream-chat-swift/pull/3182)
 - `UserListController` won't update automatically when a new user is added [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/790](https://github.com/GetStream/ios-issues-tracking/issues/790)

### 🎯 Goal

Enable cell reconfiguring and guard against reentrancy which led to an assertion in Apple's code/

### 📝 Summary

* Enable cell reconfiguring in channel list which makes it much faster
* Guard against reentrancy which can happen if reconfigure cells call ends up triggering Core Data store change which is then picked up by database observers (and leads to calling reloadChannels again)

### 🧪 Manual Testing Notes

Exploratory testing:
Open channel list and trigger channel list changes (e.g. new messages arriving)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
