### PR TITLE
Add role argument to partial user updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ✅ Added
+- Add `role` argument to partial user updates [#3253](https://github.com/GetStream/stream-chat-swift/pull/3253)
 ### 🐞 Fixed
 - Fix `channel.pinnedMessages` with missing messages [#3244](https://github.com/GetStream/stream-chat-swift/pull/3244)
 - Fix notifications muted state for the current user in channel members [#3236](https://github.com/GetStream/stream-chat-swift/pull/3236)

--- a/DemoApp/Screens/UserProfileViewController.swift
+++ b/DemoApp/Screens/UserProfileViewController.swift
@@ -14,6 +14,7 @@ class UserProfileViewController: UITableViewController, CurrentChatUserControlle
 
     enum UserProperty: CaseIterable {
         case name
+        case role
         case typingIndicatorsEnabled
         case readReceiptsEnabled
     }
@@ -86,6 +87,14 @@ class UserProfileViewController: UITableViewController, CurrentChatUserControlle
             }))
             button.setImage(.init(systemName: "pencil"), for: .normal)
             cell.accessoryView = button
+        case .role:
+            let role = currentUserController.currentUser?.userRole
+            let isAdmin = role == UserRole.admin
+            cell.textLabel?.text = "User Role"
+            cell.detailTextLabel?.text = role?.rawValue ?? "<unknown>"
+            cell.accessoryView = makeButton(title: isAdmin ? "Downgrade" : "Upgrade", action: { [weak currentUserController] in
+                currentUserController?.updateUserData(role: isAdmin ? .user : .admin)
+            })
         case .readReceiptsEnabled:
             cell.textLabel?.text = "Read Receipts Enabled"
             cell.accessoryView = makeSwitchButton(UserConfig.shared.readReceiptsEnabled ?? true) { newValue in
@@ -144,5 +153,13 @@ class UserProfileViewController: UITableViewController, CurrentChatUserControlle
         switchButton.isOn = initialValue
         switchButton.didChangeValue = didChangeValue
         return switchButton
+    }
+
+    private func makeButton(title: String, action: @escaping () -> Void) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setTitle(title, for: .normal)
+        button.addAction(UIAction(handler: { _ in action() }), for: .touchUpInside)
+        button.sizeToFit()
+        return button
     }
 }

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/UserPayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/UserPayloads.swift
@@ -165,17 +165,20 @@ struct UserUpdateRequestBody: Encodable {
     let name: String?
     let imageURL: URL?
     let privacySettings: UserPrivacySettingsPayload?
+    let role: UserRole?
     let extraData: [String: RawJSON]?
 
     init(
         name: String?,
         imageURL: URL?,
         privacySettings: UserPrivacySettingsPayload?,
+        role: UserRole?,
         extraData: [String: RawJSON]?
     ) {
         self.name = name
         self.imageURL = imageURL
         self.privacySettings = privacySettings
+        self.role = role
         self.extraData = extraData
     }
 
@@ -184,6 +187,7 @@ struct UserUpdateRequestBody: Encodable {
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(imageURL, forKey: .imageURL)
         try container.encodeIfPresent(privacySettings, forKey: .privacySettings)
+        try container.encodeIfPresent(role, forKey: .role)
         try extraData?.encode(to: encoder)
     }
 }

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -156,16 +156,20 @@ public extension CurrentChatUserController {
     ///
     /// By default all data is `nil`, and it won't be updated unless a value is provided.
     ///
+    /// - Note: This operation does a partial user update which keeps existing data if not modified.
+    ///
     /// - Parameters:
     ///   - name: Optionally provide a new name to be updated.
     ///   - imageURL: Optionally provide a new image to be updated.
     ///   - privacySettings: The privacy settings of the user. Example: If the user does not want to expose typing events or read events.
+    ///   - role: The role for the user.
     ///   - userExtraData: Optionally provide new user extra data to be updated.
     ///   - completion: Called when user is successfuly updated, or with error.
     func updateUserData(
         name: String? = nil,
         imageURL: URL? = nil,
         privacySettings: UserPrivacySettings? = nil,
+        role: UserRole? = nil,
         userExtraData: [String: RawJSON] = [:],
         completion: ((Error?) -> Void)? = nil
     ) {
@@ -179,6 +183,7 @@ public extension CurrentChatUserController {
             name: name,
             imageURL: imageURL,
             privacySettings: privacySettings,
+            role: role,
             userExtraData: userExtraData
         ) { error in
             self.callback {

--- a/Sources/StreamChat/StateLayer/ConnectedUser.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUser.swift
@@ -39,23 +39,29 @@ public final class ConnectedUser {
     
     /// Updates the currently logged-in user's data.
     ///
-    /// - Note: Setting any arguments to nil will keep the existing value.
+    /// - Note: This does partial update and only updates existing data when a non-nil value is specified.
     ///
     /// - Parameters:
     ///   - name: The name to be set to the user.
     ///   - imageURL: The URL of the avatar image.
+    ///   - privacySettings: The privacy settings of the user. Example: If the user does not want to expose typing events or read events.
+    ///   - role: The role for the user.
     ///   - extraData: Additional data associated with the user.
     ///
     /// - Throws: An error while communicating with the Stream API or when user is not logged in.
     public func update(
         name: String? = nil,
         imageURL: URL? = nil,
+        privacySettings: UserPrivacySettings? = nil,
+        role: UserRole? = nil,
         extraData: [String: RawJSON] = [:]
     ) async throws {
         try await currentUserUpdater.updateUserData(
             currentUserId: try currentUserId(),
             name: name,
             imageURL: imageURL,
+            privacySettings: privacySettings,
+            role: role,
             userExtraData: extraData
         )
     }

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -20,10 +20,11 @@ class CurrentUserUpdater: Worker {
     ///   - completion: Called when user is successfuly updated, or with error.
     func updateUserData(
         currentUserId: UserId,
-        name: String? = nil,
-        imageURL: URL? = nil,
-        privacySettings: UserPrivacySettings? = nil,
-        userExtraData: [String: RawJSON]? = nil,
+        name: String?,
+        imageURL: URL?,
+        privacySettings: UserPrivacySettings?,
+        role: UserRole?,
+        userExtraData: [String: RawJSON]?,
         completion: ((Error?) -> Void)? = nil
     ) {
         let params: [Any?] = [name, imageURL, userExtraData]
@@ -37,6 +38,7 @@ class CurrentUserUpdater: Worker {
             name: name,
             imageURL: imageURL,
             privacySettings: privacySettings.map { UserPrivacySettingsPayload(settings: $0) },
+            role: role,
             extraData: userExtraData
         )
 
@@ -206,6 +208,8 @@ extension CurrentUserUpdater {
         currentUserId: UserId,
         name: String?,
         imageURL: URL?,
+        privacySettings: UserPrivacySettings?,
+        role: UserRole?,
         userExtraData: [String: RawJSON]?
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in
@@ -213,6 +217,8 @@ extension CurrentUserUpdater {
                 currentUserId: currentUserId,
                 name: name,
                 imageURL: imageURL,
+                privacySettings: privacySettings,
+                role: role,
                 userExtraData: userExtraData
             ) { error in
                 continuation.resume(with: error)

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
@@ -32,10 +32,11 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
 
     override func updateUserData(
         currentUserId: UserId,
-        name: String? = nil,
-        imageURL: URL? = nil,
-        privacySettings: UserPrivacySettings? = nil,
-        userExtraData: [String: RawJSON]? = nil,
+        name: String?,
+        imageURL: URL?,
+        privacySettings: UserPrivacySettings?,
+        role: UserRole?,
+        userExtraData: [String: RawJSON]?,
         completion: ((Error?) -> Void)? = nil
     ) {
         updateUserData_currentUserId = currentUserId

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/UserPayloads_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/UserPayloads_Tests.swift
@@ -117,6 +117,7 @@ final class UserUpdateRequestBody_Tests: XCTestCase {
                 typingIndicators: .init(enabled: true),
                 readReceipts: .init(enabled: true)
             ),
+            role: .admin,
             extraData: ["secret_note": .string(value)]
         )
 
@@ -127,6 +128,7 @@ final class UserUpdateRequestBody_Tests: XCTestCase {
                 "typing_indicators": ["enabled": true],
                 "read_receipts": ["enabled": true]
             ],
+            "role": UserRole.admin.rawValue,
             "secret_note": value
         ]
 

--- a/Tests/StreamChatTests/APIClient/Endpoints/UserEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/UserEndpoints_Tests.swift
@@ -38,6 +38,7 @@ final class UserEndpoints_Tests: XCTestCase {
                 typingIndicators: .init(enabled: true),
                 readReceipts: .init(enabled: true)
             ),
+            role: .anonymous,
             extraData: ["company": .string(.unique)]
         )
 

--- a/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
@@ -27,13 +27,23 @@ final class ConnectedUser_Tests: XCTestCase {
     func test_updateUser_whenAPIRequestSucceeds_thenStateUpdates() async throws {
         try await setUpConnectedUser(usesMockedUpdaters: false)
         await XCTAssertEqual("InitialName", connectedUser.state.user.name)
+        await XCTAssertEqual(UserRole.admin, connectedUser.state.user.userRole)
         
         let changedName = "Name"
-        let apiResult = CurrentUserUpdateResponse(user: currentUserPayload(name: changedName))
+        let apiResult = CurrentUserUpdateResponse(
+            user: currentUserPayload(
+                name: changedName,
+                role: .user
+            )
+        )
         env.client.mockAPIClient.test_mockResponseResult(.success(apiResult))
-        try await connectedUser.update(name: changedName)
+        try await connectedUser.update(
+            name: changedName,
+            role: .user
+        )
 
         await XCTAssertEqual(changedName, connectedUser.state.user.name)
+        await XCTAssertEqual(UserRole.user, connectedUser.state.user.userRole)
     }
     
     func test_markAllChannelsRead_whenAPIRequestSucceeds_thenMarkAllSucceeds() async throws {
@@ -151,12 +161,12 @@ final class ConnectedUser_Tests: XCTestCase {
         }
     }
     
-    private func currentUserPayload(name: String = "InitialName", deviceCount: Int = 0) -> CurrentUserPayload {
+    private func currentUserPayload(name: String = "InitialName", deviceCount: Int = 0, role: UserRole = .admin) -> CurrentUserPayload {
         let devices = (0..<deviceCount).map { _ in DevicePayload.dummy }
         return CurrentUserPayload.dummy(
             userId: connectedUserId,
             name: name,
-            role: .admin,
+            role: role,
             devices: devices
         )
     }

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -55,6 +55,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         let expectedId = userPayload.id
         let expectedName = String.unique
         let expectedImageUrl = URL.unique()
+        let expectedRole = UserRole.guest
 
         // Call update user
         currentUserUpdater.updateUserData(
@@ -65,6 +66,8 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 typingIndicators: .init(enabled: true),
                 readReceipts: .init(enabled: true)
             ),
+            role: expectedRole,
+            userExtraData: nil,
             completion: { error in
                 XCTAssertNil(error)
             }
@@ -76,6 +79,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 userId: userPayload.id,
                 name: expectedName,
                 imageUrl: expectedImageUrl,
+                role: expectedRole,
                 privacySettings: .init(
                     typingIndicators: .init(enabled: true),
                     readReceipts: .init(enabled: true)
@@ -94,6 +98,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                     typingIndicators: .init(enabled: true),
                     readReceipts: .init(enabled: true)
                 ),
+                role: expectedRole,
                 extraData: [:]
             )
         )
@@ -111,6 +116,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         let expectedId = userPayload.id
         let expectedName = String.unique
         let expectedImageUrl = URL.unique()
+        let expectedRole = UserRole.anonymous
 
         // Call update user
         var completionCalled = false
@@ -122,6 +128,8 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 typingIndicators: .init(enabled: false),
                 readReceipts: .init(enabled: false)
             ),
+            role: expectedRole,
+            userExtraData: nil,
             completion: { _ in
                 completionCalled = true
             }
@@ -133,6 +141,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 userId: userPayload.id,
                 name: expectedName,
                 imageUrl: expectedImageUrl,
+                role: expectedRole,
                 privacySettings: .init(
                     typingIndicators: .init(enabled: false),
                     readReceipts: .init(enabled: false)
@@ -169,6 +178,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             currentUserId: userPayload.id,
             name: .unique,
             imageURL: nil,
+            privacySettings: nil,
+            role: nil,
+            userExtraData: [:],
             completion: { error in
                 completionError = error
             }
@@ -199,6 +211,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 currentUserId: .unique,
                 name: nil,
                 imageURL: nil,
+                privacySettings: nil,
+                role: nil,
+                userExtraData: nil,
                 completion: $0
             )
         }
@@ -224,6 +239,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             currentUserId: .unique,
             name: .unique,
             imageURL: nil,
+            privacySettings: nil,
+            role: nil,
+            userExtraData: nil,
             completion: { error in
                 completionError = error
             }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/issues/867](https://github.com/GetStream/ios-issues-tracking/issues/867)

### 🎯 Goal

Allow changing current user's role

### 📝 Summary

* Add `role` argument to user update events
* Add `privacySettings` to `CurrentUser`'s user update method (state layer)
* Remove default values from `CurrentUserUpdater` for forcing to fix all call sites

### 🧪 Manual Testing Notes

1. Log in with user and open profile
2. Tap on the "Upgrade" button for changing the user role from `user` to `admin`
3. Logout and login with the same user
4. Observe that the profile shows update user role

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
