### PR TITLE
[CI] Random test failure with test_loadReplies_whenIsFirstPage_shouldClearCurrentMessagesExcludingLocalOnly

### DIFF
--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -130,6 +130,19 @@ public final class DatabaseContainer_Spy: DatabaseContainer, Spy {
 }
 
 extension DatabaseContainer {
+    /// Reads changes from the DB synchronously. Only for test purposes!
+    func readSynchronously<T>(_ actions: @escaping (DatabaseSession) throws -> T) throws -> T {
+        let result = try waitFor { completion in
+            self.read(actions, completion: completion)
+        }
+        switch result {
+        case .success(let values):
+            return values
+        case .failure(let error):
+            throw error
+        }
+    }
+    
     /// Writes changes to the DB synchronously. Only for test purposes!
     func writeSynchronously(_ actions: @escaping (DatabaseSession) throws -> Void) throws {
         let error = try waitFor { completion in

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -2783,6 +2783,14 @@ extension MessageUpdater_Tests {
         line: UInt = #line,
         file: StaticString = #filePath
     ) throws {
+        func showsInsideThread(messageIds: [MessageId]) throws -> [Bool] {
+            try database.readSynchronously { session in
+                messageIds
+                    .compactMap { session.message(id: $0) }
+                    .map(\.showInsideThread)
+            }
+        }
+        
         let parentMessageId = MessageId.unique
         let currentUserId: UserId = .unique
         let currentMessageIds: [MessageId] = [.unique, .unique, .unique]
@@ -2811,11 +2819,7 @@ extension MessageUpdater_Tests {
             }
         }
 
-        var currentMessageDTOs: [MessageDTO] {
-            currentMessageIds.compactMap { database.viewContext.message(id: $0) }
-        }
-
-        XCTAssertEqual(currentMessageDTOs.map(\.showInsideThread), [true, true, true])
+        try XCTAssertEqual(showsInsideThread(messageIds: currentMessageIds), [true, true, true])
 
         // Simulate `loadReplies` call
         let exp = expectation(description: "should load replies")
@@ -2831,19 +2835,30 @@ extension MessageUpdater_Tests {
 
         waitForExpectations(timeout: defaultTimeout)
 
-        var newMessageDTOs: [MessageDTO] {
-            messageIds.compactMap { database.viewContext.message(id: $0) }
-        }
-
         if shouldClear {
             // Previous current messages are not shown (excluding local messages).
-            XCTAssertEqual(currentMessageDTOs.filter { $0.showInsideThread }.count, 1, file: file, line: line)
+            try XCTAssertEqual(
+                showsInsideThread(messageIds: currentMessageIds).filter { $0 }.count,
+                1,
+                file: file,
+                line: line
+            )
         } else {
             // Previous current messages are not discarded.
-            XCTAssertEqual(currentMessageDTOs.map(\.showInsideThread), [true, true, true], file: file, line: line)
+            try XCTAssertEqual(
+                showsInsideThread(messageIds: currentMessageIds),
+                [true, true, true],
+                file: file,
+                line: line
+            )
         }
 
         // Newly fetched messages are shown.
-        XCTAssertEqual(newMessageDTOs.map(\.showInsideThread), [true, true, true], file: file, line: line)
+        try XCTAssertEqual(
+            showsInsideThread(messageIds: messageIds),
+            [true, true, true],
+            file: file,
+            line: line
+        )
     }
 }


### PR DESCRIPTION
### 🎯 Goal

test_loadReplies_whenIsFirstPage_shouldClearCurrentMessagesExcludingLocalOnly sometimes fails on CI with 
```
XCTAssertEqual failed: ("1") is not equal to ("3")
[07:04:25]: ▸ Test Case '-[StreamChatTests.MessageUpdater_Tests 
```
I think it is related to timing in that test where we modify data using writableContext and then expect DTOs created using the view context to update immediately.

### 📝 Summary

* Read data from DB every time when asserting
* Add convenience read methods

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)