### PR TITLE
Fix `channel.pinnedMessages` with missing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Fix channel.pinnedMessages with missing messages [#3244](https://github.com/GetStream/stream-chat-swift/pull/3244)
+- Fix `channel.pinnedMessages` with missing messages [#3244](https://github.com/GetStream/stream-chat-swift/pull/3244)
 
 # [4.57.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.57.0)
 _June 06, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix channel.pinnedMessages with missing messages [#3244](https://github.com/GetStream/stream-chat-swift/pull/3244)
 
 # [4.57.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.57.0)
 _June 06, 2024_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -774,7 +774,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
 
         if dto.pinned && !channelDTO.pinnedMessages.contains(dto) {
             channelDTO.pinnedMessages.insert(dto)
-        } else {
+        } else if !dto.pinned {
             channelDTO.pinnedMessages.remove(dto)
         }
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/862

### 🎯 Goal
Fixes `channel.pinnedMessages` not containing the whole data from the server.

### 🛠 Implementation
The logic was incorrect. We were removing the pinned messages from `channel.pinnedMessages` if they already existed in the array. This is wrong. It should only be removed if they are not pinned anymore.

### 🧪 Manual Testing Notes
Not required. Covered by unit tests.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)