### PR TITLE
Fix marking channel read after leaving channel view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Do not retry rate-limited requests [#3182](https://github.com/GetStream/stream-chat-swift/pull/3182)
 - `UserListController` won't update automatically when a new user is added [#3184](https://github.com/GetStream/stream-chat-swift/pull/3184)
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix marking channel read after leaving channel view [#3193](https://github.com/GetStream/stream-chat-swift/pull/3193)
+
 # [4.54.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.54.0)
 _May 06, 2024_
 

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -23,7 +23,7 @@ final class ChatChannelVC_Tests: XCTestCase {
         vc = ChatChannelVC()
         vc.isViewVisible = { _ in true }
         vc.components = components
-        vc.throttler = ThrottlerMock()
+        vc.markReadThrottler = ThrottlerMock()
         cid = .unique
         channelControllerMock = ChatChannelController_Mock.mock()
         channelControllerMock.mockCid = cid
@@ -1052,7 +1052,17 @@ final class ChatChannelVC_Tests: XCTestCase {
         mockedListView.updateMessagesCompletion?()
         XCTAssertEqual(channelControllerMock.markReadCallCount, 0)
     }
-    
+
+    func test_viewWillDisappear_shouldCancelMarkReadThrottler() {
+        let mock = ThrottlerMock()
+        vc = ChatChannelVC()
+        vc.markReadThrottler = mock
+
+        vc.viewWillDisappear(false)
+
+        XCTAssertEqual(mock.cancelCallCount, 1)
+    }
+
     // MARK: - chatMessageListVC(_:headerViewForMessage:at)
 
     func test_headerViewForMessage_whenMessageShouldShowDateSeparator() throws {
@@ -1559,5 +1569,11 @@ class ThrottlerMock: Throttler {
 
     override func execute(_ action: @escaping () -> Void) {
         action()
+    }
+
+    var cancelCallCount = 0
+    override func cancel() {
+        super.cancel()
+        cancelCallCount += 1
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/777
Related to https://github.com/GetStream/stream-chat-swift/issues/3089

### 🎯 Goal
Fix marking a channel read even after the user has left the channel view.

### 📝 Summary
This could happen in a case where the user left the channel view, but the debouncer would still trigger a request to markRead.

### 🛠 Implementation
Now, when the user leaves the channel view, we cancel the throttler.

### 🧪 Manual Testing Notes
Follow steps of https://github.com/GetStream/stream-chat-swift/issues/3089

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)