### PR TITLE
[ChatStateLayer] Use a single channel list linker for linking and unlinking channels f…

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -38,8 +38,6 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     /// The `ChatClient` instance this controller belongs to.
     public let client: ChatClient
 
-    let eventsController: EventsController
-
     /// The channels matching the query of this controller.
     ///
     /// To observe changes of the channels, set your class as a delegate of this controller or use the provided
@@ -142,9 +140,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         self.query = query
         self.filter = filter
         self.environment = environment
-        eventsController = client.eventsController()
         super.init()
-        eventsController.delegate = self
     }
 
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
@@ -258,10 +254,6 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
             log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
         }
     }
-}
-
-extension ChatChannelListController: EventsControllerDelegate {
-    public func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {}
 }
 
 extension ChatChannelListController {

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -9,11 +9,11 @@ extension ChannelListState {
     final class Observer {
         private let channelListObserver: StateLayerDatabaseObserver<ListResult, ChatChannel, ChannelDTO>
         private let clientConfig: ChatClientConfig
+        private let channelListLinker: ChannelListLinker
         private let channelListUpdater: ChannelListUpdater
         private let database: DatabaseContainer
         private let dynamicFilter: ((ChatChannel) -> Bool)?
         private let eventNotificationCenter: EventNotificationCenter
-        private var eventObservers = [EventObserver]()
         private let query: ChannelListQuery
         
         init(
@@ -40,6 +40,13 @@ extension ChannelListState {
                 itemCreator: { try $0.asModel() },
                 sorting: query.sort.runtimeSorting
             )
+            channelListLinker = ChannelListLinker(
+                query: query,
+                filter: dynamicFilter,
+                clientConfig: clientConfig,
+                databaseContainer: database,
+                worker: channelListUpdater
+            )
         }
         
         struct Handlers {
@@ -47,100 +54,13 @@ extension ChannelListState {
         }
         
         func start(with handlers: Handlers) -> StreamCollection<ChatChannel> {
-            /// When we receive events, we need to check if a channel should be added or removed from
-            /// the current query depending on the following events:
-            /// - Channel created: We analyse if the channel should be added to the current query.
-            /// - New message sent: This means the channel will reorder and appear on first position,
-            ///   so we also analyse if it should be added to the current query.
-            /// - Channel is updated: We only check if we should remove it from the current query.
-            ///   We don't try to add it to the current query to not mess with pagination.
-            let nc = eventNotificationCenter
-            eventObservers = [
-                EventObserver(
-                    notificationCenter: nc,
-                    transform: { $0 as? NotificationAddedToChannelEvent }
-                ) { [weak self] event in
-                    try await self?.linkChannelIfNeeded(event.channel)
-                },
-                EventObserver(
-                    notificationCenter: nc,
-                    transform: { $0 as? MessageNewEvent },
-                    callback: { [weak self] event in
-                        try await self?.linkChannelIfNeeded(event.channel)
-                    }
-                ),
-                EventObserver(
-                    notificationCenter: nc,
-                    transform: { $0 as? NotificationMessageNewEvent },
-                    callback: { [weak self] event in
-                        try await self?.linkChannelIfNeeded(event.channel)
-                    }
-                ),
-                EventObserver(
-                    notificationCenter: nc,
-                    transform: { $0 as? ChannelUpdatedEvent },
-                    callback: { [weak self] event in
-                        try await self?.unlinkChannelIfNeeded(event.channel)
-                    }
-                ),
-                EventObserver(
-                    notificationCenter: nc,
-                    transform: { $0 as? ChannelVisibleEvent },
-                    callback: { [weak self] event in
-                        guard let self else { return }
-                        let channel = try await self.database.read { context in
-                            guard let dto = ChannelDTO.load(cid: event.cid, context: context) else {
-                                throw ClientError.ChannelDoesNotExist(cid: event.cid)
-                            }
-                            return try dto.asModel()
-                        }
-                        try await self.linkChannelIfNeeded(channel)
-                    }
-                )
-            ]
-            
             do {
+                channelListLinker.start(with: eventNotificationCenter)
                 return try channelListObserver.startObserving(didChange: handlers.channelsDidChange)
             } catch {
                 log.error("Failed to start the channel list observer for query: \(query)")
                 return StreamCollection([])
             }
-        }
-        
-        // MARK: Linking and Unlinking Channels from the Query
-        
-        private func isBelongingToChannelListQuery(channel: ChatChannel) -> Bool {
-            if let filter = dynamicFilter {
-                return filter(channel)
-            }
-            // When auto-filtering is enabled the channel will appear or not automatically if the
-            // query matches the DB Predicate. So here we default to saying it always belong to the current query.
-            if clientConfig.isChannelAutomaticFilteringEnabled {
-                return true
-            }
-            return false
-        }
-        
-        private func isChannelInList(_ cid: ChannelId) async throws -> Bool {
-            try await database.read { [query] context in
-                guard let (channelDTO, queryDTO) = context.getChannelWithQuery(cid: cid, query: query) else { return false }
-                return queryDTO.channels.contains(channelDTO)
-            }
-        }
-        
-        private func linkChannelIfNeeded(_ channel: ChatChannel) async throws {
-            let listContainsChannel = try await isChannelInList(channel.cid)
-            guard !listContainsChannel else { return }
-            guard isBelongingToChannelListQuery(channel: channel) else { return }
-            try await channelListUpdater.link(channel: channel, with: query)
-            try await channelListUpdater.startWatchingChannels(withIds: [channel.cid])
-        }
-        
-        private func unlinkChannelIfNeeded(_ channel: ChatChannel) async throws {
-            let listContainsChannel = try await isChannelInList(channel.cid)
-            guard listContainsChannel else { return }
-            guard !isBelongingToChannelListQuery(channel: channel) else { return }
-            try await channelListUpdater.unlink(channel: channel, with: query)
         }
     }
 }

--- a/Sources/StreamChat/Workers/ChannelListLinker.swift
+++ b/Sources/StreamChat/Workers/ChannelListLinker.swift
@@ -1,0 +1,128 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// When we receive events, we need to check if a channel should be added or removed from
+/// the current query depending on the following events:
+/// - Channel created: We analyse if the channel should be added to the current query.
+/// - New message sent: This means the channel will reorder and appear on first position,
+///   so we also analyse if it should be added to the current query.
+/// - Channel is updated: We only check if we should remove it from the current query.
+///   We don't try to add it to the current query to not mess with pagination.
+final class ChannelListLinker {
+    private let clientConfig: ChatClientConfig
+    private let databaseContainer: DatabaseContainer
+    private var eventObservers = [EventObserver]()
+    private let filter: ((ChatChannel) -> Bool)?
+    private let query: ChannelListQuery
+    private let worker: ChannelListUpdater
+    
+    init(
+        query: ChannelListQuery,
+        filter: ((ChatChannel) -> Bool)?,
+        clientConfig: ChatClientConfig,
+        databaseContainer: DatabaseContainer,
+        worker: ChannelListUpdater
+    ) {
+        self.clientConfig = clientConfig
+        self.databaseContainer = databaseContainer
+        self.filter = filter
+        self.query = query
+        self.worker = worker
+    }
+    
+    func start(with nc: EventNotificationCenter) {
+        guard eventObservers.isEmpty else { return }
+        eventObservers = [
+            EventObserver(
+                notificationCenter: nc,
+                transform: { $0 as? NotificationAddedToChannelEvent }
+            ) { [weak self] event in self?.linkChannelIfNeeded(event.channel) },
+            EventObserver(
+                notificationCenter: nc,
+                transform: { $0 as? MessageNewEvent },
+                callback: { [weak self] event in self?.linkChannelIfNeeded(event.channel) }
+            ),
+            EventObserver(
+                notificationCenter: nc,
+                transform: { $0 as? NotificationMessageNewEvent },
+                callback: { [weak self] event in self?.linkChannelIfNeeded(event.channel) }
+            ),
+            EventObserver(
+                notificationCenter: nc,
+                transform: { $0 as? ChannelUpdatedEvent },
+                callback: { [weak self] event in self?.unlinkChannelIfNeeded(event.channel) }
+            ),
+            EventObserver(
+                notificationCenter: nc,
+                transform: { $0 as? ChannelVisibleEvent },
+                callback: { [weak self, databaseContainer] event in
+                    let context = databaseContainer.backgroundReadOnlyContext
+                    context.perform {
+                        guard let channel = try? context.channel(cid: event.cid)?.asModel() else { return }
+                        self?.linkChannelIfNeeded(channel)
+                    }
+                }
+            )
+        ]
+    }
+
+    private func isInChannelList(_ channel: ChatChannel, completion: @escaping (Bool) -> Void) {
+        let context = databaseContainer.backgroundReadOnlyContext
+        context.performAndWait { [weak self] in
+            guard let self else { return }
+            if let (channelDTO, queryDTO) = context.getChannelWithQuery(cid: channel.cid, query: self.query) {
+                let isPresent = queryDTO.channels.contains(channelDTO)
+                completion(isPresent)
+            } else {
+                completion(false)
+            }
+        }
+    }
+    
+    /// Handles if a channel should be linked to the current query or not.
+    private func linkChannelIfNeeded(_ channel: ChatChannel) {
+        guard shouldChannelBelongToCurrentQuery(channel) else { return }
+        isInChannelList(channel) { [worker, query] exists in
+            guard !exists else { return }
+            worker.link(channel: channel, with: query) { error in
+                if let error = error {
+                    log.error(error)
+                    return
+                }
+                worker.startWatchingChannels(withIds: [channel.cid]) { error in
+                    guard let error = error else { return }
+                    log.warning(
+                        "Failed to start watching linked channel: \(channel.cid), error: \(error.localizedDescription)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Handles if a channel should be unlinked from the current query or not.
+    private func unlinkChannelIfNeeded(_ channel: ChatChannel) {
+        guard !shouldChannelBelongToCurrentQuery(channel) else { return }
+        isInChannelList(channel) { [worker, query] exists in
+            guard exists else { return }
+            worker.unlink(channel: channel, with: query)
+        }
+    }
+
+    /// Checks if the given channel should belong to the current query or not.
+    private func shouldChannelBelongToCurrentQuery(_ channel: ChatChannel) -> Bool {
+        if let filter = filter {
+            return filter(channel)
+        }
+
+        if clientConfig.isChannelAutomaticFilteringEnabled {
+            // When auto-filtering is enabled the channel will appear or not automatically if the
+            // query matches the DB Predicate. So here we default to saying it always belong to the current query.
+            return true
+        }
+
+        return false
+    }
+}

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -212,30 +212,6 @@ private extension ChannelListUpdater {
 
 @available(iOS 13.0, *)
 extension ChannelListUpdater {
-    func link(channel: ChatChannel, with query: ChannelListQuery) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            link(channel: channel, with: query) { error in
-                continuation.resume(with: error)
-            }
-        }
-    }
-
-    func startWatchingChannels(withIds ids: [ChannelId]) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            startWatchingChannels(withIds: ids) { error in
-                continuation.resume(with: error)
-            }
-        }
-    }
-
-    func unlink(channel: ChatChannel, with query: ChannelListQuery) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            unlink(channel: channel, with: query) { error in
-                continuation.resume(with: error)
-            }
-        }
-    }
-
     @discardableResult func update(channelListQuery: ChannelListQuery) async throws -> [ChatChannel] {
         try await withCheckedThrowingContinuation { continuation in
             update(channelListQuery: channelListQuery) { result in

--- a/Sources/StreamChat/Workers/EventObservers/EventObserver.swift
+++ b/Sources/StreamChat/Workers/EventObservers/EventObserver.swift
@@ -23,23 +23,6 @@ class EventObserver {
         }
     }
     
-    @available(iOS 13.0, *)
-    convenience init<EventType>(
-        notificationCenter: NotificationCenter,
-        transform: @escaping (Event) -> EventType?,
-        callback: @escaping (EventType) async throws -> Void
-    ) {
-        self.init(notificationCenter: notificationCenter, transform: transform) { event in
-            Task {
-                do {
-                    try await callback(event)
-                } catch {
-                    log.debug("Event observer failed to handle event \(event) with error \(error)")
-                }
-            }
-        }
-    }
-
     deinit {
         stopObserving()
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -263,6 +263,8 @@
 		4F427F6A2BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6C2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
 		4F427F6D2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
+		4F45802E2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */; };
+		4F45802F2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */; };
 		4F5151962BC3DEA1001B7152 /* UserSearch_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */; };
 		4F5151982BC407ED001B7152 /* UserList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151972BC407ED001B7152 /* UserList_Tests.swift */; };
 		4F51519A2BC57C40001B7152 /* MessageState_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151992BC57C40001B7152 /* MessageState_Tests.swift */; };
@@ -3050,6 +3052,7 @@
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
+		4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListLinker.swift; sourceTree = "<group>"; };
 		4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearch_Tests.swift; sourceTree = "<group>"; };
 		4F5151972BC407ED001B7152 /* UserList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList_Tests.swift; sourceTree = "<group>"; };
 		4F5151992BC57C40001B7152 /* MessageState_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState_Tests.swift; sourceTree = "<group>"; };
@@ -5613,6 +5616,7 @@
 		799C9427247D2FB9001F1104 /* Workers */ = {
 			isa = PBXGroup;
 			children = (
+				4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */,
 				792A4F1A247FE84900EAF71D /* ChannelListUpdater.swift */,
 				882C5755252C791400E60C44 /* ChannelMemberListUpdater.swift */,
 				88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */,
@@ -11212,6 +11216,7 @@
 				DA4EE5B2252B67F500CB26D4 /* UserListController+SwiftUI.swift in Sources */,
 				C18F5B522840BD2C00527915 /* DBDate.swift in Sources */,
 				AD483B962A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift in Sources */,
+				4F45802E2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */,
 				AD0CC02E2BDC08E9005E2C66 /* ChatClient+ReactionListController.swift in Sources */,
 				841BA9F52BCE8089000C73E4 /* PollsEndpoints.swift in Sources */,
 				43D3F0F62841052600B74921 /* CallPayloads.swift in Sources */,
@@ -12127,6 +12132,7 @@
 				C121E8D0274544B100023E4C /* UserListSortingKey.swift in Sources */,
 				C121E8D1274544B100023E4C /* ChannelMemberListSortingKey.swift in Sources */,
 				C121E8D2274544B100023E4C /* ClientError.swift in Sources */,
+				4F45802F2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */,
 				C143789127BC03EE00E23965 /* EndpointPath.swift in Sources */,
 				C121E8D3274544B100023E4C /* ErrorPayload.swift in Sources */,
 				C121E8D4274544B100023E4C /* NSManagedObject+Extensions.swift in Sources */,

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -327,10 +327,16 @@ final class ChannelListController_Tests: XCTestCase {
     // MARK: - Linking and Unlinking Channels when channels are updated/inserted
 
     func test_didReceiveEvent_whenNotificationAddedToChannelEvent_shouldLinkChannelToQuery() {
+        controller.synchronize()
+        
         let event = makeAddedChannelEvent(with: .mock(cid: .unique))
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
+        AssertAsync.willBeTrue(env.channelListUpdater?.link_completion != nil)
         env.channelListUpdater?.link_completion?(nil)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 1)
@@ -338,10 +344,16 @@ final class ChannelListController_Tests: XCTestCase {
     }
 
     func test_didReceiveEvent_whenMessageNewEvent_shouldLinkChannelToQuery() {
+        controller.synchronize()
+        
         let event = makeMessageNewEvent(with: .mock(cid: .unique))
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
+        AssertAsync.willBeTrue(env.channelListUpdater?.link_completion != nil)
         env.channelListUpdater?.link_completion?(nil)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 1)
@@ -349,12 +361,18 @@ final class ChannelListController_Tests: XCTestCase {
     }
     
     func test_didReceiveEvent_whenChannelVisibleEvent_shouldLinkChannelToQuery() {
+        controller.synchronize()
+        
         let channel = ChatChannel.mock(cid: .unique)
         try? database.createChannel(cid: channel.cid, channelReads: [])
         let event = makeChannelVisibleEvent(with: channel)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
+        AssertAsync.willBeTrue(env.channelListUpdater?.link_completion != nil)
         env.channelListUpdater?.link_completion?(nil)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 1)
@@ -362,10 +380,16 @@ final class ChannelListController_Tests: XCTestCase {
     }
 
     func test_didReceiveEvent_whenNotificationMessageNewEvent_shouldLinkChannelToQuery() {
+        controller.synchronize()
+        
         let event = makeNotificationMessageNewEvent(with: .mock(cid: .unique))
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
+        AssertAsync.willBeTrue(env.channelListUpdater?.link_completion != nil)
         env.channelListUpdater?.link_completion?(nil)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 1)
@@ -390,10 +414,11 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let event = makeAddedChannelEvent(with: .mock(cid: cid))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
-        env.channelListUpdater?.link_completion?(nil)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 0)
         XCTAssertEqual(env.channelListUpdater?.startWatchingChannels_callCount, 0)
@@ -417,10 +442,11 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let event = makeMessageNewEvent(with: .mock(cid: cid))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
-        env.channelListUpdater?.link_completion?(nil)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 0)
         XCTAssertEqual(env.channelListUpdater?.startWatchingChannels_callCount, 0)
@@ -444,10 +470,11 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let event = makeNotificationMessageNewEvent(with: .mock(cid: cid))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
-        env.channelListUpdater?.link_completion?(nil)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 0)
         XCTAssertEqual(env.channelListUpdater?.startWatchingChannels_callCount, 0)
@@ -461,8 +488,13 @@ final class ChannelListController_Tests: XCTestCase {
 
         let event = makeAddedChannelEvent(with: .mock(cid: .unique, memberCount: 4))
 
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
+        AssertAsync.willBeTrue(env.channelListUpdater?.link_completion != nil)
         env.channelListUpdater?.link_completion?(nil)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 1)
@@ -489,10 +521,11 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let event = makeAddedChannelEvent(with: .mock(cid: cid, memberCount: 4))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
-        env.channelListUpdater?.link_completion?(nil)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 0)
         XCTAssertEqual(env.channelListUpdater?.startWatchingChannels_callCount, 0)
@@ -505,10 +538,11 @@ final class ChannelListController_Tests: XCTestCase {
         setupControllerWithFilter(filter)
 
         let event = makeAddedChannelEvent(with: .mock(cid: .unique, memberCount: 4))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
-        env.channelListUpdater?.link_completion?(nil)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.link_callCount, 0)
         XCTAssertEqual(env.channelListUpdater?.startWatchingChannels_callCount, 0)
@@ -534,10 +568,13 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let event = makeChannelUpdatedEvent(with: .mock(cid: cid, memberCount: 4))
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
-
-        XCTAssertEqual(env.channelListUpdater?.unlink_callCount, 1)
+        AssertAsync.willBeEqual(env.channelListUpdater?.unlink_callCount, 1)
     }
 
     func test_didReceiveEvent_whenChannelUpdatedEvent__whenFilterMatches_shouldNotUnlinkChannelFromQuery() throws {
@@ -559,8 +596,11 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let event = makeChannelUpdatedEvent(with: .mock(cid: cid, memberCount: 4))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.unlink_callCount, 0)
     }
@@ -572,8 +612,11 @@ final class ChannelListController_Tests: XCTestCase {
         setupControllerWithFilter(filter)
 
         let event = makeChannelUpdatedEvent(with: .mock(cid: .unique, memberCount: 4))
-
-        controller.eventsController(controller.eventsController, didReceiveEvent: event)
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        controller.client.eventNotificationCenter.process(event) {
+            eventExpectation.fulfill()
+        }
+        wait(for: [eventExpectation], timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelListUpdater?.unlink_callCount, 0)
     }


### PR DESCRIPTION
…rom query

### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Use a single entity for linking and unlinking channels.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
