### PR TITLE
[Demo app] Fallback to jpeg path extension if the downloaded file does not specify it

### DIFF
--- a/DemoAppPush/NotificationService.swift
+++ b/DemoAppPush/NotificationService.swift
@@ -28,7 +28,11 @@ class NotificationService: UNNotificationServiceExtension {
                 return
             }
 
-            let localURL = URL(fileURLWithPath: path).appendingPathComponent(url.lastPathComponent)
+            // UNNotificationAttachment requires path extension to be set (fallback to jpeg if not set)
+            var localURL = URL(fileURLWithPath: path).appendingPathComponent(UUID().uuidString + url.lastPathComponent)
+            if localURL.pathExtension.isEmpty {
+                localURL.appendPathExtension("jpeg")
+            }
 
             do {
                 try FileManager.default.moveItem(at: downloadedUrl, to: localURL)


### PR DESCRIPTION
### 🔗 Issue Links

Related [ios-issues-tracking/issues/872](https://github.com/GetStream/ios-issues-tracking/issues/872)

### 🎯 Goal

When notification extension downloads an image without path extension, UNNotificationAttachment creation fails. Just fallback to jpeg if not set.

Example is google maps and static links to maps.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
