### PR TITLE
Only sync at most 250 channels at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix triggering user query calls whenever a new user was added in `UserListController` [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)
 - Fix duplicated watching channel calls when reconnecting [#3187](https://github.com/GetStream/stream-chat-swift/pull/3187)
+- Fix `/sync` call failing because of surpassing the 255 channels limit [#3188](https://github.com/GetStream/stream-chat-swift/pull/3188)
 ### 🔄 Changed
 - Do not retry rate-limited requests [#3182](https://github.com/GetStream/stream-chat-swift/pull/3182)
 - `UserListController` won't update automatically when a new user is added [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -191,7 +191,7 @@ class SyncRepository {
     private func getChannelIds(completion: @escaping ([ChannelId]) -> Void) {
         database.backgroundReadOnlyContext.perform {
             let request = ChannelDTO.allChannelsFetchRequest
-            request.fetchLimit = 1000
+            request.fetchLimit = 250
             request.propertiesToFetch = ["cid"]
             let channels = (try? self.database.backgroundReadOnlyContext.fetch(request)) ?? []
             completion(channels.compactMap { try? ChannelId(cid: $0.cid) })


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/792

### 🎯 Goal
Fixes trying to sync more than 255 channels at the same time. (Backend limit)

### 📝 Summary
Changes the limit to 250, and it should be more than enough. At most, customers will have about 100 active channels at the same time, and even then, it wouldn't be a big deal if all channels where not synced. Only the most recents are important, and eventually, they will be refetched anyways. 

The reason we could hit 255+ channels syncing is that we never erase the channels from the DB; we just unlink them from the queries. So, there could be a case where a user could have more than 255 channels in their local DB, with really old channels. 

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
