### PR TITLE
Fix message attachments returning nil sometimes in push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix notifications muted state for the current user in channel members [#3236](https://github.com/GetStream/stream-chat-swift/pull/3236)
 - Reset channel members and watchers state when fetching the initial state of the channel [#3245](https://github.com/GetStream/stream-chat-swift/pull/3245)
 - Fix inconsistent message text when extremely quickly updating it [#3242](https://github.com/GetStream/stream-chat-swift/pull/3242)
+- Fix message attachments returning nil sometimes in push notification extensions [#3261](https://github.com/GetStream/stream-chat-swift/pull/3261)
 ### 🔄 Changed
 - Enable background mapping by default, which improves performance overall [#3250](https://github.com/GetStream/stream-chat-swift/pull/3250)
 

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -195,6 +195,8 @@ class MessageRepository {
                 self.database.write({ session in
                     message = try session.saveMessage(payload: boxed.message, for: cid, syncOwnReactions: true, cache: nil).asModel()
                     if !store {
+                        // Force load attachments before discarding changes
+                        _ = message?.attachmentCounts
                         self.database.writableContext.discardCurrentChanges()
                     }
                 }, completion: { error in


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/issues/872](https://github.com/GetStream/ios-issues-tracking/issues/872)

### 🎯 Goal

Force load attachments in push notification extensions since discard changes would remove them.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)