### PR TITLE
Do not add non-answer to poll's latestAnswers

### DIFF
--- a/Sources/StreamChat/Database/DTOs/PollVoteDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/PollVoteDTO.swift
@@ -179,6 +179,7 @@ extension NSManagedObjectContext {
         if let optionId {
             let currentVoteCount = poll.voteCountsByOption?[optionId] ?? 0
             poll.voteCountsByOption?[optionId] = currentVoteCount + 1
+            poll.latestAnswers.remove(dto)
         }
         
         if let query = query {

--- a/Tests/StreamChatTests/Repositories/PollsRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/PollsRepository_Tests.swift
@@ -271,6 +271,44 @@ final class PollsRepository_Tests: XCTestCase {
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
     
+    func test_castPollVote_whenLocallySaving_thenLatestAnswerDoesNotIncludeVote() throws {
+        let completionCalled = expectation(description: "completion called")
+        let pollId = "123"
+        let messageId: String = .unique
+        let pollOptionId = "345"
+        
+        try database.writeSynchronously { session in
+            try session.savePoll(
+                payload: self.dummyPollPayload(
+                    id: pollId,
+                    options: [self.dummyPollOptionPayload(id: pollOptionId)]
+                ),
+                cache: nil
+            )
+        }
+        
+        repository.castPollVote(
+            messageId: messageId,
+            pollId: pollId,
+            answerText: nil,
+            optionId: pollOptionId,
+            currentUserId: .unique,
+            query: nil,
+            deleteExistingVotes: []
+        ) { _ in
+            completionCalled.fulfill()
+        }
+        wait(for: [apiClient.request_expectation], timeout: defaultTimeout)
+
+        database.backgroundReadOnlyContext.performAndWait {
+            let poll = try? database.backgroundReadOnlyContext.poll(id: pollId)
+            XCTAssertEqual(0, poll?.latestAnswers.count)
+        }
+        
+        apiClient.test_simulateResponse(Result<PollVotePayloadResponse, Error>.failure(TestError()))
+        wait(for: [completionCalled], timeout: defaultTimeout)
+    }
+    
     func test_castPollAnswer_whenSuccess() {
         let completionCalled = expectation(description: "completion called")
         let pollId = "123"


### PR DESCRIPTION
### 🎯 Goal

`Poll.latestAnswers` contained non-answer for a brief moment of time.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)