### PR TITLE
Fix Core Data model warnings in unit-tests

### DIFF
--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -83,7 +83,7 @@ class DatabaseContainer: NSPersistentContainer {
     private let deletedMessageVisibility: ChatClientConfig.DeletedMessageVisibility?
     private let shouldShowShadowedMessages: Bool?
 
-    static var cachedModel: NSManagedObjectModel?
+    static var cachedModels = [String: NSManagedObjectModel]()
 
     /// All `NSManagedObjectContext`s this container owns.
     private(set) lazy var allContext: [NSManagedObjectContext] = [viewContext, backgroundReadOnlyContext, stateLayerContext, writableContext]
@@ -111,7 +111,7 @@ class DatabaseContainer: NSPersistentContainer {
         shouldShowShadowedMessages: Bool? = nil
     ) {
         let managedObjectModel: NSManagedObjectModel
-        if let cachedModel = Self.cachedModel {
+        if let cachedModel = Self.cachedModels[modelName] {
             managedObjectModel = cachedModel
         } else {
             // It's safe to unwrap the following values because this is not settable by users and it's always a programmer error.
@@ -119,7 +119,7 @@ class DatabaseContainer: NSPersistentContainer {
             let modelURL = bundle.url(forResource: modelName, withExtension: "momd")!
             let model = NSManagedObjectModel(contentsOf: modelURL)!
             managedObjectModel = model
-            Self.cachedModel = model
+            Self.cachedModels[modelName] = model
         }
 
         self.localCachingSettings = localCachingSettings

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -31,7 +31,6 @@ public final class DatabaseContainer_Spy: DatabaseContainer, Spy {
     private(set) var sessionMock: DatabaseSession_Mock?
 
     public convenience init(localCachingSettings: ChatClientConfig.LocalCaching? = nil) {
-        Self.cachedModel = nil
         self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), localCachingSettings: localCachingSettings)
         shouldCleanUpTempDBFiles = true
     }
@@ -46,7 +45,6 @@ public final class DatabaseContainer_Spy: DatabaseContainer, Spy {
         deletedMessagesVisibility: ChatClientConfig.DeletedMessageVisibility? = nil,
         shouldShowShadowedMessages: Bool? = nil
     ) {
-        Self.cachedModel = nil
         init_kind = kind
         super.init(
             kind: kind,
@@ -61,7 +59,6 @@ public final class DatabaseContainer_Spy: DatabaseContainer, Spy {
     }
 
     convenience init(sessionMock: DatabaseSession_Mock) {
-        Self.cachedModel = nil
         self.init(kind: .inMemory)
         self.sessionMock = sessionMock
     }


### PR DESCRIPTION
### 🎯 Goal

Fix warnings like these in unit-tests:
```
Warning:  	 'UserListQueryDTO' (0x60000b5714a0) from NSManagedObjectModel (0x6000024e3a20) claims 'UserListQueryDTO'.

Error: -11 07:06:27.705004+0000 xctest[13294:90482] [error] warning:  	 'UserListQueryDTO' (0x60000b5718c0) from NSManagedObjectModel (0x6000024ada90) claims 'UserListQueryDTO'.
```

### 🛠 Implementation

Allow creating the managed object context model only once

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)