### PR TITLE
Keep the message order when sending multiple messages with failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add a new state layer with async-await and observable state objects ([learn more](https://getstream.io/chat/docs/sdk/ios/state-layer/state-layer-overview/)) [#3177](https://github.com/GetStream/stream-chat-swift/pull/3177)
+### 🐞 Fixed
+- Keep the message order when sending multiple messages and one of them fails [#3202](https://github.com/GetStream/stream-chat-swift/pull/3202)
 
 # [4.55.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.55.0)
 _May 13, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add a new state layer with async-await and observable state objects ([learn more](https://getstream.io/chat/docs/sdk/ios/state-layer/state-layer-overview/)) [#3177](https://github.com/GetStream/stream-chat-swift/pull/3177)
 ### 🐞 Fixed
-- Keep the message order when sending multiple messages and one of them fails [#3202](https://github.com/GetStream/stream-chat-swift/pull/3202)
+- Keep the message order when sending multiple messages when one of them fails [#3202](https://github.com/GetStream/stream-chat-swift/pull/3202)
 
 # [4.55.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.55.0)
 _May 13, 2024_

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -13,6 +13,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
 
     var sendMessageResult: Result<ChatMessage, MessageRepositoryError>?
     @Atomic var sendMessageCalls: [MessageId: (Result<ChatMessage, MessageRepositoryError>) -> Void] = [:]
+    var sendMessageResultHandler: ((MessageId, (Result<ChatMessage, MessageRepositoryError>) -> Void) -> Void)?
     var getMessageResult: Result<ChatMessage, Error>?
     var receivedGetMessageStore: Bool?
     var saveSuccessfullyDeletedMessageError: Error?
@@ -30,6 +31,10 @@ final class MessageRepository_Mock: MessageRepository, Spy {
             }
         }
 
+        if let sendMessageResultHandler {
+            sendMessageResultHandler(messageId, completion)
+        }
+        
         if let sendMessageResult = sendMessageResult {
             completion(sendMessageResult)
         }
@@ -74,5 +79,6 @@ final class MessageRepository_Mock: MessageRepository, Spy {
         spyState.clear()
         sendMessageCalls.removeAll()
         sendMessageResult = nil
+        sendMessageResultHandler = nil
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/819](https://github.com/GetStream/ios-issues-tracking/issues/819)

### 🎯 Goal

Fix the issue of incorrect order of messages when multiple messages are in the pending send state 

### 📝 Summary

**Before**
`MessageSender` tries to send queued messages one by one and even if one fails, it just tries to send the next one. This could change the order since the next one is delivered but the previous one is in failed state still and if I resend it, it gets ordered after the last succeeded message.
**After**
`MessageSender` fails all the messages in the queue after encountering a failure. User can then try to resend them explicitly.

### 🛠 Implementation

Fail all the messages in the queue when encountering a failure.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
