### PR TITLE
Reset channel members and watchers states when fetching the initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Reset channel members and watchers state when fetching the initial state of the channel [#3245](https://github.com/GetStream/stream-chat-swift/pull/3245)
 
 # [4.57.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.57.0)
 _June 06, 2024_


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/issues/866](https://github.com/GetStream/ios-issues-tracking/issues/866)

### 🎯 Goal

* Reset members and watches when resetting the channel data to the initial state

### 📝 Summary

* When we run synchronize then we should reset member data since members might have been removed
* It was fixed for chat state layer and state layer has tests for this already.

### 🧪 Manual Testing Notes

- Log in with Luke on device 1
- Log in with Han on device 2
- Luke creates a channel with Han
- Han opens the channel and sees that they are both part of the channel
- Han quits the demo app on device 2
- Luke leaves the channel
- Han launches the app again and navigates to the channel

What happens: Luke is shown as a member
Expected: Luke is not shown as a member for Han 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)