### PR TITLE
Significantly improve performance of database observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reset channel members and watchers state when fetching the initial state of the channel [#3245](https://github.com/GetStream/stream-chat-swift/pull/3245)
 - Fix inconsistent message text when extremely quickly updating it [#3242](https://github.com/GetStream/stream-chat-swift/pull/3242)
 - Fix message attachments returning nil sometimes in push notification extensions [#3261](https://github.com/GetStream/stream-chat-swift/pull/3261)
+- Significantly improve performance of database observers [#3260](https://github.com/GetStream/stream-chat-swift/pull/3260)
 ### 🔄 Changed
 - Enable background mapping by default, which improves performance overall [#3250](https://github.com/GetStream/stream-chat-swift/pull/3250)
 

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -39,6 +39,8 @@ public enum StreamRuntimeCheck {
     ///  Enables using our legacy web socket connection.
     public static var _useLegacyWebSocketConnection = false
     
+    /// For *internal use* only
+    ///
     /// Enables reusing unchanged converted items in database observers.
-    public static var isDatabaseObserverItemReusingEnabled = true
+    public static var _isDatabaseObserverItemReusingEnabled = true
 }

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -38,4 +38,7 @@ public enum StreamRuntimeCheck {
     ///
     ///  Enables using our legacy web socket connection.
     public static var _useLegacyWebSocketConnection = false
+    
+    /// Enables reusing unchanged converted items in database observers.
+    public static var isDatabaseObserverItemReusingEnabled = true
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1550,7 +1550,8 @@ private extension ChatChannelController {
                     deletedMessagesVisibility: deletedMessageVisibility ?? .visibleForCurrentUser,
                     shouldShowShadowedMessages: shouldShowShadowedMessages ?? false
                 ),
-                itemCreator: { try $0.asModel() as ChatMessage }
+                itemCreator: { try $0.asModel() as ChatMessage },
+                itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id)
             )
             observer.onDidChange = { [weak self] changes in
                 self?.delegateCallback {

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -279,7 +279,14 @@ extension ChatChannelListController {
             _ sorting: [SortValue<ChatChannel>]
         )
             -> ListDatabaseObserverWrapper<ChatChannel, ChannelDTO> = {
-                ListDatabaseObserverWrapper(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3, sorting: $4)
+                ListDatabaseObserverWrapper(
+                    isBackground: $0,
+                    database: $1,
+                    fetchRequest: $2,
+                    itemCreator: $3,
+                    itemReuseKeyPaths: (\ChatChannel.cid.rawValue, \ChannelDTO.cid),
+                    sorting: $4
+                )
             }
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
@@ -157,6 +157,7 @@ extension ChatChannelWatcherListController {
                 database: $1,
                 fetchRequest: $2,
                 itemCreator: $3,
+                itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id),
                 fetchedResultsControllerType: $4
             )
         }

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundListDatabaseObserver.swift
@@ -61,6 +61,7 @@ class ListDatabaseObserverWrapper<Item, DTO: NSManagedObject> {
         database: DatabaseContainer,
         fetchRequest: NSFetchRequest<DTO>,
         itemCreator: @escaping (DTO) throws -> Item,
+        itemReuseKeyPaths: (item: KeyPath<Item, String>, dto: KeyPath<DTO, String>)?,
         sorting: [SortValue<Item>] = [],
         fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type = NSFetchedResultsController<DTO>.self
     ) {
@@ -70,6 +71,7 @@ class ListDatabaseObserverWrapper<Item, DTO: NSManagedObject> {
                 context: database.backgroundReadOnlyContext,
                 fetchRequest: fetchRequest,
                 itemCreator: itemCreator,
+                itemReuseKeyPaths: itemReuseKeyPaths,
                 sorting: sorting,
                 fetchedResultsControllerType: fetchedResultsControllerType
             )
@@ -78,6 +80,7 @@ class ListDatabaseObserverWrapper<Item, DTO: NSManagedObject> {
                 context: database.viewContext,
                 fetchRequest: fetchRequest,
                 itemCreator: itemCreator,
+                itemReuseKeyPaths: itemReuseKeyPaths,
                 sorting: sorting,
                 fetchedResultsControllerType: fetchedResultsControllerType
             )
@@ -104,6 +107,7 @@ class BackgroundListDatabaseObserver<Item, DTO: NSManagedObject>: BackgroundData
         context: NSManagedObjectContext,
         fetchRequest: NSFetchRequest<DTO>,
         itemCreator: @escaping (DTO) throws -> Item,
+        itemReuseKeyPaths: (item: KeyPath<Item, String>, dto: KeyPath<DTO, String>)? = nil,
         sorting: [SortValue<Item>],
         fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type = NSFetchedResultsController<DTO>.self
     ) {
@@ -111,6 +115,7 @@ class BackgroundListDatabaseObserver<Item, DTO: NSManagedObject>: BackgroundData
             context: context,
             fetchRequest: fetchRequest,
             itemCreator: itemCreator,
+            itemReuseKeyPaths: itemReuseKeyPaths,
             sorting: sorting,
             fetchedResultsControllerType: fetchedResultsControllerType
         )

--- a/Sources/StreamChat/Controllers/DatabaseObserver/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/ListDatabaseObserver.swift
@@ -182,6 +182,7 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
     private(set) var frc: NSFetchedResultsController<DTO>!
 
     let itemCreator: (DTO) throws -> Item
+    let itemReuseKeyPaths: (item: KeyPath<Item, String>, dto: KeyPath<DTO, String>)?
     let sorting: [SortValue<Item>]
     let request: NSFetchRequest<DTO>
     let context: NSManagedObjectContext
@@ -206,12 +207,14 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
         context: NSManagedObjectContext,
         fetchRequest: NSFetchRequest<DTO>,
         itemCreator: @escaping (DTO) throws -> Item,
+        itemReuseKeyPaths: (item: KeyPath<Item, String>, dto: KeyPath<DTO, String>)? = nil,
         sorting: [SortValue<Item>],
         fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type = NSFetchedResultsController<DTO>.self
     ) {
         self.context = context
         request = fetchRequest
         self.itemCreator = itemCreator
+        self.itemReuseKeyPaths = itemReuseKeyPaths
         self.sorting = sorting
         frc = fetchedResultsControllerType.init(
             fetchRequest: request,

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -169,7 +169,14 @@ extension ChatChannelMemberListController {
             _ itemCreator: @escaping (MemberDTO) throws -> ChatChannelMember,
             _ controllerType: NSFetchedResultsController<MemberDTO>.Type
         ) -> ListDatabaseObserverWrapper<ChatChannelMember, MemberDTO> = {
-            .init(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3, fetchedResultsControllerType: $4)
+            .init(
+                isBackground: $0,
+                database: $1,
+                fetchRequest: $2,
+                itemCreator: $3,
+                itemReuseKeyPaths: (\ChatChannelMember.id, \MemberDTO.id),
+                fetchedResultsControllerType: $4
+            )
         }
     }
 }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -757,7 +757,14 @@ extension ChatMessageController {
             _ itemCreator: @escaping (MessageDTO) throws -> ChatMessage,
             _ fetchedResultsControllerType: NSFetchedResultsController<MessageDTO>.Type
         ) -> ListDatabaseObserverWrapper<ChatMessage, MessageDTO> = {
-            .init(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3, fetchedResultsControllerType: $4)
+            .init(
+                isBackground: $0,
+                database: $1,
+                fetchRequest: $2,
+                itemCreator: $3,
+                itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id),
+                fetchedResultsControllerType: $4
+            )
         }
 
         var messageUpdaterBuilder: (

--- a/Sources/StreamChat/Controllers/PollController/PollController.swift
+++ b/Sources/StreamChat/Controllers/PollController/PollController.swift
@@ -313,7 +313,8 @@ extension PollController {
                 isBackground: $0,
                 database: $1,
                 fetchRequest: $2,
-                itemCreator: $3
+                itemCreator: $3,
+                itemReuseKeyPaths: (\PollVote.id, \PollVoteDTO.id)
             )
         }
     }

--- a/Sources/StreamChat/Controllers/PollController/PollVoteListController.swift
+++ b/Sources/StreamChat/Controllers/PollController/PollVoteListController.swift
@@ -194,7 +194,13 @@ extension PollVoteListController {
             _ itemCreator: @escaping (PollVoteDTO) throws -> PollVote
         )
             -> ListDatabaseObserverWrapper<PollVote, PollVoteDTO> = {
-                ListDatabaseObserverWrapper(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3)
+                ListDatabaseObserverWrapper(
+                    isBackground: $0,
+                    database: $1,
+                    fetchRequest: $2,
+                    itemCreator: $3,
+                    itemReuseKeyPaths: (\PollVote.id, \PollVoteDTO.id)
+                )
             }
     }
 }

--- a/Sources/StreamChat/Controllers/ReactionListController/ReactionListController.swift
+++ b/Sources/StreamChat/Controllers/ReactionListController/ReactionListController.swift
@@ -177,7 +177,7 @@ extension ChatReactionListController {
                     database: $1,
                     fetchRequest: $2,
                     itemCreator: $3,
-                    itemReuseKeyPaths: nil // no id
+                    itemReuseKeyPaths: (\ChatMessageReaction.id, \MessageReactionDTO.id)
                 )
             }
     }

--- a/Sources/StreamChat/Controllers/ReactionListController/ReactionListController.swift
+++ b/Sources/StreamChat/Controllers/ReactionListController/ReactionListController.swift
@@ -172,7 +172,13 @@ extension ChatReactionListController {
             _ itemCreator: @escaping (MessageReactionDTO) throws -> ChatMessageReaction
         )
             -> ListDatabaseObserverWrapper<ChatMessageReaction, MessageReactionDTO> = {
-                ListDatabaseObserverWrapper(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3)
+                ListDatabaseObserverWrapper(
+                    isBackground: $0,
+                    database: $1,
+                    fetchRequest: $2,
+                    itemCreator: $3,
+                    itemReuseKeyPaths: nil // no id
+                )
             }
     }
 }

--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -94,7 +94,8 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
             fetchRequest: MessageDTO.messagesFetchRequest(
                 for: lastQuery ?? query
             ),
-            itemCreator: { try $0.asModel() as ChatMessage }
+            itemCreator: { try $0.asModel() as ChatMessage },
+            itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id)
         )
         observer.onDidChange = { [weak self] changes in
             self?.delegateCallback { [weak self] in

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
@@ -208,7 +208,7 @@ extension ChatThreadListController {
                     database: $1,
                     fetchRequest: $2,
                     itemCreator: $3,
-                    itemReuseKeyPaths: nil // no id
+                    itemReuseKeyPaths: (\ChatThread.reuseId, \ThreadDTO.reuseId)
                 )
             }
     }

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
@@ -204,7 +204,11 @@ extension ChatThreadListController {
         )
             -> ListDatabaseObserverWrapper<ChatThread, ThreadDTO> = {
                 ListDatabaseObserverWrapper(
-                    isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3
+                    isBackground: $0,
+                    database: $1,
+                    fetchRequest: $2,
+                    itemCreator: $3,
+                    itemReuseKeyPaths: nil // no id
                 )
             }
     }

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -167,7 +167,13 @@ extension ChatUserListController {
             _ itemCreator: @escaping (UserDTO) throws -> ChatUser
         )
             -> ListDatabaseObserverWrapper<ChatUser, UserDTO> = {
-                ListDatabaseObserverWrapper(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3)
+                ListDatabaseObserverWrapper(
+                    isBackground: $0,
+                    database: $1,
+                    fetchRequest: $2,
+                    itemCreator: $3,
+                    itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id)
+                )
             }
     }
 }

--- a/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -210,6 +210,7 @@ extension MessageReactionDTO {
         }
 
         return try .init(
+            id: id,
             type: .init(rawValue: type),
             score: Int(score),
             createdAt: createdAt?.bridgeDate ?? .init(),

--- a/Sources/StreamChat/Database/DTOs/ThreadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ThreadDTO.swift
@@ -234,3 +234,15 @@ extension NSManagedObjectContext {
         results.forEach { delete($0) }
     }
 }
+
+extension ThreadDTO {
+    var reuseId: String {
+        channel.cid + parentMessageId
+    }
+}
+
+extension ChatThread {
+    var reuseId: String {
+        channel.cid.rawValue + parentMessageId
+    }
+}

--- a/Sources/StreamChat/Models/MessageReaction.swift
+++ b/Sources/StreamChat/Models/MessageReaction.swift
@@ -7,6 +7,8 @@ import Foundation
 /// A type representing a message reaction. `ChatMessageReaction` is an immutable snapshot
 /// of a message reaction entity at the given time.
 public struct ChatMessageReaction: Hashable {
+    let id: String
+    
     /// The reaction type.
     public let type: MessageReactionType
 

--- a/Sources/StreamChat/Models/MessageReaction.swift
+++ b/Sources/StreamChat/Models/MessageReaction.swift
@@ -7,6 +7,7 @@ import Foundation
 /// A type representing a message reaction. `ChatMessageReaction` is an immutable snapshot
 /// of a message reaction entity at the given time.
 public struct ChatMessageReaction: Hashable {
+    /// The id of the reaction.
     let id: String
     
     /// The reaction type.

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -38,6 +38,7 @@ extension ChannelListState {
                     chatClientConfig: clientConfig
                 ),
                 itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: (\ChatChannel.cid.rawValue, \ChannelDTO.cid),
                 sorting: query.sort.runtimeSorting
             )
             channelListLinker = ChannelListLinker(

--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -43,12 +43,14 @@ extension ChatState {
                     shouldShowShadowedMessages: clientConfig.shouldShowShadowedMessages
                 ),
                 itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id),
                 sorting: []
             )
             watchersObserver = StateLayerDatabaseObserver(
                 databaseContainer: database,
                 fetchRequest: UserDTO.watcherFetchRequest(cid: cid),
                 itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id),
                 sorting: []
             )
             self.eventNotificationCenter = eventNotificationCenter

--- a/Sources/StreamChat/StateLayer/MemberListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MemberListState+Observer.swift
@@ -13,7 +13,8 @@ extension MemberListState {
             memberListObserver = StateLayerDatabaseObserver(
                 databaseContainer: database,
                 fetchRequest: MemberDTO.members(matching: query),
-                itemCreator: { try $0.asModel() }
+                itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: (\ChatChannelMember.id, \MemberDTO.id)
             )
         }
         

--- a/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageSearchState+Observer.swift
@@ -41,7 +41,8 @@ extension MessageSearchState {
                 messagesObserver = StateLayerDatabaseObserver(
                     databaseContainer: database,
                     fetchRequest: MessageDTO.messagesFetchRequest(for: query),
-                    itemCreator: { try $0.asModel() }
+                    itemCreator: { try $0.asModel() },
+                    itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id)
                 )
                 do {
                     if let messagesObserver {

--- a/Sources/StreamChat/StateLayer/MessageState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageState+Observer.swift
@@ -31,7 +31,7 @@ extension MessageState {
                     sort: ChatMessageReaction.defaultSortingDescriptors()
                 ),
                 itemCreator: { try $0.asModel() },
-                itemReuseKeyPaths: nil // no id
+                itemReuseKeyPaths: (\ChatMessageReaction.id, \MessageReactionDTO.id)
             )
             repliesObserver = StateLayerDatabaseObserver(
                 databaseContainer: database,

--- a/Sources/StreamChat/StateLayer/MessageState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageState+Observer.swift
@@ -30,7 +30,8 @@ extension MessageState {
                     for: messageId,
                     sort: ChatMessageReaction.defaultSortingDescriptors()
                 ),
-                itemCreator: { try $0.asModel() }
+                itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: nil // no id
             )
             repliesObserver = StateLayerDatabaseObserver(
                 databaseContainer: database,
@@ -41,7 +42,8 @@ extension MessageState {
                     deletedMessagesVisibility: clientConfig.deletedMessagesVisibility,
                     shouldShowShadowedMessages: clientConfig.shouldShowShadowedMessages
                 ),
-                itemCreator: { try $0.asModel() }
+                itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id)
             )
         }
         

--- a/Sources/StreamChat/StateLayer/ReactionListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ReactionListState+Observer.swift
@@ -14,7 +14,7 @@ extension ReactionListState {
                 databaseContainer: database,
                 fetchRequest: MessageReactionDTO.reactionListFetchRequest(query: query),
                 itemCreator: { try $0.asModel() },
-                itemReuseKeyPaths: nil // no id
+                itemReuseKeyPaths: (\ChatMessageReaction.id, \MessageReactionDTO.id)
             )
         }
         

--- a/Sources/StreamChat/StateLayer/ReactionListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ReactionListState+Observer.swift
@@ -13,7 +13,8 @@ extension ReactionListState {
             reactionListObserver = StateLayerDatabaseObserver(
                 databaseContainer: database,
                 fetchRequest: MessageReactionDTO.reactionListFetchRequest(query: query),
-                itemCreator: { try $0.asModel() }
+                itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: nil // no id
             )
         }
         

--- a/Sources/StreamChat/StateLayer/UserListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/UserListState+Observer.swift
@@ -15,7 +15,8 @@ extension UserListState {
             usersObserver = StateLayerDatabaseObserver(
                 databaseContainer: database,
                 fetchRequest: UserDTO.userListFetchRequest(query: query),
-                itemCreator: { try $0.asModel() }
+                itemCreator: { try $0.asModel() },
+                itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id)
             )
         }
         

--- a/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
+++ b/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
@@ -1,0 +1,57 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+/// Converts database models to immutable value types by reusing existing items.
+enum DatabaseItemConverter {
+    /// Convert database models by reusing existing unchanged items.
+    /// - Parameters:
+    ///   - dtos: A list of DTOs in the NSFetchedResultsController.
+    ///   - existing: A list of existing items.
+    ///   - changes: List changes reported by the NSFetchedResultsController.
+    ///   - itemCreator: A closure which converts database models.
+    ///   - itemReuseKeyPaths: A pair of keypaths used for matching database models to existing items.
+    ///   - sorting: A list of sort values for sorting items outside of NSFetchedResultsController.
+    ///   - checkCancellation: A closure called before each invocation fo the `itemCreator`. If true, no more models are converted.
+    /// - Returns: <#description#>
+    static func convert<Item, DTO>(
+        dtos: [DTO],
+        existing: [Item],
+        changes: [ListChange<Item>]?,
+        itemCreator: (DTO) throws -> Item,
+        itemReuseKeyPaths: (item: KeyPath<Item, String>, dto: KeyPath<DTO, String>)?,
+        sorting: [SortValue<Item>],
+        checkCancellation: () -> Bool
+    ) -> [Item] where DTO: NSManagedObject {
+        let items: [Item]
+        
+        // Reuse converted items by id
+        if let itemReuseKeyPaths, !existing.isEmpty {
+            let existingItems = existing.map { ($0[keyPath: itemReuseKeyPaths.item], $0) }
+            var lookup = Dictionary(existingItems, uniquingKeysWith: { _, second in second })
+            // Changes contains newly converted items, add them to the lookup
+            changes?
+                .map(\.item)
+                .forEach { updatedItem in
+                    let key = updatedItem[keyPath: itemReuseKeyPaths.item]
+                    lookup[key] = updatedItem
+                }
+            items = dtos.compactMap { dto in
+                if let existing = lookup[dto[keyPath: itemReuseKeyPaths.dto]] {
+                    return existing
+                }
+                guard !checkCancellation() else { return nil }
+                return try? itemCreator(dto)
+            }
+        } else {
+            items = dtos.compactMap { dto in
+                guard !checkCancellation() else { return nil }
+                return try? itemCreator(dto)
+            }
+        }
+        return sorting.isEmpty ? items : items.sort(using: sorting)
+    }
+}

--- a/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
+++ b/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
@@ -29,7 +29,7 @@ enum DatabaseItemConverter {
         let items: [Item]
         
         // Reuse converted items by id
-        if StreamRuntimeCheck.isDatabaseObserverItemReusingEnabled, let itemReuseKeyPaths, !existing.isEmpty {
+        if StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled, let itemReuseKeyPaths, !existing.isEmpty {
             let existingItems = existing.map { ($0[keyPath: itemReuseKeyPaths.item], $0) }
             var lookup = Dictionary(existingItems, uniquingKeysWith: { _, second in second })
             // Changes contains newly converted items, add them to the lookup

--- a/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
+++ b/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
@@ -15,8 +15,8 @@ enum DatabaseItemConverter {
     ///   - itemCreator: A closure which converts database models.
     ///   - itemReuseKeyPaths: A pair of keypaths used for matching database models to existing items.
     ///   - sorting: A list of sort values for sorting items outside of NSFetchedResultsController.
-    ///   - checkCancellation: A closure called before each invocation fo the `itemCreator`. If true, no more models are converted.
-    /// - Returns: <#description#>
+    ///   - checkCancellation: A closure called before each invocation of the `itemCreator`. If true, no more models are converted.
+    /// - Returns: Returns a list of immutable models by reusing existing unchanged models.
     static func convert<Item, DTO>(
         dtos: [DTO],
         existing: [Item],

--- a/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
+++ b/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
@@ -29,7 +29,7 @@ enum DatabaseItemConverter {
         let items: [Item]
         
         // Reuse converted items by id
-        if let itemReuseKeyPaths, !existing.isEmpty {
+        if StreamRuntimeCheck.isDatabaseObserverItemReusingEnabled, let itemReuseKeyPaths, !existing.isEmpty {
             let existingItems = existing.map { ($0[keyPath: itemReuseKeyPaths.item], $0) }
             var lookup = Dictionary(existingItems, uniquingKeysWith: { _, second in second })
             // Changes contains newly converted items, add them to the lookup

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -263,6 +263,8 @@
 		4F427F6A2BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
 		4F427F6C2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
 		4F427F6D2BA2F53200D92238 /* ConnectedUserState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */; };
+		4F4562F62C240FD200675C7F /* DatabaseItemConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4562F52C240FD200675C7F /* DatabaseItemConverter.swift */; };
+		4F4562F72C240FD200675C7F /* DatabaseItemConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4562F52C240FD200675C7F /* DatabaseItemConverter.swift */; };
 		4F45802E2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */; };
 		4F45802F2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */; };
 		4F5151962BC3DEA1001B7152 /* UserSearch_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */; };
@@ -3105,6 +3107,7 @@
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
+		4F4562F52C240FD200675C7F /* DatabaseItemConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseItemConverter.swift; sourceTree = "<group>"; };
 		4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListLinker.swift; sourceTree = "<group>"; };
 		4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearch_Tests.swift; sourceTree = "<group>"; };
 		4F5151972BC407ED001B7152 /* UserList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList_Tests.swift; sourceTree = "<group>"; };
@@ -9321,6 +9324,7 @@
 		F6D61D992510B3E300EB0624 /* Database */ = {
 			isa = PBXGroup;
 			children = (
+				4F4562F52C240FD200675C7F /* DatabaseItemConverter.swift */,
 				F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */,
 				6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */,
 			);
@@ -11444,6 +11448,7 @@
 				CFE616B928348A5D00AE2ABF /* CountdownTracker.swift in Sources */,
 				40789D1F29F6AC500018C2BB /* AudioPlaying.swift in Sources */,
 				79FC85E724ACCBC500A665ED /* Token.swift in Sources */,
+				4F4562F62C240FD200675C7F /* DatabaseItemConverter.swift in Sources */,
 				79877A0E2498E4BC00015F8B /* Channel.swift in Sources */,
 				DA4AA3B22502718600FAAF6E /* ChannelController+Combine.swift in Sources */,
 				40789D1D29F6AC500018C2BB /* AudioPlayingDelegate.swift in Sources */,
@@ -12289,6 +12294,7 @@
 				4FD2BE572B9AF8A300FFC6F2 /* ChannelList.swift in Sources */,
 				C1E8AD58278C8A6F0041B775 /* SyncRepository.swift in Sources */,
 				841BA9FC2BCE8468000C73E4 /* CastPollVoteRequestBody.swift in Sources */,
+				4F4562F72C240FD200675C7F /* DatabaseItemConverter.swift in Sources */,
 				C121E8AE274544B000023E4C /* ChannelController+SwiftUI.swift in Sources */,
 				C121E8AF274544B000023E4C /* ChannelController+Combine.swift in Sources */,
 				C121E8B0274544B000023E4C /* ChannelListController.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessageReaction_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessageReaction_Mock.swift
@@ -15,6 +15,7 @@ extension ChatMessageReaction {
         extraData: [String: RawJSON] = [:]
     ) -> ChatMessageReaction {
         .init(
+            id: .unique,
             type: type,
             score: score,
             createdAt: createdAt,

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessageReaction_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessageReaction_Mock.swift
@@ -7,6 +7,7 @@ import Foundation
 
 extension ChatMessageReaction {
     public static func mock(
+        id: String = .unique,
         type: MessageReactionType,
         score: Int = 1,
         createdAt: Date = .distantPast,
@@ -15,7 +16,7 @@ extension ChatMessageReaction {
         extraData: [String: RawJSON] = [:]
     ) -> ChatMessageReaction {
         .init(
-            id: .unique,
+            id: id,
             type: type,
             score: score,
             createdAt: createdAt,

--- a/Tests/StreamChatTests/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
@@ -495,6 +495,7 @@ private class TestEnvironment {
                 database: $1,
                 fetchRequest: $2,
                 itemCreator: $3,
+                itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id),
                 fetchedResultsControllerType: $4
             )
             self.watcherListObserver?.synchronizeError = self.watcherListObserverSynchronizeError

--- a/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
@@ -461,6 +461,7 @@ private class TestEnvironment {
                 database: $1,
                 fetchRequest: $2,
                 itemCreator: $3,
+                itemReuseKeyPaths: (\ChatChannelMember.id, \MemberDTO.id),
                 fetchedResultsControllerType: $4
             )
             self.memberListObserver?.synchronizeError = self.memberListObserverSynchronizeError

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController+Combine_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController+Combine_Tests.swift
@@ -107,6 +107,7 @@ final class MessageController_Combine_Tests: iOS13TestCase {
         messageController = nil
 
         let newReaction: ChatMessageReaction = .init(
+            id: .unique,
             type: "like",
             score: 1,
             createdAt: .unique,

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
@@ -69,6 +69,7 @@ final class MessageController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = messageController.observableObject
 
         let newReaction: ChatMessageReaction = .init(
+            id: .unique,
             type: "likes",
             score: 3,
             createdAt: .unique,

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -1689,6 +1689,7 @@ final class MessageController_Tests: XCTestCase {
 
         let mockedReactions = repeatElement(
             ChatMessageReaction(
+                id: .unique,
                 type: "likes",
                 score: 1,
                 createdAt: .unique,

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -2441,6 +2441,7 @@ private class TestEnvironment {
                     database: $1,
                     fetchRequest: $2,
                     itemCreator: $3,
+                    itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id),
                     fetchedResultsControllerType: $4
                 )
                 return self.repliesObserver!

--- a/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
@@ -221,7 +221,8 @@ extension ChatThreadListController_Tests {
                         isBackground: false,
                         database: database,
                         fetchRequest: fetchRequest,
-                        itemCreator: itemCreator
+                        itemCreator: itemCreator,
+                        itemReuseKeyPaths: nil
                     )
                 }
             )

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -4153,7 +4153,8 @@ final class MessageDTO_Tests: XCTestCase {
                 deletedMessagesVisibility: .visibleForCurrentUser,
                 shouldShowShadowedMessages: false
             ),
-            itemCreator: { try $0.asModel() as ChatMessage }
+            itemCreator: { try $0.asModel() as ChatMessage },
+            itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id)
         )
         try observer.startObserving()
         return observer

--- a/Tests/StreamChatTests/ListDatabaseObserverWrapper_Tests.swift
+++ b/Tests/StreamChatTests/ListDatabaseObserverWrapper_Tests.swift
@@ -143,7 +143,8 @@ final class ListDatabaseObserverWrapper_Tests: XCTestCase {
             isBackground: isBackground,
             database: database,
             fetchRequest: fetchRequest,
-            itemCreator: { $0.testId }
+            itemCreator: { $0.testId },
+            itemReuseKeyPaths: nil
         )
 
         // Call startObserving to set everything up
@@ -196,6 +197,7 @@ extension ListDatabaseObserverWrapper_Tests {
             database: database,
             fetchRequest: fetchRequest,
             itemCreator: { $0.uniqueValue },
+            itemReuseKeyPaths: nil,
             fetchedResultsControllerType: FRC.self
         )
     }

--- a/Tests/StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting_Tests.swift
@@ -347,6 +347,7 @@ final class ListDatabaseObserver_Sorting_Tests: XCTestCase {
             database: database,
             fetchRequest: request,
             itemCreator: { try $0.asModel() },
+            itemReuseKeyPaths: (\ChatChannel.cid.rawValue, \ChannelDTO.cid),
             sorting: sorting.runtimeSorting
         )
 

--- a/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift
@@ -206,17 +206,70 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
     
     // MARK: - Reusing Existing Items
     
-    func test_reuseItems_whenSomeItemsChange_thenOthersAreReused() async throws {
+    func test_reuseChannels_whenSomeChange_thenOthersAreReused() async throws {
+        let memberId = UserId.unique
+        let memberPayload = MemberPayload.dummy(user: .dummy(userId: memberId))
+        let query = ChannelListQuery(
+            filter: .in(.members, values: [memberId]),
+            sort: [.init(key: .createdAt, isAscending: true)]
+        )
+        let makePayload: (Int) -> ChannelListPayload = { count in
+            let channelPayloads = (0..<count)
+                .map {
+                    self.dummyPayload(
+                        with: ChannelId(type: .messaging, id: "\($0)"),
+                        members: [memberPayload],
+                        createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0))
+                    )
+                }
+            return ChannelListPayload(channels: channelPayloads)
+        }
+        
+        try await client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: makePayload(5), query: query)
+        }
+        
+        let expectation = XCTestExpectation()
+        var itemCreatorCounter = 0
+        let channelListObserver = StateLayerDatabaseObserver(
+            databaseContainer: client.mockDatabaseContainer,
+            fetchRequest: ChannelDTO.channelListFetchRequest(
+                query: query,
+                chatClientConfig: client.config
+            ),
+            itemCreator: {
+                itemCreatorCounter += 1
+                return try $0.asModel()
+            },
+            itemReuseKeyPaths: (\ChatChannel.cid.rawValue, \ChannelDTO.cid),
+            sorting: query.sort.runtimeSorting
+        )
+        _ = try channelListObserver.startObserving(onContextDidChange: { _ in
+            expectation.fulfill()
+        })
+        XCTAssertEqual(5, itemCreatorCounter)
+        
+        // Change 1 existing
+        try await client.mockDatabaseContainer.write { session in
+            let channelPayload = makePayload(1).channels[0]
+            try session.saveChannel(payload: channelPayload, query: query, cache: nil)
+        }
+        
+        await fulfillmentCompatibility(of: [expectation], timeout: defaultTimeout)
+
+        // 4 are reused, 1 is created
+        XCTAssertEqual(6, itemCreatorCounter)
+    }
+    
+    func test_reuseMessages_whenSomeChange_thenOthersAreReused() async throws {
         let firstPayload = makeChannelPayload(messageCount: 10, createdAtOffset: 0)
         try await client.mockDatabaseContainer.write { session in
             try session.saveChannel(payload: firstPayload)
         }
         
         let expectation = XCTestExpectation()
-        var changeCount = 0
         let observer = makeMessagesListObserver()
         _ = try observer.startObserving(onContextDidChange: { _ in
-            changeCount += 1
             expectation.fulfill()
         })
         XCTAssertEqual(10, messageItemCreatorCounter)
@@ -231,6 +284,132 @@ final class StateLayerDatabaseObserver_Tests: XCTestCase {
 
         // 5 are reused, 5 are created
         XCTAssertEqual(15, messageItemCreatorCounter)
+    }
+    
+    func test_reuseReactions_whenSomeChange_thenOthersAreReused() async throws {
+        let channelPayload = makeChannelPayload(messageCount: 5, createdAtOffset: 0)
+        try await client.mockDatabaseContainer.write { session in
+            try session.saveChannel(payload: channelPayload)
+        }
+        let messageId = try XCTUnwrap(channelPayload.messages.first?.id)
+        let makePayload: (Int) -> MessageReactionsPayload = { count in
+            let reactions = (0..<count)
+                .reversed() // last updated ones first
+                .map {
+                    MessageReactionPayload.dummy(
+                        messageId: messageId,
+                        createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0)),
+                        updatedAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0)),
+                        user: .dummy(userId: .unique)
+                    )
+                }
+            return MessageReactionsPayload(reactions: reactions)
+        }
+        let query = ReactionListQuery(messageId: messageId)
+        try await client.databaseContainer.write { session in
+            session.saveReactions(payload: makePayload(5), query: query)
+        }
+        let expectation = XCTestExpectation()
+        var itemCreatorCounter = 0
+        let reactionListObserver = StateLayerDatabaseObserver(
+            databaseContainer: client.mockDatabaseContainer,
+            fetchRequest: MessageReactionDTO.reactionListFetchRequest(query: query),
+            itemCreator: {
+                itemCreatorCounter += 1
+                return try $0.asModel()
+            },
+            itemReuseKeyPaths: (\ChatMessageReaction.id, \MessageReactionDTO.id)
+        )
+        _ = try reactionListObserver.startObserving(onContextDidChange: { _ in
+            expectation.fulfill()
+        })
+        XCTAssertEqual(5, itemCreatorCounter)
+        
+        // Change 1 existing
+        try await client.mockDatabaseContainer.write { session in
+            try session.saveReaction(payload: makePayload(1).reactions[0], query: query, cache: nil)
+        }
+        
+        await fulfillmentCompatibility(of: [expectation], timeout: defaultTimeout)
+
+        // 4 are reused, 1 is created
+        XCTAssertEqual(6, itemCreatorCounter)
+    }
+    
+    func test_reuseThreads_whenSomeChange_thenOthersAreReused() async throws {
+        let makePayload: (Int) -> ThreadListPayload = { count in
+            let threads = (0..<count)
+                .map { ThreadPayload.dummy(parentMessageId: "\($0)") }
+            return ThreadListPayload(threads: threads, next: nil)
+        }
+        try await client.databaseContainer.write { session in
+            session.saveThreadList(payload: makePayload(5))
+        }
+        let expectation = XCTestExpectation()
+        var itemCreatorCounter = 0
+        let threadListObserver = StateLayerDatabaseObserver(
+            databaseContainer: client.mockDatabaseContainer,
+            fetchRequest: ThreadDTO.threadListFetchRequest(),
+            itemCreator: {
+                itemCreatorCounter += 1
+                return try $0.asModel()
+            },
+            itemReuseKeyPaths: (\ChatThread.reuseId, \ThreadDTO.reuseId)
+        )
+        _ = try threadListObserver.startObserving(onContextDidChange: { _ in
+            expectation.fulfill()
+        })
+        XCTAssertEqual(5, itemCreatorCounter)
+        
+        // Change 1 existing
+        try await client.mockDatabaseContainer.write { session in
+            try session.saveThread(payload: makePayload(1).threads[0], cache: nil)
+        }
+        
+        await fulfillmentCompatibility(of: [expectation], timeout: defaultTimeout)
+
+        // 4 are reused, 1 is created
+        XCTAssertEqual(6, itemCreatorCounter)
+    }
+    
+    func test_reuseUsers_whenSomeChange_thenOthersAreReused() async throws {
+        let makePayload: (Int) -> UserListPayload = { count in
+            let users = (0..<count)
+                .map { UserPayload.dummy(userId: "\($0)", name: "name_\($0)") }
+            return UserListPayload(users: users)
+        }
+        let query = UserListQuery(
+            filter: .query(.id, text: .unique),
+            sort: [.init(key: .id, isAscending: true)]
+        )
+        try await client.databaseContainer.write { session in
+            session.saveUsers(payload: makePayload(5), query: query)
+        }
+        let expectation = XCTestExpectation()
+        var itemCreatorCounter = 0
+        let usersObserver = StateLayerDatabaseObserver(
+            databaseContainer: client.mockDatabaseContainer,
+            fetchRequest: UserDTO.userListFetchRequest(query: query),
+            itemCreator: {
+                itemCreatorCounter += 1
+                return try $0.asModel()
+            },
+            itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id)
+        )
+        _ = try usersObserver.startObserving(onContextDidChange: { _ in
+            expectation.fulfill()
+        })
+        XCTAssertEqual(5, itemCreatorCounter)
+        
+        // Change 1 existing
+        try await client.mockDatabaseContainer.write { session in
+            try session.saveUser(payload: makePayload(1).users[0])
+        }
+        
+        await fulfillmentCompatibility(of: [expectation], timeout: defaultTimeout)
+
+        // 4 are reused, 1 is created
+        XCTAssertEqual(6, itemCreatorCounter)
     }
     
     // MARK: -

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
@@ -1058,6 +1058,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             reactionScores: ["like": 1],
             latestReactions: [
                 .init(
+                    id: .unique,
                     type: "like",
                     score: 1,
                     createdAt: .unique,
@@ -1098,6 +1099,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             reactionScores: ["like": 1],
             latestReactions: [
                 .init(
+                    id: .unique,
                     type: "surfing",
                     score: 1,
                     createdAt: .unique,
@@ -1138,6 +1140,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             reactionScores: ["like": 1],
             latestReactions: [
                 .init(
+                    id: .unique,
                     type: "like",
                     score: 1,
                     createdAt: .unique,
@@ -1178,6 +1181,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             reactionScores: ["like": 1],
             latestReactions: [
                 .init(
+                    id: .unique,
                     type: "like",
                     score: 1,
                     createdAt: .unique,
@@ -2051,6 +2055,7 @@ private extension Array where Element == (ChatMessage, Bool) {
             reactionScores: ["like": 1],
             latestReactions: [
                 .init(
+                    id: .unique,
                     type: "like",
                     score: 1,
                     createdAt: .unique,


### PR DESCRIPTION
### 🔗 Issue Links

Related [ios-issues-tracking/issues/870](https://github.com/GetStream/ios-issues-tracking/issues/870)

### 🎯 Goal

* Improved performance of database observers by reusing unchanged items

### 📝 Summary

* Reuse existing model instances what did not change when NSFetchedResultsController reports list changes
* Reuse newly created items stored in `ListChange` when did change content callback is triggered
* Affects `BackgroundDatabaseObserver` and `StateLayerDatabaseObserver` (list type)

### 🛠 Implementation

`DTO` and immutable model types are matched using a single `id` value. Since `ListChange.item` contains a newly converted item, instead of recreating it again, we reuse the value.

### 🎨 Showcase

When comparing how much CPU time does the `BackgroundDatabaseObserver.updateItems` takes when opening the demo app, navigating to a channel, loading several pages of messages, then we can see significant improvement.

| Before | After |
| ------ | ----- |
|  ~1100ms  |  ~200ms  |

<img width="1886" alt="result" src="https://github.com/GetStream/stream-chat-swift/assets/1469907/ad308db9-2162-4773-9c39-cee574983d5c">

### 🧪 Manual Testing Notes

Since we reuse existing items and do not convert the whole list, we need to be sure, that NSFetchedResultsController does not miss any data changes in more complex relationships. Therefore, we need to do a manual testing round covering many use-cases.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzZtNWp0NzBwdnVidzN6OTI3enR6aWs0a2RpOGZibWx1NGkxN252MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/bTMzzPaOABxzG/giphy.gif)
