### PR TITLE
[Threads v2] Add `ChatThreadListController`

### DIFF
--- a/Sources/StreamChat/Controllers/ThreadListController/ChatClient+ThreadListController.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ChatClient+ThreadListController.swift
@@ -1,0 +1,13 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension ChatClient {
+    /// Creates a new `ThreadListController` with the provided thread query.
+    /// - Returns: A new instance of `ChatThreadListController`.
+    internal func threadListController(query: ThreadListQuery) -> ChatThreadListController {
+        .init(query: query, client: self)
+    }
+}

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController+Combine.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController+Combine.swift
@@ -1,0 +1,51 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+@available(iOS 13, *)
+extension ChatThreadListController {
+    /// A publisher emitting a new value every time the state of the controller changes.
+    internal var statePublisher: AnyPublisher<DataController.State, Never> {
+        basePublishers.state.keepAlive(self)
+    }
+
+    /// A publisher emitting a new value every time the reactions change.
+    internal var threadsChangesPublisher: AnyPublisher<[ListChange<ChatThread>], Never> {
+        basePublishers.threadsChanges.keepAlive(self)
+    }
+
+    /// An internal backing object for all publicly available Combine publishers. We use it to simplify the way we expose
+    /// publishers. Instead of creating custom `Publisher` types, we use `CurrentValueSubject` and `PassthroughSubject` internally,
+    /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
+    class BasePublishers {
+        /// The wrapped controller.
+        unowned let controller: ChatThreadListController
+
+        /// A backing subject for `statePublisher`.
+        let state: CurrentValueSubject<DataController.State, Never>
+
+        /// A backing subject for `threadsChangesPublisher`.
+        let threadsChanges: PassthroughSubject<[ListChange<ChatThread>], Never> = .init()
+
+        init(controller: ChatThreadListController) {
+            self.controller = controller
+            state = .init(controller.state)
+
+            controller.multicastDelegate.add(additionalDelegate: self)
+        }
+    }
+}
+
+@available(iOS 13, *)
+extension ChatThreadListController.BasePublishers: ChatThreadListControllerDelegate {
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state.send(state)
+    }
+
+    func controller(_ controller: ChatThreadListController, didChangeThreads changes: [ListChange<ChatThread>]) {
+        threadsChanges.send(changes)
+    }
+}

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController+SwiftUI.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController+SwiftUI.swift
@@ -1,0 +1,45 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+@available(iOS 13, *)
+extension ChatThreadListController {
+    /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
+    internal var observableObject: ObservableObject { .init(controller: self) }
+
+    /// A wrapper object which makes it possible to use the controller comfortably in SwiftUI.
+    internal class ObservableObject: SwiftUI.ObservableObject {
+        /// The underlying controller. You can still access it and call methods on it.
+        internal let controller: ChatThreadListController
+
+        /// The threads.
+        @Published internal private(set) var threads: LazyCachedMapCollection<ChatThread> = []
+
+        /// The current state of the controller.
+        @Published internal private(set) var state: DataController.State
+
+        /// Creates a new `ObservableObject` wrapper with the provided controller instance.
+        init(controller: ChatThreadListController) {
+            self.controller = controller
+            state = controller.state
+
+            controller.multicastDelegate.add(additionalDelegate: self)
+
+            threads = controller.threads
+        }
+    }
+}
+
+@available(iOS 13, *)
+extension ChatThreadListController.ObservableObject: ChatThreadListControllerDelegate {
+    internal func controller(_ controller: ChatThreadListController, didChangeThreads changes: [ListChange<ChatThread>]) {
+        threads = controller.threads
+    }
+
+    internal func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state = state
+    }
+}

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
@@ -1,0 +1,206 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+extension ChatClient {
+    /// Creates a new `ThreadListController` with the provided thread query.
+    /// - Returns: A new instance of `ChatThreadListController`.
+    internal func threadListController(query: ThreadListQuery) -> ChatThreadListController {
+        .init(query: query, client: self)
+    }
+}
+
+/// `ChatThreadListController` is a controller class which allows querying and
+/// observing the thread replies of the current user.
+internal class ChatThreadListController: DataController, DelegateCallable, DataStoreProvider {
+    /// The query of the thread list.
+    internal let query: ThreadListQuery
+
+    /// The `ChatClient` instance this controller belongs to.
+    internal let client: ChatClient
+
+    /// The threads matching the query of this controller.
+    ///
+    /// To observe changes of the threads, set your class as a delegate of this controller
+    /// or use the provided combine publishers.
+    internal var threads: LazyCachedMapCollection<ChatThread> {
+        startThreadListObserverIfNeeded()
+        return threadListObserver.items
+    }
+
+    /// The updater used to fetch the remote data and communicate with servers.
+    private lazy var updater: ThreadListUpdater = self.environment
+        .threadListUpdaterBuilder(
+            client.databaseContainer,
+            client.apiClient
+        )
+
+    /// A Boolean value that returns whether pagination is finished.
+    internal private(set) var hasLoadedAllOlderThreads: Bool = false
+
+    /// A type-erased delegate.
+    var multicastDelegate: MulticastDelegate<ChatThreadListControllerDelegate> = .init() {
+        didSet {
+            stateMulticastDelegate.set(mainDelegate: multicastDelegate.mainDelegate)
+            stateMulticastDelegate.set(additionalDelegates: multicastDelegate.additionalDelegates)
+
+            // After setting delegate local changes will be fetched and observed.
+            startThreadListObserverIfNeeded()
+        }
+    }
+
+    private(set) lazy var threadListObserver: ListDatabaseObserverWrapper<ChatThread, ThreadDTO> = {
+        let request = ThreadDTO.threadListFetchRequest()
+        let observer = self.environment.createThreadListDatabaseObserver(
+            StreamRuntimeCheck._isBackgroundMappingEnabled,
+            client.databaseContainer,
+            request,
+            { try $0.asModel() }
+        )
+
+        observer.onDidChange = { [weak self] changes in
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                $0.controller(self, didChangeThreads: changes)
+            }
+        }
+
+        return observer
+    }()
+
+//    var _basePublishers: Any?
+//    /// An internal backing object for all publicly available Combine publishers. We use it to simplify the way we expose
+//    /// publishers. Instead of creating custom `Publisher` types, we use `CurrentValueSubject` and `PassthroughSubject` internally,
+//    /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
+//    @available(iOS 13, *)
+//    var basePublishers: BasePublishers {
+//        if let value = _basePublishers as? BasePublishers {
+//            return value
+//        }
+//        _basePublishers = BasePublishers(controller: self)
+//        return _basePublishers as? BasePublishers ?? .init(controller: self)
+//    }
+
+    private let environment: Environment
+
+    /// Creates a new `ChatThreadListController`.
+    init(
+        query: ThreadListQuery,
+        client: ChatClient,
+        environment: Environment = .init()
+    ) {
+        self.client = client
+        self.query = query
+        self.environment = environment
+    }
+
+    override internal func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        startThreadListObserverIfNeeded()
+
+        let limit = query.limit
+        updater.loadThreads(
+            query: query
+        ) { [weak self] result in
+            switch result {
+            case let .success(threads):
+                self?.threadListObserver.refreshItems { [weak self] in
+                    self?.state = .remoteDataFetched
+                }
+                self?.hasLoadedAllOlderThreads = threads.count < limit
+                self?.callback { completion?(nil) }
+            case let .failure(error):
+                self?.state = .remoteDataFetchFailed(ClientError(with: error))
+                self?.callback { completion?(error) }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Loads older threads.
+    ///
+    /// - Parameters:
+    ///   - limit: The size of the new page of threads.
+    ///   - completion: The completion.
+    internal func loadOlderThreads(
+        limit: Int? = nil,
+        completion: ((Result<[ChatThread], Error>) -> Void)? = nil
+    ) {
+        let limit = limit ?? query.limit
+        var updatedQuery = query
+        updatedQuery.limit = limit
+        updatedQuery.next = updater.nextCursor
+        updater.loadThreads(query: updatedQuery) { result in
+            switch result {
+            case let .success(threads):
+                self.hasLoadedAllOlderThreads = threads.count < limit
+                self.callback { completion?(.success(threads)) }
+            case let .failure(error):
+                self.callback { completion?(.failure(error)) }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// If the `state` of the controller is `initialized`, this method calls `startObserving` on the
+    /// `threadListObserver` to fetch the local data and start observing the changes. It also changes
+    /// `state` based on the result.
+    private func startThreadListObserverIfNeeded() {
+        guard state == .initialized else { return }
+        do {
+            try threadListObserver.startObserving()
+            state = .localDataFetched
+        } catch {
+            state = .localDataFetchFailed(ClientError(with: error))
+            log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
+        }
+    }
+}
+
+extension ChatThreadListController {
+    struct Environment {
+        var threadListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> ThreadListUpdater = ThreadListUpdater.init
+
+        var createThreadListDatabaseObserver: (
+            _ isBackground: Bool,
+            _ database: DatabaseContainer,
+            _ fetchRequest: NSFetchRequest<ThreadDTO>,
+            _ itemCreator: @escaping (ThreadDTO) throws -> ChatThread
+        )
+            -> ListDatabaseObserverWrapper<ChatThread, ThreadDTO> = {
+                ListDatabaseObserverWrapper(
+                    isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3
+                )
+            }
+    }
+}
+
+extension ChatThreadListController {
+    /// Set the delegate of `ThreadListController` to observe thread changes.
+    internal weak var delegate: ChatThreadListControllerDelegate? {
+        get { multicastDelegate.mainDelegate }
+        set { multicastDelegate.set(mainDelegate: newValue) }
+    }
+}
+
+/// `ChatThreadListController` uses this protocol to communicate changes to its delegate.
+internal protocol ChatThreadListControllerDelegate: DataControllerStateDelegate {
+    /// The controller changed the list of observed threads.
+    ///
+    /// - Parameters:
+    ///   - controller: The controller emitting the change callback.
+    ///   - changes: The change to the list of threads.
+    func controller(
+        _ controller: ChatThreadListController,
+        didChangeThreads threads: [ListChange<ChatThread>]
+    )
+}

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
@@ -110,9 +110,9 @@ internal class ChatThreadListController: DataController, DelegateCallable, DataS
             case let .success(threads):
                 self?.threadListObserver.refreshItems { [weak self] in
                     self?.state = .remoteDataFetched
+                    self?.hasLoadedAllOlderThreads = threads.count < limit
+                    self?.callback { completion?(nil) }
                 }
-                self?.hasLoadedAllOlderThreads = threads.count < limit
-                self?.callback { completion?(nil) }
             case let .failure(error):
                 self?.state = .remoteDataFetchFailed(ClientError(with: error))
                 self?.callback { completion?(error) }
@@ -201,6 +201,6 @@ internal protocol ChatThreadListControllerDelegate: DataControllerStateDelegate 
     ///   - changes: The change to the list of threads.
     func controller(
         _ controller: ChatThreadListController,
-        didChangeThreads threads: [ListChange<ChatThread>]
+        didChangeThreads changes: [ListChange<ChatThread>]
     )
 }

--- a/Sources/StreamChat/Database/DTOs/ThreadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ThreadDTO.swift
@@ -188,8 +188,8 @@ extension NSManagedObjectContext {
     }
 
     func deleteAllThreads() throws {
-        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: ThreadDTO.entityName)
-        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-        try persistentStoreCoordinator?.execute(deleteRequest, with: self)
+        let fetchRequest: NSFetchRequest<ThreadDTO> = NSFetchRequest(entityName: ThreadDTO.entityName)
+        let results = try fetch(fetchRequest)
+        results.forEach { delete($0) }
     }
 }

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -394,6 +394,12 @@ protocol QueuedRequestDatabaseSession {
 }
 
 protocol ThreadDatabaseSession {
+    /// Loads the thread with the given parentMessageId in case it is available locally.
+    func thread(
+        parentMessageId: MessageId,
+        cache: PreWarmedCache?
+    ) -> ThreadDTO?
+
     /// Creates `ThreadDTO` objects for the given thread payloads.
     @discardableResult
     func saveThreadList(payload: ThreadListPayload) -> [ThreadDTO]

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -396,13 +396,12 @@ protocol QueuedRequestDatabaseSession {
 protocol ThreadDatabaseSession {
     /// Creates `ThreadDTO` objects for the given thread payloads.
     @discardableResult
-    func saveThreadList(payload: ThreadListPayload, query: ThreadListQuery?) -> [ThreadDTO]
+    func saveThreadList(payload: ThreadListPayload) -> [ThreadDTO]
     
     /// Creates a new `ThreadDTO` object in the database with the given `payload`.
     @discardableResult
     func saveThread(
         payload: ThreadPayload,
-        query: ThreadListQuery?,
         cache: PreWarmedCache?
     ) throws -> ThreadDTO
 
@@ -421,6 +420,9 @@ protocol ThreadDatabaseSession {
         parentMessageId: String,
         cache: PreWarmedCache?
     ) throws -> ThreadReadDTO
+
+    /// Cleans all the threads in the database.
+    func deleteAllThreads() throws
 }
 
 protocol DatabaseSession: UserDatabaseSession,

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -65,7 +65,7 @@
         <relationship name="previewMessage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="previewOfChannel" inverseEntity="MessageDTO"/>
         <relationship name="queries" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelListQueryDTO" inverseName="channels" inverseEntity="ChannelListQueryDTO"/>
         <relationship name="reads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelReadDTO" inverseName="channel" inverseEntity="ChannelReadDTO"/>
-        <relationship name="threads" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ThreadDTO" inverseName="channel" inverseEntity="ThreadDTO"/>
+        <relationship name="threads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ThreadDTO" inverseName="channel" inverseEntity="ThreadDTO"/>
         <relationship name="watchers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="watchedChannels" inverseEntity="UserDTO"/>
         <fetchIndex name="defaultSortingIndex">
             <fetchIndexElement property="defaultSortingAt" type="Binary" order="ascending"/>

--- a/Sources/StreamChat/Query/ThreadListQuery.swift
+++ b/Sources/StreamChat/Query/ThreadListQuery.swift
@@ -15,7 +15,7 @@ internal struct ThreadListQuery: Encodable {
     }
 
     /// A boolean indicating whether to watch for changes in the thread or not.
-    internal var watch: Bool = false
+    internal var watch: Bool
     /// The amount of replies fetched per thread. Default is 2.
     internal var replyLimit: Int = 2
     /// The amount of participants fetched per thread. Default is 100.
@@ -25,5 +25,9 @@ internal struct ThreadListQuery: Encodable {
     /// The pagination token from the previous response to fetch the next page.
     internal var next: String?
 
-    internal init() {}
+    internal init(
+        watch: Bool
+    ) {
+        self.watch = watch
+    }
 }

--- a/Sources/StreamChat/Query/ThreadListQuery.swift
+++ b/Sources/StreamChat/Query/ThreadListQuery.swift
@@ -15,13 +15,13 @@ internal struct ThreadListQuery: Encodable {
     }
 
     /// A boolean indicating whether to watch for changes in the thread or not.
-    internal var watch: Bool?
+    internal var watch: Bool = false
     /// The amount of replies fetched per thread. Default is 2.
-    internal var replyLimit: Int?
+    internal var replyLimit: Int = 2
     /// The amount of participants fetched per thread. Default is 100.
-    internal var participantLimit: Int?
+    internal var participantLimit: Int = 100
     /// The amount of threads fetched per page. Default is 10.
-    internal var limit: Int?
+    internal var limit: Int = 10
     /// The pagination token from the previous response to fetch the next page.
     internal var next: String?
 

--- a/Sources/StreamChat/Query/ThreadQuery.swift
+++ b/Sources/StreamChat/Query/ThreadQuery.swift
@@ -17,11 +17,11 @@ internal struct ThreadQuery: Encodable {
     /// The parent message ID which the thread belongs to.
     internal var messageId: MessageId
     /// A boolean indicating whether to watch for changes in the thread or not.
-    internal var watch: Bool?
+    internal var watch: Bool = false
     /// The amount of replies fetched from the thread. Default is 2.
-    internal var replyLimit: Int?
+    internal var replyLimit: Int = 2
     /// The amount of participants fetched per thread. Default is 100.
-    internal var participantLimit: Int?
+    internal var participantLimit: Int = 100
 
     internal init(messageId: MessageId) {
         self.messageId = messageId

--- a/Sources/StreamChat/Workers/ThreadListUpdater.swift
+++ b/Sources/StreamChat/Workers/ThreadListUpdater.swift
@@ -1,0 +1,41 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+/// Makes a thread list query call to the backend and updates the local storage with the results.
+class ThreadListUpdater: Worker {
+    /// The cursor to be used for fetching a new page of threads.
+    var nextCursor: String?
+
+    func loadThreads(
+        query: ThreadListQuery,
+        completion: @escaping (Result<[ChatThread], Error>) -> Void
+    ) {
+        apiClient.request(endpoint: .threads(query: query)) { [weak self] result in
+            switch result {
+            case .success(let threadListPayload):
+                self?.nextCursor = threadListPayload.next
+                var threads: [ChatThread] = []
+                self?.database.write({ session in
+                    if query.next == nil {
+                        try session.deleteAllThreads()
+                    }
+                    threads = try session.saveThreadList(payload: threadListPayload).map {
+                        try $0.asModel()
+                    }
+                    self?.nextCursor = threadListPayload.next
+                }, completion: { error in
+                    if let error = error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(threads))
+                    }
+                })
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/Workers/ThreadListUpdater.swift
+++ b/Sources/StreamChat/Workers/ThreadListUpdater.swift
@@ -20,6 +20,9 @@ class ThreadListUpdater: Worker {
                 var threads: [ChatThread] = []
                 self?.database.write({ session in
                     if query.next == nil {
+                        /// For now, there is no `ThreadListQuery.filter` support.
+                        /// So we only have 1  thread list, which is all threads.
+                        /// So when fetching the first page, we need to cleanup all threads.
                         try session.deleteAllThreads()
                     }
                     threads = try session.saveThreadList(payload: threadListPayload).map {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -11353,11 +11353,8 @@
 				C135A1CB28F45F6B0058EFB6 /* AuthenticationRepository.swift in Sources */,
 				CFE616BB28348AC500AE2ABF /* StreamTimer.swift in Sources */,
 				F65D9091250A5989000B8CEB /* WebSocketConnectEndpoint.swift in Sources */,
-<<<<<<< HEAD
 				4F97F2772BA87E30001C4D66 /* MessageSearchState.swift in Sources */,
-=======
 				AD94906D2BF68BA800E69224 /* ChatClient+ThreadListController.swift in Sources */,
->>>>>>> ef5535279 (Add SwiftUI and Combine Helpers)
 				4A4E184728D06F260062378D /* Documentation.docc in Sources */,
 				842F9745277A09B10060A489 /* PinnedMessagesQuery.swift in Sources */,
 				DAE566EB24FFD26C00E39431 /* CurrentUserController+SwiftUI.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1503,6 +1503,8 @@
 		AD94904D2BF392DB00E69224 /* ThreadListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */; };
 		AD94904E2BF392DB00E69224 /* ThreadListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */; };
 		AD9490572BF3BA9600E69224 /* ThreadListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490562BF3BA9600E69224 /* ThreadListController.swift */; };
+		AD94905A2BF5702700E69224 /* ThreadListUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490582BF5701D00E69224 /* ThreadListUpdater_Tests.swift */; };
+		AD94905D2BF630D900E69224 /* ThreadPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94905B2BF630D200E69224 /* ThreadPayload.swift */; };
 		AD95FD0D28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD0E28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD1128FA038900DBDF41 /* ImageDownloadOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */; };
@@ -4121,6 +4123,8 @@
 		AD91C35328A5550C004D1E45 /* ChatMessageListVC+DiffKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageListVC+DiffKit.swift"; sourceTree = "<group>"; };
 		AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListUpdater.swift; sourceTree = "<group>"; };
 		AD9490562BF3BA9600E69224 /* ThreadListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListController.swift; sourceTree = "<group>"; };
+		AD9490582BF5701D00E69224 /* ThreadListUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListUpdater_Tests.swift; sourceTree = "<group>"; };
+		AD94905B2BF630D200E69224 /* ThreadPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPayload.swift; sourceTree = "<group>"; };
 		AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResize.swift; sourceTree = "<group>"; };
 		AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadOptions.swift; sourceTree = "<group>"; };
 		AD99A7CD28EF17CA005185DF /* SlackReactonsItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackReactonsItemView.swift; sourceTree = "<group>"; };
@@ -6555,6 +6559,7 @@
 		A344076127D753530044F150 /* DummyData */ = {
 			isa = PBXGroup;
 			children = (
+				AD94905B2BF630D200E69224 /* ThreadPayload.swift */,
 				84C11BDE27FB2B4600000A9E /* ChannelPayload.swift */,
 				79D7A1CD2593A40900D3C2BF /* ChannelDetailPayload.swift */,
 				A3D9D68227EDE35100725066 /* ChatChannel.swift */,
@@ -6855,6 +6860,7 @@
 		A364D09627D0C56C0029857A /* Workers */ = {
 			isa = PBXGroup;
 			children = (
+				AD9490582BF5701D00E69224 /* ThreadListUpdater_Tests.swift */,
 				792921C424C0479700116BBB /* ChannelListUpdater_Tests.swift */,
 				882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */,
 				88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */,
@@ -10736,6 +10742,7 @@
 				A311B43627E8BC8400CFCF6D /* ChannelMemberController_Delegate.swift in Sources */,
 				A3C3BC7827E8AA9400224761 /* ChannelListQuery+Equatable.swift in Sources */,
 				82E6553B2B0677EA00D64906 /* TestRunnerEnvironment.swift in Sources */,
+				AD94905D2BF630D900E69224 /* ThreadPayload.swift in Sources */,
 				A3C3BC3B27E87F5100224761 /* EventMiddleware_Mock.swift in Sources */,
 				A311B43727E8BC8400CFCF6D /* ChannelController_Delegate.swift in Sources */,
 				A344077427D753530044F150 /* ChannelUnreadCount_Mock.swift in Sources */,
@@ -11374,6 +11381,7 @@
 				AD6E32962BBB10890073831B /* ThreadListPayload_Tests.swift in Sources */,
 				8A0175F425013B6400570345 /* TypingEventSender_Tests.swift in Sources */,
 				C149B744282A61FF00F25BED /* NSManagedObject+Validation_Tests.swift in Sources */,
+				AD94905A2BF5702700E69224 /* ThreadListUpdater_Tests.swift in Sources */,
 				8875CF9B2587A89F00BBA6AC /* AttachmentId_Tests.swift in Sources */,
 				79D6CF2125FA6ACF00BE2EEC /* MemberEventMiddleware_Tests.swift in Sources */,
 				40B345F429C46AE500B96027 /* AudioPlaybackState_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1500,6 +1500,9 @@
 		AD90D18525D56196001D03BB /* CurrentUserUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD90D18425D56196001D03BB /* CurrentUserUpdater_Tests.swift */; };
 		AD91C35428A5550C004D1E45 /* ChatMessageListVC+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD91C35328A5550C004D1E45 /* ChatMessageListVC+DiffKit.swift */; };
 		AD91C35528A5550C004D1E45 /* ChatMessageListVC+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD91C35328A5550C004D1E45 /* ChatMessageListVC+DiffKit.swift */; };
+		AD94904D2BF392DB00E69224 /* ThreadListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */; };
+		AD94904E2BF392DB00E69224 /* ThreadListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */; };
+		AD9490572BF3BA9600E69224 /* ThreadListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490562BF3BA9600E69224 /* ThreadListController.swift */; };
 		AD95FD0D28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD0E28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD1128FA038900DBDF41 /* ImageDownloadOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */; };
@@ -4116,6 +4119,8 @@
 		AD90D18425D56196001D03BB /* CurrentUserUpdater_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentUserUpdater_Tests.swift; sourceTree = "<group>"; };
 		AD90D18C25D5619C001D03BB /* CurrentUserUpdater_Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentUserUpdater_Mock.swift; sourceTree = "<group>"; };
 		AD91C35328A5550C004D1E45 /* ChatMessageListVC+DiffKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageListVC+DiffKit.swift"; sourceTree = "<group>"; };
+		AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListUpdater.swift; sourceTree = "<group>"; };
+		AD9490562BF3BA9600E69224 /* ThreadListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListController.swift; sourceTree = "<group>"; };
 		AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResize.swift; sourceTree = "<group>"; };
 		AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadOptions.swift; sourceTree = "<group>"; };
 		AD99A7CD28EF17CA005185DF /* SlackReactonsItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackReactonsItemView.swift; sourceTree = "<group>"; };
@@ -5621,6 +5626,7 @@
 				882C5755252C791400E60C44 /* ChannelMemberListUpdater.swift */,
 				88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */,
 				79682C4524BC9DAF0071578E /* ChannelUpdater.swift */,
+				AD94904C2BF392DB00E69224 /* ThreadListUpdater.swift */,
 				AD7DFC3525D2FA8100DD9DA3 /* CurrentUserUpdater.swift */,
 				F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */,
 				84A43CB226A9A54700302763 /* EventSender.swift */,
@@ -5708,6 +5714,7 @@
 				DAE566F22500F97E00E39431 /* ChannelController */,
 				DAE566F32500F98D00E39431 /* ChannelListController */,
 				79C5CBF925F671AE00D98001 /* ChannelWatcherListController */,
+				AD9490552BF3BA8000E69224 /* ThreadListController */,
 				ADF34F6925CD6A0100AD637C /* ConnectionController */,
 				DAE566F42500F99900E39431 /* CurrentUserController */,
 				847E946C269C685F00E31D0C /* EventsController */,
@@ -8376,6 +8383,14 @@
 				2210525E256FE16600A5F0DB /* CommandLabelView.swift */,
 			);
 			path = CommandLabelView;
+			sourceTree = "<group>";
+		};
+		AD9490552BF3BA8000E69224 /* ThreadListController */ = {
+			isa = PBXGroup;
+			children = (
+				AD9490562BF3BA9600E69224 /* ThreadListController.swift */,
+			);
+			path = ThreadListController;
 			sourceTree = "<group>";
 		};
 		AD95FD0A28F98C1E00DBDF41 /* VideoLoading */ = {
@@ -11050,6 +11065,7 @@
 				DA640FBB2535CF8500D32944 /* ChannelListSortingKey.swift in Sources */,
 				C1FC2F8F2742579D0062530F /* Data+Extensions.swift in Sources */,
 				8899BC3F2542FFA1003CB98B /* MessageReactionPayload.swift in Sources */,
+				AD94904D2BF392DB00E69224 /* ThreadListUpdater.swift in Sources */,
 				797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */,
 				799C9438247D2FB9001F1104 /* ChatClientConfig.swift in Sources */,
 				C1FC2F992742579D0062530F /* StringHTTPHandler.swift in Sources */,
@@ -11116,6 +11132,7 @@
 				4042968029FAC9F80089126D /* AudioAnalysing.swift in Sources */,
 				DAD539DB250B8A9C00CFC649 /* Controller.swift in Sources */,
 				F6ED5F76250278D7005D7327 /* SyncEndpoint.swift in Sources */,
+				AD9490572BF3BA9600E69224 /* ThreadListController.swift in Sources */,
 				AD8FEE582AA8E1A100273F88 /* ChatClient+Environment.swift in Sources */,
 				AD52A2192804850700D0157E /* ChannelConfigDTO.swift in Sources */,
 				797A756824814F0D003CF16D /* Bundle+Extensions.swift in Sources */,
@@ -12140,6 +12157,7 @@
 				C121E8D5274544B100023E4C /* NSManagedObjectContext+Extensions.swift in Sources */,
 				40789D4029F6AFC40018C2BB /* Debouncer_Tests.swift in Sources */,
 				C121E8D6274544B100023E4C /* InternetConnection.swift in Sources */,
+				AD94904E2BF392DB00E69224 /* ThreadListUpdater.swift in Sources */,
 				C121E8D7274544B100023E4C /* Reachability_Vendor.swift in Sources */,
 				C121E8D8274544B100023E4C /* Error+InternetNotAvailable.swift in Sources */,
 				4F83FA472BA43DC3008BD8CD /* MemberList.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1508,6 +1508,9 @@
 		AD9490602BF65DE400E69224 /* ChatThreadListController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94905F2BF65DE400E69224 /* ChatThreadListController_Tests.swift */; };
 		AD9490622BF66D1E00E69224 /* ThreadListUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490612BF66D1E00E69224 /* ThreadListUpdater_Mock.swift */; };
 		AD9490662BF6756200E69224 /* ChatThread_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490652BF6756200E69224 /* ChatThread_Mock.swift */; };
+		AD94906D2BF68BA800E69224 /* ChatClient+ThreadListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490672BF68A8800E69224 /* ChatClient+ThreadListController.swift */; };
+		AD94906E2BF68BAE00E69224 /* ThreadListController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490692BF68A9900E69224 /* ThreadListController+SwiftUI.swift */; };
+		AD94906F2BF68BB200E69224 /* ThreadListController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94906B2BF68AB000E69224 /* ThreadListController+Combine.swift */; };
 		AD95FD0D28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD0E28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD1128FA038900DBDF41 /* ImageDownloadOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */; };
@@ -4131,6 +4134,9 @@
 		AD94905F2BF65DE400E69224 /* ChatThreadListController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListController_Tests.swift; sourceTree = "<group>"; };
 		AD9490612BF66D1E00E69224 /* ThreadListUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListUpdater_Mock.swift; sourceTree = "<group>"; };
 		AD9490652BF6756200E69224 /* ChatThread_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThread_Mock.swift; sourceTree = "<group>"; };
+		AD9490672BF68A8800E69224 /* ChatClient+ThreadListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+ThreadListController.swift"; sourceTree = "<group>"; };
+		AD9490692BF68A9900E69224 /* ThreadListController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreadListController+SwiftUI.swift"; sourceTree = "<group>"; };
+		AD94906B2BF68AB000E69224 /* ThreadListController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreadListController+Combine.swift"; sourceTree = "<group>"; };
 		AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResize.swift; sourceTree = "<group>"; };
 		AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadOptions.swift; sourceTree = "<group>"; };
 		AD99A7CD28EF17CA005185DF /* SlackReactonsItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackReactonsItemView.swift; sourceTree = "<group>"; };
@@ -8403,7 +8409,10 @@
 		AD9490552BF3BA8000E69224 /* ThreadListController */ = {
 			isa = PBXGroup;
 			children = (
+				AD9490672BF68A8800E69224 /* ChatClient+ThreadListController.swift */,
 				AD9490562BF3BA9600E69224 /* ThreadListController.swift */,
+				AD9490692BF68A9900E69224 /* ThreadListController+SwiftUI.swift */,
+				AD94906B2BF68AB000E69224 /* ThreadListController+Combine.swift */,
 			);
 			path = ThreadListController;
 			sourceTree = "<group>";
@@ -11244,6 +11253,7 @@
 				792A4F462480107A00EAF71D /* ChannelQuery.swift in Sources */,
 				AD37D7C42BC979B000800D8C /* ThreadDTO.swift in Sources */,
 				88E26D5E2580E92000F55AB5 /* AttachmentId.swift in Sources */,
+				AD94906F2BF68BB200E69224 /* ThreadListController+Combine.swift in Sources */,
 				799C9447247D50F3001F1104 /* Worker.swift in Sources */,
 				79280F782489181200CDEB89 /* URLSessionWebSocketEngine.swift in Sources */,
 				792A4F3C247FFBB400EAF71D /* Timers.swift in Sources */,
@@ -11329,6 +11339,7 @@
 				4F1BEE762BE384ED00B6685C /* ReactionList.swift in Sources */,
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */,
+				AD94906E2BF68BAE00E69224 /* ThreadListController+SwiftUI.swift in Sources */,
 				AD78568C298B268F00C2FEAD /* ChannelControllerDelegate.swift in Sources */,
 				841BAA072BCE9A49000C73E4 /* UpdatePartialRequestBody.swift in Sources */,
 				79896D5C2506593E00BA8F1C /* ChannelReadDTO.swift in Sources */,
@@ -11342,7 +11353,11 @@
 				C135A1CB28F45F6B0058EFB6 /* AuthenticationRepository.swift in Sources */,
 				CFE616BB28348AC500AE2ABF /* StreamTimer.swift in Sources */,
 				F65D9091250A5989000B8CEB /* WebSocketConnectEndpoint.swift in Sources */,
+<<<<<<< HEAD
 				4F97F2772BA87E30001C4D66 /* MessageSearchState.swift in Sources */,
+=======
+				AD94906D2BF68BA800E69224 /* ChatClient+ThreadListController.swift in Sources */,
+>>>>>>> ef5535279 (Add SwiftUI and Combine Helpers)
 				4A4E184728D06F260062378D /* Documentation.docc in Sources */,
 				842F9745277A09B10060A489 /* PinnedMessagesQuery.swift in Sources */,
 				DAE566EB24FFD26C00E39431 /* CurrentUserController+SwiftUI.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1505,6 +1505,9 @@
 		AD9490572BF3BA9600E69224 /* ThreadListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490562BF3BA9600E69224 /* ThreadListController.swift */; };
 		AD94905A2BF5702700E69224 /* ThreadListUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490582BF5701D00E69224 /* ThreadListUpdater_Tests.swift */; };
 		AD94905D2BF630D900E69224 /* ThreadPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94905B2BF630D200E69224 /* ThreadPayload.swift */; };
+		AD9490602BF65DE400E69224 /* ChatThreadListController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94905F2BF65DE400E69224 /* ChatThreadListController_Tests.swift */; };
+		AD9490622BF66D1E00E69224 /* ThreadListUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490612BF66D1E00E69224 /* ThreadListUpdater_Mock.swift */; };
+		AD9490662BF6756200E69224 /* ChatThread_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9490652BF6756200E69224 /* ChatThread_Mock.swift */; };
 		AD95FD0D28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD0E28F991ED00DBDF41 /* ImageResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */; };
 		AD95FD1128FA038900DBDF41 /* ImageDownloadOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */; };
@@ -4125,6 +4128,9 @@
 		AD9490562BF3BA9600E69224 /* ThreadListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListController.swift; sourceTree = "<group>"; };
 		AD9490582BF5701D00E69224 /* ThreadListUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListUpdater_Tests.swift; sourceTree = "<group>"; };
 		AD94905B2BF630D200E69224 /* ThreadPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPayload.swift; sourceTree = "<group>"; };
+		AD94905F2BF65DE400E69224 /* ChatThreadListController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListController_Tests.swift; sourceTree = "<group>"; };
+		AD9490612BF66D1E00E69224 /* ThreadListUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadListUpdater_Mock.swift; sourceTree = "<group>"; };
+		AD9490652BF6756200E69224 /* ChatThread_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThread_Mock.swift; sourceTree = "<group>"; };
 		AD95FD0C28F991ED00DBDF41 /* ImageResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResize.swift; sourceTree = "<group>"; };
 		AD95FD1028FA038900DBDF41 /* ImageDownloadOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadOptions.swift; sourceTree = "<group>"; };
 		AD99A7CD28EF17CA005185DF /* SlackReactonsItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackReactonsItemView.swift; sourceTree = "<group>"; };
@@ -6538,6 +6544,7 @@
 				A344075227D753530044F150 /* ChatMessageReaction_Mock.swift */,
 				A344075E27D753530044F150 /* ChatUser_Mock.swift */,
 				A344075427D753530044F150 /* CurrentChatUser_Mock.swift */,
+				AD9490652BF6756200E69224 /* ChatThread_Mock.swift */,
 				A344075527D753530044F150 /* Attachments */,
 			);
 			path = "Models + Extensions";
@@ -6892,6 +6899,7 @@
 				8ACFBF642507AA440093C6FD /* TypingEventsSender_Mock.swift */,
 				DA84072F2526002D005A0F62 /* UserListUpdater_Mock.swift */,
 				8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */,
+				AD9490612BF66D1E00E69224 /* ThreadListUpdater_Mock.swift */,
 				A364D09A27D0C5FD0029857A /* Background */,
 			);
 			path = Workers;
@@ -7042,6 +7050,7 @@
 		A364D0A527D127E00029857A /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				AD94905E2BF65CC500E69224 /* ThreadListController */,
 				A364D0A827D128650029857A /* ChannelController */,
 				A364D0A927D128830029857A /* ChannelListController */,
 				A364D0AA27D128BB0029857A /* ChannelWatcherListController */,
@@ -8395,6 +8404,14 @@
 			isa = PBXGroup;
 			children = (
 				AD9490562BF3BA9600E69224 /* ThreadListController.swift */,
+			);
+			path = ThreadListController;
+			sourceTree = "<group>";
+		};
+		AD94905E2BF65CC500E69224 /* ThreadListController */ = {
+			isa = PBXGroup;
+			children = (
+				AD94905F2BF65DE400E69224 /* ChatThreadListController_Tests.swift */,
 			);
 			path = ThreadListController;
 			sourceTree = "<group>";
@@ -10768,6 +10785,7 @@
 				A3C3BC1B27E87EFE00224761 /* ChatClient_Mock.swift in Sources */,
 				A3C3BC6727E8AA0A00224761 /* ChatMessage+Unique.swift in Sources */,
 				A3C3BC3427E87F2900224761 /* SyncRepository_Mock.swift in Sources */,
+				AD9490662BF6756200E69224 /* ChatThread_Mock.swift in Sources */,
 				A3C3BC7B27E8AA9400224761 /* EndpoinPath+Equatable.swift in Sources */,
 				A344078727D753530044F150 /* CurrentUserPayload.swift in Sources */,
 				A3C3BC2927E87F2000224761 /* ChannelDetailPayload.swift in Sources */,
@@ -11594,6 +11612,7 @@
 				40789D3F29F6AFC40018C2BB /* Debouncer_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
 				4F1BEE7F2BE38B5500B6685C /* ReactionList_Tests.swift in Sources */,
+				AD9490602BF65DE400E69224 /* ChatThreadListController_Tests.swift in Sources */,
 				40B345F729C46AE500B96027 /* StreamPlayerObserver_Tests.swift in Sources */,
 				796CBC1C25F7CD58003299B0 /* UserChannelBanEventsMiddleware_Tests.swift in Sources */,
 				DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */,
@@ -11628,6 +11647,7 @@
 				C111B5B628CF3B1200C79D53 /* BackgroundListDatabaseObserver_Tests.swift in Sources */,
 				A3C7BAD327E4E05300BBF4FA /* MemberListFilterScope_Tests.swift in Sources */,
 				8A0D649D24E579F70017A3C0 /* GuestUserTokenPayload_Tests.swift in Sources */,
+				AD9490622BF66D1E00E69224 /* ThreadListUpdater_Mock.swift in Sources */,
 				8A0C3BE224C1F74200CAFD19 /* MessageEvents_Tests.swift in Sources */,
 				7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */,
 				88D85DAB252F3C2A00AE1030 /* MemberListController_Tests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatThread_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatThread_Mock.swift
@@ -1,0 +1,69 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+extension ChatThread {
+    static func mock(
+        parentMessage: ChatMessage = .mock(),
+        channel: ChatChannel = .mock(cid: .unique),
+        createdBy: ChatUser = .mock(id: .unique),
+        replyCount: Int = 3,
+        participantCount: Int = 3,
+        threadParticipants: [ThreadParticipant] = [],
+        lastMessageAt: Date? = .unique,
+        createdAt: Date = .unique,
+        updatedAt: Date? = .unique,
+        title: String? = nil,
+        latestReplies: [ChatMessage] = [],
+        reads: [ThreadRead] = []
+    ) -> ChatThread {
+        .init(
+            parentMessageId: parentMessage.id,
+            parentMessage: parentMessage,
+            channel: channel,
+            createdBy: createdBy,
+            replyCount: replyCount,
+            participantCount: participantCount,
+            threadParticipants: threadParticipants,
+            lastMessageAt: lastMessageAt,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            title: title,
+            latestReplies: latestReplies,
+            reads: reads
+        )
+    }
+}
+
+extension ThreadParticipant {
+    static func mock(
+        user: ChatUser = .mock(id: .unique),
+        threadId: String = .unique,
+        createdAt: Date = .unique,
+        lastReadAt: Date? = .unique
+    ) -> ThreadParticipant {
+        .init(
+            user: user,
+            threadId: threadId,
+            createdAt: createdAt,
+            lastReadAt: lastReadAt
+        )
+    }
+}
+
+extension ThreadRead {
+    static func mock(
+        user: ChatUser = .unique,
+        lastReadAt: Date? = .unique,
+        unreadMessagesCount: Int = 0
+    ) -> ThreadRead {
+        .init(
+            user: user,
+            lastReadAt: lastReadAt,
+            unreadMessagesCount: unreadMessagesCount
+        )
+    }
+}

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -369,16 +369,16 @@ class DatabaseSession_Mock: DatabaseSession {
         underlyingSession.loadChannelRead(cid: cid, userId: userId)
     }
 
-    func saveThreadList(payload: ThreadListPayload, query: ThreadListQuery?) -> [ThreadDTO] {
-        underlyingSession.saveThreadList(payload: payload, query: query)
+    func saveThreadList(payload: ThreadListPayload) -> [ThreadDTO] {
+        underlyingSession.saveThreadList(payload: payload)
     }
 
     func saveThreadParticipant(payload: ThreadParticipantPayload, threadId: String, cache: PreWarmedCache?) throws -> ThreadParticipantDTO {
         try underlyingSession.saveThreadParticipant(payload: payload, threadId: threadId, cache: cache)
     }
 
-    func saveThread(payload: ThreadPayload, query: ThreadListQuery?, cache: PreWarmedCache?) throws -> ThreadDTO {
-        try underlyingSession.saveThread(payload: payload, query: query, cache: cache)
+    func saveThread(payload: ThreadPayload, cache: PreWarmedCache?) throws -> ThreadDTO {
+        try underlyingSession.saveThread(payload: payload, cache: cache)
     }
 
     func saveThreadRead(payload: ThreadReadPayload, parentMessageId: String, cache: PreWarmedCache?) throws -> ThreadReadDTO {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -369,6 +369,10 @@ class DatabaseSession_Mock: DatabaseSession {
         underlyingSession.loadChannelRead(cid: cid, userId: userId)
     }
 
+    func thread(parentMessageId: MessageId, cache: PreWarmedCache?) -> ThreadDTO? {
+        underlyingSession.thread(parentMessageId: parentMessageId, cache: cache)
+    }
+
     func saveThreadList(payload: ThreadListPayload) -> [ThreadDTO] {
         underlyingSession.saveThreadList(payload: payload)
     }
@@ -383,6 +387,10 @@ class DatabaseSession_Mock: DatabaseSession {
 
     func saveThreadRead(payload: ThreadReadPayload, parentMessageId: String, cache: PreWarmedCache?) throws -> ThreadReadDTO {
         try underlyingSession.saveThreadRead(payload: payload, parentMessageId: parentMessageId, cache: cache)
+    }
+
+    func deleteAllThreads() throws {
+        try underlyingSession.deleteAllThreads()
     }
 }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ThreadListUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ThreadListUpdater_Mock.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ThreadListUpdater_Mock: ThreadListUpdater {
+    init() {
+        let requestEncoder = DefaultRequestEncoder(
+            baseURL: .unique(),
+            apiKey: .init(.unique)
+        )
+        let requestDecoder = DefaultRequestDecoder()
+        super.init(
+            database: DatabaseContainer_Spy(),
+            apiClient: APIClient_Spy()
+        )
+    }
+
+    static func mock() -> Self {
+        Self()
+    }
+
+    var loadThreadsCallCount = 0
+    var loadThreadsCalledWith: ThreadListQuery?
+    var loadThreadsCompletion: ((Result<[ChatThread], any Error>) -> Void)?
+
+    override func loadThreads(
+        query: ThreadListQuery,
+        completion: @escaping (Result<[ChatThread], any Error>) -> Void
+    ) {
+        loadThreadsCallCount += 1
+        loadThreadsCalledWith = query
+        loadThreadsCompletion = completion
+    }
+}

--- a/TestTools/StreamChatTestTools/TestData/DummyData/ThreadPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/ThreadPayload.swift
@@ -1,0 +1,42 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+import XCTest
+
+extension ThreadPayload {
+    /// Returns dummy thread payload with the given values.
+    static func dummy(
+        parentMessageId: MessageId,
+        parentMessage: MessagePayload? = nil,
+        channel: ChannelDetailPayload = .dummy(),
+        createdBy: UserPayload = .dummy(userId: .newUniqueId),
+        replyCount: Int = 0,
+        participantCount: Int = 0,
+        threadParticipants: [ThreadParticipantPayload] = [],
+        lastMessageAt: Date? = nil,
+        createdAt: Date = .unique,
+        updatedAt: Date? = .unique,
+        title: String? = nil,
+        latestReplies: [MessagePayload] = [],
+        read: [ThreadReadPayload] = []
+    ) -> Self {
+        .init(
+            parentMessageId: parentMessageId,
+            parentMessage: .dummy(messageId: parentMessageId),
+            channel: channel,
+            createdBy: createdBy,
+            replyCount: replyCount,
+            participantCount: participantCount,
+            threadParticipants: threadParticipants,
+            lastMessageAt: lastMessageAt,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            title: title,
+            latestReplies: latestReplies,
+            read: read
+        )
+    }
+}

--- a/Tests/StreamChatTests/APIClient/Endpoints/ThreadEndpoint_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ThreadEndpoint_Tests.swift
@@ -10,12 +10,11 @@ import XCTest
 
 final class ThreadEndpoints_Tests: XCTestCase {
     func test_threads() throws {
-        var query = ThreadListQuery()
+        var query = ThreadListQuery(watch: false)
         query.limit = 10
         query.next = "test"
         query.participantLimit = 10
         query.replyLimit = 10
-        query.watch = false
 
         let endpoint = Endpoint<ThreadListPayload>.threads(query: query)
         let body = try AnyEndpoint(endpoint).bodyAsDictionary()
@@ -35,12 +34,11 @@ final class ThreadEndpoints_Tests: XCTestCase {
     }
 
     func test_threads_whenWatchIsTrue_thenRequiresConnectionIsTrue() throws {
-        var query = ThreadListQuery()
+        var query = ThreadListQuery(watch: true)
         query.limit = 10
         query.next = "test"
         query.participantLimit = 10
         query.replyLimit = 10
-        query.watch = true
 
         let endpoint = Endpoint<ThreadListPayload>.threads(query: query)
         let body = try AnyEndpoint(endpoint).bodyAsDictionary()

--- a/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
@@ -1,0 +1,204 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChatThreadListController_Tests: XCTestCase {
+    var client: ChatClient_Mock!
+    var channelId: ChannelId!
+    var controller: ChatThreadListController!
+    var updaterMock: ThreadListUpdater_Mock!
+
+    override func setUp() {
+        super.setUp()
+        client = ChatClient.mock
+        channelId = .unique
+        updaterMock = ThreadListUpdater_Mock()
+        controller = makeController(updater: updaterMock)
+    }
+
+    func test_synchronize_whenSuccess() {
+        let exp = expectation(description: "synchronize completion")
+        controller = makeController()
+        controller.synchronize { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        XCTAssertEqual(updaterMock.loadThreadsCalledWith?.limit, controller.query.limit)
+
+        updaterMock.loadThreadsCompletion?(.success([
+            .mock(),
+            .mock()
+        ]))
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertEqual(controller.state, .remoteDataFetched)
+        XCTAssertTrue(controller.hasLoadedAllOlderThreads)
+    }
+
+    func test_synchronize_whenSuccess_whenMoreThreadsThanLimit() {
+        let exp = expectation(description: "synchronize completion")
+        var query = ThreadListQuery(watch: true)
+        query.limit = 2
+        controller = makeController(query: query)
+        controller.synchronize { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+
+        updaterMock.loadThreadsCompletion?(.success([
+            .mock(),
+            .mock(),
+            .mock(),
+            .mock()
+        ]))
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertFalse(controller.hasLoadedAllOlderThreads)
+    }
+
+    func test_synchronize_whenFailure() {
+        let exp = expectation(description: "synchronize completion")
+        controller = makeController()
+        controller.synchronize { error in
+            XCTAssertNotNil(error)
+            exp.fulfill()
+        }
+        updaterMock.loadThreadsCompletion?(.failure(ClientError()))
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertFalse(controller.hasLoadedAllOlderThreads)
+        switch controller.state {
+        case .remoteDataFetchFailed:
+            break
+        default:
+            XCTFail()
+        }
+    }
+    
+    func test_loadOlderThreads_whenSuccess() {
+        let exp = expectation(description: "loadOlderThreads completion")
+        controller = makeController()
+        controller.loadOlderThreads() { result in
+            let threads = try? result.get()
+            XCTAssertNotNil(threads)
+            exp.fulfill()
+        }
+        XCTAssertEqual(updaterMock.loadThreadsCalledWith?.limit, controller.query.limit)
+
+        updaterMock.loadThreadsCompletion?(.success([
+            .mock(),
+            .mock()
+        ]))
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertTrue(controller.hasLoadedAllOlderThreads)
+    }
+
+    func test_loadOlderThreads_whenSuccess_whenMoreThreadsThanLimit() {
+        let exp = expectation(description: "loadOlderThreads completion")
+        controller = makeController()
+        controller.loadOlderThreads(limit: 2) { result in
+            let threads = try? result.get()
+            XCTAssertNotNil(threads)
+            exp.fulfill()
+        }
+        XCTAssertEqual(updaterMock.loadThreadsCalledWith?.limit, 2)
+
+        updaterMock.loadThreadsCompletion?(.success([
+            .mock(),
+            .mock(),
+            .mock()
+        ]))
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertFalse(controller.hasLoadedAllOlderThreads)
+    }
+
+    func test_loadOlderThreads_whenFailure() {
+        let exp = expectation(description: "synchronize completion")
+        controller = makeController()
+        controller.loadOlderThreads() { error in
+            XCTAssertNotNil(error)
+            exp.fulfill()
+        }
+        updaterMock.loadThreadsCompletion?(.failure(ClientError()))
+
+        wait(for: [exp], timeout: defaultTimeout)
+    }
+
+    func test_observer_triggerDidChangeThreads_threadsHaveCorrectOrder() throws {
+        class DelegateMock: ChatThreadListControllerDelegate {
+            var threads: [ChatThread] = []
+            func controller(
+                _ controller: ChatThreadListController,
+                didChangeThreads changes: [ListChange<ChatThread>]
+            ) {
+                threads = Array(controller.threads)
+            }
+        }
+
+        let delegate = DelegateMock()
+        controller.synchronize()
+        controller.delegate = delegate
+
+        try client.databaseContainer.writeSynchronously { session in
+            let date = Date.unique
+            session.saveThreadList(payload: .init(
+                threads: [
+                    .dummy(
+                        parentMessageId: .unique,
+                        updatedAt: date.addingTimeInterval(3),
+                        title: "1"
+                    ),
+                    .dummy(
+                        parentMessageId: .unique,
+                        updatedAt: date.addingTimeInterval(2),
+                        title: "2"
+                    ),
+                    .dummy(
+                        parentMessageId: .unique,
+                        updatedAt: date.addingTimeInterval(1),
+                        title: "3"
+                    )
+                ],
+                next: nil
+            ))
+        }
+
+        XCTAssertEqual(controller.threads.count, 3)
+        XCTAssertEqual(delegate.threads.map(\.title), ["1", "2", "3"])
+    }
+}
+
+// MARK: - Helpers
+
+extension ChatThreadListController_Tests {
+    func makeController(
+        query: ThreadListQuery = .init(watch: true),
+        updater: ThreadListUpdater? = nil,
+        observer: ListDatabaseObserverWrapper<ChatThread, ThreadDTO>? = nil
+    ) -> ChatThreadListController {
+        ChatThreadListController(
+            query: query,
+            client: client,
+            environment: .init(
+                threadListUpdaterBuilder: { _, _ in
+                    updater ?? self.updaterMock
+                },
+                createThreadListDatabaseObserver: { _, database, fetchRequest, itemCreator in
+                    observer ?? .init(
+                        isBackground: false,
+                        database: database,
+                        fetchRequest: fetchRequest,
+                        itemCreator: itemCreator
+                    )
+                }
+            )
+        )
+    }
+}

--- a/Tests/StreamChatTests/Database/DTOs/ThreadDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ThreadDTO_Tests.swift
@@ -32,8 +32,7 @@ final class ThreadDTO_Tests: XCTestCase {
         )
 
         let dto = database.viewContext.saveThreadList(
-            payload: payload,
-            query: nil
+            payload: payload
         )
 
         XCTAssertEqual(dto.count, 2)
@@ -58,7 +57,6 @@ final class ThreadDTO_Tests: XCTestCase {
 
         let dto = try database.viewContext.saveThread(
             payload: payload,
-            query: nil,
             cache: nil
         )
 
@@ -96,7 +94,6 @@ final class ThreadDTO_Tests: XCTestCase {
 
         let dto = try database.viewContext.saveThread(
             payload: payload,
-            query: nil,
             cache: nil
         )
 

--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -96,8 +96,7 @@ final class DatabaseContainer_Tests: XCTestCase {
                         self.dummyThreadPayload()
                     ],
                     next: nil
-                ),
-                query: nil
+                )
             )
             try session.saveUser(payload: .dummy(userId: .unique), query: .user(withID: currentUserId), cache: nil)
             try session.saveUser(payload: .dummy(userId: .unique))

--- a/Tests/StreamChatTests/Workers/ThreadListUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ThreadListUpdater_Tests.swift
@@ -1,0 +1,170 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ThreadListUpdater_Tests: XCTestCase {
+    var apiClient: APIClient_Spy!
+    var database: DatabaseContainer!
+    var updater: ThreadListUpdater!
+
+    override func setUp() {
+        super.setUp()
+
+        apiClient = APIClient_Spy()
+        database = DatabaseContainer_Spy()
+        updater = ThreadListUpdater(database: database, apiClient: apiClient)
+    }
+
+    override func tearDown() {
+        apiClient.cleanUp()
+
+        apiClient = nil
+        updater = nil
+        database = nil
+
+        super.tearDown()
+    }
+
+    func test_loadThreads_whenSuccessful() throws {
+        let messageId = MessageId.unique
+        let channelId = ChannelId.unique
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: .dummy(channel: .dummy(cid: channelId)))
+            try session.saveMessage(
+                payload: .dummy(messageId: messageId),
+                for: channelId,
+                syncOwnReactions: false,
+                cache: nil
+            )
+        }
+
+        let payload = ThreadListPayload(
+            threads: [
+                .dummy(
+                    parentMessageId: messageId,
+                    channel: .dummy(cid: channelId),
+                    replyCount: 3,
+                    participantCount: 3,
+                    threadParticipants: [
+                        dummyThreadParticipantPayload(),
+                        dummyThreadParticipantPayload(),
+                        dummyThreadParticipantPayload()
+                    ],
+                    title: "Test",
+                    latestReplies: [.dummy(), .dummy()],
+                    read: [
+                        dummyThreadReadPayload(unreadMessagesCount: 3),
+                        dummyThreadReadPayload(unreadMessagesCount: 3)
+                    ]
+                ),
+                .dummy(parentMessageId: .unique, channel: .dummy(cid: channelId)),
+                .dummy(parentMessageId: .unique, channel: .dummy(cid: .unique))
+            ],
+            next: .unique
+        )
+
+        let query = ThreadListQuery(watch: true)
+        let completionCalled = expectation(description: "completion called")
+        updater.loadThreads(query: query) { result in
+            XCTAssertNil(result.error)
+            XCTAssertEqual(result.value?.count, 3)
+            completionCalled.fulfill()
+        }
+
+        apiClient.test_simulateResponse(.success(payload))
+
+        wait(for: [completionCalled], timeout: defaultTimeout)
+
+        let referenceEndpoint: Endpoint<ThreadListPayload> = .threads(
+            query: query
+        )
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+
+        let loadedThreads = payload.threads.map {
+            database.viewContext.thread(parentMessageId: $0.parentMessageId, cache: nil)
+        }
+        XCTAssertEqual(loadedThreads.count, 3)
+        XCTAssertEqual(updater.nextCursor, payload.next)
+    }
+
+    func test_loadThreads_whenFirstPage_deletesPreviousThreads() throws {
+        let messageId = MessageId.unique
+        let channelId = ChannelId.unique
+        let previousThreads = [MessageId.unique, MessageId.unique]
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: .dummy(channel: .dummy(cid: channelId)))
+            try session.saveMessage(
+                payload: .dummy(messageId: messageId),
+                for: channelId,
+                syncOwnReactions: false,
+                cache: nil
+            )
+            // Save previous threads
+            try previousThreads.forEach { previousThreadId in
+                try session.saveThread(
+                    payload: .dummy(parentMessageId: previousThreadId, channel: .dummy(cid: channelId)),
+                    cache: nil
+                )
+            }
+        }
+
+        var loadedPreviousThreads: [ThreadDTO] {
+            previousThreads.compactMap { database.viewContext.thread(parentMessageId: $0, cache: nil) }
+        }
+        XCTAssertEqual(loadedPreviousThreads.count, 2)
+
+        let payload = ThreadListPayload(
+            threads: [
+                .dummy(parentMessageId: .unique, channel: .dummy(cid: .unique)),
+                .dummy(parentMessageId: .unique, channel: .dummy(cid: .unique)),
+                .dummy(parentMessageId: .unique, channel: .dummy(cid: .unique))
+            ],
+            next: nil
+        )
+
+        let query = ThreadListQuery(watch: true)
+        var completionCalled = expectation(description: "completion called")
+        updater.loadThreads(query: query) { result in
+            XCTAssertNil(result.error)
+            XCTAssertEqual(result.value?.count, 3)
+            completionCalled.fulfill()
+        }
+
+        apiClient.test_simulateResponse(.success(payload))
+        wait(for: [completionCalled], timeout: defaultTimeout)
+
+        let referenceEndpoint: Endpoint<ThreadListPayload> = .threads(
+            query: query
+        )
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+
+        let loadedThreads = payload.threads.map {
+            database.viewContext.thread(parentMessageId: $0.parentMessageId, cache: nil)
+        }
+        XCTAssertEqual(loadedThreads.count, 3)
+        XCTAssertEqual(loadedPreviousThreads.count, 0)
+    }
+
+    func test_loadThreads_whenFailure() throws {
+        let query = ThreadListQuery(watch: true)
+        let completionCalled = expectation(description: "completion called")
+        updater.loadThreads(query: query) { result in
+            XCTAssertNotNil(result.error)
+            completionCalled.fulfill()
+        }
+
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<ThreadListPayload, Error>.failure(error))
+
+        wait(for: [completionCalled], timeout: defaultTimeout)
+
+        let referenceEndpoint: Endpoint<ThreadListPayload> = .threads(
+            query: query
+        )
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links
Relates to https://github.com/GetStream/ios-issues-tracking/issues/752

### 🎯 Goal
Adds the implementaton of `ChatThreadListController` to be able to fetch the threads of the current user.

### 📝 Summary
- Implementation of `ChatThreadListController` to fetch the threads of the current user (Internal for now, until UI Components are exposed)
- Add default arguments to `ThreadListQuery`, since the optional arguments were confusing and unclear. It is better to have explicit default arguments on the client side.
- Make `watch` a required argument of `ThreadListQuery` so that it is more aligned to the future APIs (like the modern state layer). The goal is for the developer to make a decision on whether he wants to observe changes or not and not make that decision ourselves.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)