### PR TITLE
Fix notifications muted state for the current user in channel members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix notifications muted state for the current user in channel members [#3236](https://github.com/GetStream/stream-chat-swift/pull/3236)
 
 # [4.57.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.57.0)
 _June 06, 2024_

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -279,17 +279,18 @@ extension NSManagedObjectContext {
             _ = try saveMessage(payload: $0, channelDTO: dto, syncOwnReactions: true, cache: cache)
         }
 
-        // Sometimes, `members` are not part of `ChannelDetailPayload` so they need to be saved here too.
-        try payload.members.forEach {
-            let member = try saveMember(payload: $0, channelId: payload.channel.cid, query: nil, cache: cache)
-            dto.members.insert(member)
-        }
-
+        // Note: membership payload should be saved before all the members
         if let membership = payload.membership {
             let membership = try saveMember(payload: membership, channelId: payload.channel.cid, query: nil, cache: cache)
             dto.membership = membership
         } else {
             dto.membership = nil
+        }
+        
+        // Sometimes, `members` are not part of `ChannelDetailPayload` so they need to be saved here too.
+        try payload.members.forEach {
+            let member = try saveMember(payload: $0, channelId: payload.channel.cid, query: nil, cache: cache)
+            dto.members.insert(member)
         }
 
         dto.watcherCount = Int64(clamping: payload.watcherCount ?? 0)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/issues/855](https://github.com/GetStream/ios-issues-tracking/issues/855)

### 🎯 Goal

Channel membership can contain invalid notifications_muted value at the moment which was overriding correct data in channel members.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
