### PR TITLE
Add an option to switch API keys in the tests

### DIFF
--- a/DemoApp/Shared/DemoUsers.swift
+++ b/DemoApp/Shared/DemoUsers.swift
@@ -5,7 +5,7 @@
 import Foundation
 import StreamChat
 
-let apiKeyString = "8br4watad788"
+let apiKeyString = ProcessInfo.processInfo.arguments.contains("SWIFTUI_API_KEY") ? "zcgvnykxsfm8" : "8br4watad788"
 let applicationGroupIdentifier = "group.io.getstream.iOS.ChatDemoApp"
 
 enum DemoUserType {

--- a/StreamChatUITestsApp/StreamChat/User.swift
+++ b/StreamChatUITestsApp/StreamChat/User.swift
@@ -8,10 +8,22 @@ import StreamChat
 extension UserCredentials {
 
     static var `default`: UserCredentials {
+        ProcessInfo.processInfo.arguments.contains("SWIFTUI_API_KEY") ? .swiftUI : .swift
+    }
+
+    static var swift: UserCredentials {
         UserCredentials(id: "luke_skywalker",
                         name: "Luke Skywalker",
                         avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg")!,
                         token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0",
+                        birthLand: "Tatooine")
+    }
+    
+    static var swiftUI: UserCredentials {
+        UserCredentials(id: "luke_skywalker",
+                        name: "Luke Skywalker",
+                        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg")!,
+                        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.b6EiC8dq2AHk0JPfI-6PN-AM9TVzt8JV-qB1N9kchlI",
                         birthLand: "Tatooine")
     }
 }

--- a/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
@@ -16,6 +16,7 @@ class StreamTestCase: XCTestCase {
     var server: StreamMockServer!
     var recordVideo = false
     var mockServerEnabled = true
+    var switchApiKey = false
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -58,6 +59,9 @@ extension StreamTestCase {
                 .httpHost: "\(MockServerConfiguration.httpHost)",
                 .port: "\(MockServerConfiguration.port)"
             ])
+        } else if switchApiKey {
+            // Use SwiftUI api key instead
+            app.setLaunchArguments(.switchApiKey)
         }
     }
 

--- a/StreamChatUITestsAppUITests/Tests/Performance/ChannelListScrollTime.swift
+++ b/StreamChatUITestsAppUITests/Tests/Performance/ChannelListScrollTime.swift
@@ -9,12 +9,12 @@ class ChannelListScrollTime: StreamTestCase {
     
     override func setUpWithError() throws {
         mockServerEnabled = false
+        switchApiKey = true
         try super.setUpWithError()
     }
     
     func testChannelListScrollTime() {
         WHEN("user opens the channel list") {
-            backendRobot.generateChannels(count: 100, messagesCount: 1)
             userRobot.login().waitForChannelListToLoad()
         }
         THEN("user scrolls the channel list") {

--- a/TestTools/StreamChatTestMockServer/Utilities/LaunchArgument.swift
+++ b/TestTools/StreamChatTestMockServer/Utilities/LaunchArgument.swift
@@ -24,6 +24,7 @@ public enum EnvironmentVariable: String {
 
 public enum LaunchArgument: String {
     case useMockServer = "USE_MOCK_SERVER"
+    case switchApiKey = "SWIFTUI_API_KEY"
     case jwt = "MOCK_JWT"
 }
 


### PR DESCRIPTION
### 🎯 Goal

- Fix Performance tests that rely on a stable and filled-in channel list

### 📝 Summary

- Added an option to switch API keys in the tests