### PR TITLE
Fix duplicated watching channel calls when reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix triggering user query calls whenever a new user was added in `UserListController` [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)
+- Fix duplicated watching channel calls when reconnecting [#3187](https://github.com/GetStream/stream-chat-swift/pull/3187)
 ### 🔄 Changed
 - Do not retry rate-limited requests [#3182](https://github.com/GetStream/stream-chat-swift/pull/3182)
 - `UserListController` won't update automatically when a new user is added [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -423,12 +423,27 @@ public class ChatClient {
         ]
     }
 
-    func trackChannelController(_ channelController: ChatChannelController) {
+    func startTrackingChannelController(_ channelController: ChatChannelController) {
+        // If it is already tracking, do nothing.
+        guard !activeChannelControllers.contains(channelController) else {
+            return
+        }
         activeChannelControllers.add(channelController)
     }
 
-    func trackChannelListController(_ channelListController: ChatChannelListController) {
+    func stopTrackingChannelController(_ channelController: ChatChannelController) {
+        activeChannelControllers.remove(channelController)
+    }
+
+    func startTrackingChannelListController(_ channelListController: ChatChannelListController) {
+        guard !activeChannelListControllers.contains(channelListController) else {
+            return
+        }
         activeChannelListControllers.add(channelListController)
+    }
+
+    func stopTrackingChannelListController(_ channelListController: ChatChannelListController) {
+        activeChannelListControllers.remove(channelListController)
     }
 
     func completeConnectionIdWaiters(connectionId: String?) {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1020,6 +1020,9 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             channelModificationFailed(completion)
             return
         }
+
+        client.startTrackingChannelController(self)
+
         updater.startWatching(cid: cid, isInRecoveryMode: isInRecoveryMode) { error in
             self.state = error.map { .remoteDataFetchFailed(ClientError(with: $0)) } ?? .remoteDataFetched
             self.callback {
@@ -1051,6 +1054,9 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             channelModificationFailed(completion)
             return
         }
+
+        client.stopTrackingChannelController(self)
+
         updater.stopWatching(cid: cid) { error in
             self.state = error.map { .remoteDataFetchFailed(ClientError(with: $0)) } ?? .localDataFetched
             self.callback {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -218,11 +218,10 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
 
         setChannelObserver()
         setMessagesObserver()
-
-        client.trackChannelController(self)
     }
 
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        client.startTrackingChannelController(self)
         synchronize(isInRecoveryMode: false, completion)
     }
 

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -140,12 +140,12 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         self.environment = environment
         eventsController = client.eventsController()
         super.init()
-        client.trackChannelListController(self)
         eventsController.delegate = self
     }
 
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
         startChannelListObserverIfNeeded()
+        client.startTrackingChannelListController(self)
         updateChannelList(completion)
     }
 

--- a/Sources/StreamChat/Utils/ThreadSafeWeakCollection.swift
+++ b/Sources/StreamChat/Utils/ThreadSafeWeakCollection.swift
@@ -24,9 +24,15 @@ final class ThreadSafeWeakCollection<T: AnyObject> {
         return count
     }
 
-    func add(_ object: T?) {
+    func add(_ object: T) {
         queue.async(flags: .barrier) {
             self.storage.add(object)
+        }
+    }
+
+    func remove(_ object: T) {
+        queue.async(flags: .barrier) {
+            self.storage.remove(object)
         }
     }
 

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -307,8 +307,8 @@ final class ChatClient_Tests: XCTestCase {
         )
         let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
         connectionRepository.disconnectResult = .success(())
-        client.trackChannelController(ChannelControllerSpy())
-        client.trackChannelListController(ChatChannelListController_Mock.mock())
+        client.startTrackingChannelController(ChannelControllerSpy())
+        client.startTrackingChannelListController(ChatChannelListController_Mock.mock())
 
         XCTAssertEqual(client.activeChannelControllers.count, 1)
         XCTAssertEqual(client.activeChannelListControllers.count, 1)
@@ -823,6 +823,70 @@ final class ChatClient_Tests: XCTestCase {
         }
 
         XCTAssertEqual(streamHeader, SystemEnvironment.xStreamClientHeader)
+    }
+
+    // MARK: - Active Controller
+
+    func test_startTrackingChannelController() {
+        let client = ChatClient(config: .init())
+
+        let controller = ChatChannelController_Mock.mock()
+        client.startTrackingChannelController(controller)
+
+        XCTAssertTrue(client.activeChannelControllers.allObjects.first === controller)
+    }
+
+    func test_startTrackingChannelController_whenAlreadyExists_thenDoNotDuplicate() {
+        let client = ChatClient(config: .init())
+
+        let controller = ChatChannelController_Mock.mock()
+        client.startTrackingChannelController(controller)
+        client.startTrackingChannelController(controller)
+
+        XCTAssertTrue(client.activeChannelControllers.allObjects.first === controller)
+        XCTAssertEqual(client.activeChannelControllers.allObjects.count, 1)
+    }
+
+    func test_stopTrackingChannelController() {
+        let client = ChatClient(config: .init())
+        let controller = ChatChannelController_Mock.mock()
+        client.startTrackingChannelController(controller)
+        XCTAssertEqual(client.activeChannelControllers.allObjects.count, 1)
+
+        client.stopTrackingChannelController(controller)
+
+        XCTAssertTrue(client.activeChannelControllers.allObjects.isEmpty)
+    }
+
+    func test_startTrackingChannelListController() {
+        let client = ChatClient(config: .init())
+
+        let controller = ChatChannelListController_Mock.mock()
+        client.startTrackingChannelListController(controller)
+
+        XCTAssertTrue(client.activeChannelListControllers.allObjects.first === controller)
+    }
+
+    func test_startTrackingChannelListController_whenAlreadyExists_thenDoNotDuplicate() {
+        let client = ChatClient(config: .init())
+
+        let controller = ChatChannelListController_Mock.mock()
+        client.startTrackingChannelListController(controller)
+        client.startTrackingChannelListController(controller)
+
+        XCTAssertTrue(client.activeChannelListControllers.allObjects.first === controller)
+        XCTAssertEqual(client.activeChannelListControllers.allObjects.count, 1)
+    }
+
+    func test_stopTrackingChannelListController() {
+        let client = ChatClient(config: .init())
+        let controller = ChatChannelListController_Mock.mock()
+        client.startTrackingChannelListController(controller)
+        XCTAssertEqual(client.activeChannelListControllers.allObjects.count, 1)
+
+        client.stopTrackingChannelListController(controller)
+
+        XCTAssertTrue(client.activeChannelListControllers.allObjects.isEmpty)
     }
 }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -4545,6 +4545,23 @@ final class ChannelController_Tests: XCTestCase {
         }
     }
 
+    func test_startWatching_tracksActiveChannelController() {
+        let client = ChatClient.mock
+        let channelQuery = ChannelQuery(cid: channelId)
+        let channelListQuery = ChannelListQuery(filter: .containMembers(userIds: [.unique]))
+        let controller = ChatChannelController(
+            channelQuery: channelQuery,
+            channelListQuery: channelListQuery,
+            client: client
+        )
+        XCTAssert(client.activeChannelControllers.allObjects.isEmpty)
+
+        controller.startWatching(isInRecoveryMode: false)
+        XCTAssert(controller.client === client)
+        XCTAssert(client.activeChannelControllers.count == 1)
+        XCTAssert(client.activeChannelControllers.allObjects.first === controller)
+    }
+
     func test_startWatching_propagatesErrorFromUpdater() {
         // Simulate `startWatching` call and catch the completion
         var completionCalledError: Error?
@@ -4711,6 +4728,22 @@ final class ChannelController_Tests: XCTestCase {
 
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+    }
+
+    func test_stopWatching_removesActiveChannelController() {
+        let client = ChatClient.mock
+        let channelQuery = ChannelQuery(cid: channelId)
+        let channelListQuery = ChannelListQuery(filter: .containMembers(userIds: [.unique]))
+        let controller = ChatChannelController(
+            channelQuery: channelQuery,
+            channelListQuery: channelListQuery,
+            client: client
+        )
+        controller.synchronize()
+        XCTAssert(client.activeChannelControllers.count == 1)
+
+        controller.stopWatching()
+        XCTAssert(client.activeChannelControllers.allObjects.isEmpty == true)
     }
 
     // MARK: - Freeze channel

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -5045,9 +5045,9 @@ final class ChannelController_Tests: XCTestCase {
         AssertAsync.staysTrue(weakController != nil)
     }
 
-    // MARK: Init registers active controller
+    // MARK: Synchronize registers active controller
 
-    func test_initRegistersActiveController() {
+    func test_synchronize_shouldRegistersActiveController() {
         let client = ChatClient.mock
         let channelQuery = ChannelQuery(cid: channelId)
         let channelListQuery = ChannelListQuery(filter: .containMembers(userIds: [.unique]))
@@ -5057,6 +5057,8 @@ final class ChannelController_Tests: XCTestCase {
             channelListQuery: channelListQuery,
             client: client
         )
+
+        controller.synchronize()
 
         XCTAssert(controller.client === client)
         XCTAssert(client.activeChannelControllers.count == 1)

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1060,12 +1060,13 @@ final class ChannelListController_Tests: XCTestCase {
         )
     }
 
-    // MARK: Init registers active controller
+    // MARK: Synchronize registers active controller
 
-    func test_initRegistersActiveController() {
+    func test_synchronize_shouldRegistersActiveController() {
         let client = ChatClient.mock
         let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
         let controller = ChatChannelListController(query: query, client: client, environment: env.environment)
+        controller.synchronize()
 
         XCTAssert(controller.client === client)
         XCTAssert(client.activeChannelListControllers.count == 1)

--- a/Tests/StreamChatTests/Utils/ThreadSafeWeakCollection_Tests.swift
+++ b/Tests/StreamChatTests/Utils/ThreadSafeWeakCollection_Tests.swift
@@ -14,7 +14,9 @@ final class ThreadSafeWeakCollection_Tests: XCTestCase {
             _ = collection.allObjects
         }
         DispatchQueue.concurrentPerform(iterations: 100) { _ in
-            collection.add(NSObject())
+            let object = NSObject()
+            collection.add(object)
+            collection.remove(object)
         }
         DispatchQueue.concurrentPerform(iterations: 100) { _ in
             collection.removeAllObjects()


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/800

### 🎯 Goal

Fix having duplicated watching channel calls after reconnection logic.

Context: Whenever we reconnect, if the user is watching channels, we track these channels and re-watch them. 

### 📝 Summary
This was because we were incorrectly adding a channel controller to `activeChannelControllers` whenever we created a controller. This is wrong; we should only add it when we call synchronize or start watching a channel. Only in this scenario do we need to track a channel. 

Besides this, we did not control whether we already had a channel in the `activeChannelControllers`. So, there were cases where we had duplicated active channel controllers, and whenever a reconnection happened, it would trigger duplicated watch calls.

Lastly, even if a channel is open, if the customer stops watching the channel, it should not be in the `activeChannelControllers`. This was also missing.

### 🧪 Manual Testing Notes
1- Open Proxyman
2- Open Demo App Configuration and setup token refresh with 15s
3- Open the Channel List
4- Wait for reconnection
5- No channel query call should be made (Do not confuse with channel list call)
6- Open and close a few channels
7- 4. and 5.
8- Open a channel, and remain open
9- When reconnecting the a watch call should be made for the open channel

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)