### PR TITLE
Increase the function_body_length rule's warning from 120 to 150

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -71,7 +71,7 @@ trailing_whitespace:
   ignores_empty_lines: true
 
 function_body_length:
-  warning: 120
+  warning: 150
   error: 200
 
 file_name_no_space:


### PR DESCRIPTION
### 🎯 Goal

We have SwiftLint's warning about function length going on for some time. We either bump the threshold or turn it off completely.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdjlzZ3A2YjVjNnp0cHZ3czc0ZzIzOHJpaXl6dWsxa3Z0dHdmaTg5YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/yALcFbrKshfoY/giphy.gif)
