### PR TITLE
Always use in-memory database in tests

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		4F73F39F2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */; };
 		4F83FA462BA43DC3008BD8CD /* MemberList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F83FA452BA43DC3008BD8CD /* MemberList.swift */; };
 		4F83FA472BA43DC3008BD8CD /* MemberList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F83FA452BA43DC3008BD8CD /* MemberList.swift */; };
+		4F862F9A2C38001000062502 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F862F992C38001000062502 /* FileManager+Extensions.swift */; };
 		4F8E53062B7CD01D008C0F9F /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E53052B7CD01D008C0F9F /* Chat.swift */; };
 		4F8E530B2B7CEBFB008C0F9F /* ChatClient+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */; };
 		4F8E53162B7F58BE008C0F9F /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E53052B7CD01D008C0F9F /* Chat.swift */; };
@@ -3156,6 +3157,7 @@
 		4F73F3972B91BD3000563CD9 /* MessageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState.swift; sourceTree = "<group>"; };
 		4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageState+Observer.swift"; sourceTree = "<group>"; };
 		4F83FA452BA43DC3008BD8CD /* MemberList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberList.swift; sourceTree = "<group>"; };
+		4F862F992C38001000062502 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
 		4F8E53052B7CD01D008C0F9F /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Factory.swift"; sourceTree = "<group>"; };
 		4F8E531B2B833D6C008C0F9F /* ChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatState.swift; sourceTree = "<group>"; };
@@ -7989,6 +7991,7 @@
 				A3C7BAE127E4E95800BBF4FA /* CleanUpTypingEvent+Equatable.swift */,
 				A3C3BC5A27E8810000224761 /* DispatchQueue+Random.swift */,
 				A3C7BA9927E3849B00BBF4FA /* EndpoinPath+Equatable.swift */,
+				4F862F992C38001000062502 /* FileManager+Extensions.swift */,
 				A3C7BA8027E37BA200BBF4FA /* Endpoint+Mock.swift */,
 				DA84074A2526417B005A0F62 /* JSONEncoder+Extensions.swift */,
 				A344075F27D753530044F150 /* NSManagedObject+ContextChange.swift */,
@@ -11048,6 +11051,7 @@
 				A3C3BC7227E8AA4300224761 /* DecodableEntity.swift in Sources */,
 				40D484062A1264F1009E4134 /* MockAudioPlayer.swift in Sources */,
 				A3C3BC6527E8AA0A00224761 /* Int+Unique.swift in Sources */,
+				4F862F9A2C38001000062502 /* FileManager+Extensions.swift in Sources */,
 				A3C3BC6327E8AA0A00224761 /* AttachmentId+Unique.swift in Sources */,
 				A3C3BC3827E87F5100224761 /* BackgroundTaskScheduler_Mock.swift in Sources */,
 				84EE53B12BBC32AD00FD2A13 /* Chat_Mock.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Extensions/FileManager+Extensions.swift
+++ b/TestTools/StreamChatTestTools/Extensions/FileManager+Extensions.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public extension FileManager {
+    /// Removes temporary files created with ``URL.newTemporaryFileURL``.
+    static func removeAllTemporaryFiles() {
+        let urls = try? FileManager.default.contentsOfDirectory(
+            at: URL.temporaryDirectoryRoot,
+            includingPropertiesForKeys: nil
+        )
+        guard let urls else { return }
+        let urlsToDelete = urls.filter({ $0.lastPathComponent == URL.temporaryFileName })
+        guard urlsToDelete.count > 0 else { return }
+        urlsToDelete.forEach { url in
+            try? FileManager.default.removeItem(at: url)
+        }
+        print("Deleted \(urlsToDelete.count) files in the temporary directory")
+    }
+}

--- a/TestTools/StreamChatTestTools/Extensions/Unique/URL+Unique.swift
+++ b/TestTools/StreamChatTestTools/Extensions/Unique/URL+Unique.swift
@@ -12,15 +12,22 @@ public extension URL {
 
     /// Returns a unique URL that can be used for storing a temporary file.
     static func newTemporaryFileURL() -> URL {
-        newTemporaryDirectoryURL().appendingPathComponent("temp_file")
+        newTemporaryDirectoryURL().appendingPathComponent(temporaryFileName)
     }
 
     /// Creates a new temporary directory and returns its URL.
     static func newTemporaryDirectoryURL() -> URL {
         let directoryId = UUID().uuidString
-        let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        let newDirURL = tempDirectoryURL.appendingPathComponent(directoryId)
+        let newDirURL = URL.temporaryDirectoryRoot.appendingPathComponent(directoryId)
         try! FileManager.default.createDirectory(at: newDirURL, withIntermediateDirectories: true, attributes: nil)
         return newDirURL
     }
+}
+
+extension URL {
+    static var temporaryDirectoryRoot: URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    }
+    
+    static let temporaryFileName = "temp_file"
 }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -31,8 +31,7 @@ public final class DatabaseContainer_Spy: DatabaseContainer, Spy {
     private(set) var sessionMock: DatabaseSession_Mock?
 
     public convenience init(localCachingSettings: ChatClientConfig.LocalCaching? = nil) {
-        self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), localCachingSettings: localCachingSettings)
-        shouldCleanUpTempDBFiles = true
+        self.init(kind: .inMemory, localCachingSettings: localCachingSettings)
     }
 
     override public init(

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
@@ -9,6 +9,11 @@ import XCTest
 final class ChannelListPayload_Tests: XCTestCase {
     private var database: DatabaseContainer_Spy!
     
+    override func setUpWithError() throws {
+        // Clean up any db files left behind
+        FileManager.removeAllTemporaryFiles()
+    }
+    
     override func tearDownWithError() throws {
         database = nil
     }

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
@@ -7,6 +7,12 @@
 import XCTest
 
 final class ChannelListPayload_Tests: XCTestCase {
+    private var database: DatabaseContainer_Spy!
+    
+    override func tearDownWithError() throws {
+        database = nil
+    }
+    
     func test_channelQueryJSON_isSerialized_withDefaultExtraData() throws {
         // GIVEN
         let url = XCTestCase.mockData(fromJSONFile: "ChannelsQuery")
@@ -65,28 +71,23 @@ final class ChannelListPayload_Tests: XCTestCase {
     }
 
     func test_hugeChannelListQuery_save_DB_empty() throws {
-        throw XCTSkip("https://github.com/GetStream/ios-issues-tracking/issues/848")
-        
         let decodedPayload = createHugeChannelList()
-        let timeout: TimeInterval = 60
-        
+        let timeout: TimeInterval = 180
+        database = DatabaseContainer_Spy(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()))
         measure {
-            let databaseContainer = DatabaseContainer_Spy()
-            saveChannelListPayload(decodedPayload, database: databaseContainer, timeout: timeout)
+            saveChannelListPayload(decodedPayload, database: database, timeout: timeout)
         }
     }
 
     func test_hugeChannelListQuery_save_DB_filled() throws {
-        throw XCTSkip("https://github.com/GetStream/ios-issues-tracking/issues/848")
-        
         let decodedPayload = createHugeChannelList()
-        let databaseContainer = DatabaseContainer_Spy()
-        let timeout: TimeInterval = 60
+        database = DatabaseContainer_Spy(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()))
+        let timeout: TimeInterval = 180
 
-        saveChannelListPayload(decodedPayload, database: databaseContainer, timeout: timeout)
+        saveChannelListPayload(decodedPayload, database: database, timeout: timeout)
 
         measure {
-            saveChannelListPayload(decodedPayload, database: databaseContainer, timeout: timeout)
+            saveChannelListPayload(decodedPayload, database: database, timeout: timeout)
         }
     }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -1731,11 +1731,15 @@ final class ChannelController_Tests: XCTestCase {
         // Create controller for the existing new DM channel
         setupControllerForNewMessageChannel(cid: channelId)
 
+        // Trigger DB observers for background mapping
+        _ = controller.messages
+        waitForInitialMessagesUpdate(count: 0)
+        
         // Unlike new DM ChannelController, this ChannelController knows it's final `cid` so it should be able to fetch initial values
         // from DB, without the `synchronize` call
         // Assert that initial reported values are correct
         XCTAssertEqual(controller.channel?.cid, dummyChannel.channel.cid)
-        AssertAsync.willBeTrue(controller.messages.count == dummyChannel.messages.count)
+        XCTAssertTrue(controller.messages.count == dummyChannel.messages.count)
     }
 
     // MARK: - Updating channel

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -1733,7 +1733,7 @@ final class ChannelController_Tests: XCTestCase {
 
         // Trigger DB observers for background mapping
         _ = controller.messages
-        waitForInitialMessagesUpdate(count: 0)
+        waitForInitialMessagesUpdate(count: 10)
         
         // Unlike new DM ChannelController, this ChannelController knows it's final `cid` so it should be able to fetch initial values
         // from DB, without the `synchronize` call

--- a/Tests/StreamChatTests/Controllers/PollsControllers/PollController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/PollsControllers/PollController_Tests.swift
@@ -135,6 +135,10 @@ final class PollController_Tests: XCTestCase {
         // Create poll in that matches controller's `pollId`
         let user = UserPayload.dummy(userId: currentUserId)
         try client.databaseContainer.createPoll(id: pollId, createdBy: user)
+        
+        // Trigger DB observers when using background mapping
+        _ = controller.poll
+        waitForDelegateCallback()
 
         // Assert message is fetched from the database and has correct field values
         var poll = try XCTUnwrap(controller.poll)
@@ -150,7 +154,8 @@ final class PollController_Tests: XCTestCase {
         try client.databaseContainer.writeSynchronously { session in
             try session.savePoll(payload: pollPayload, cache: nil)
         }
-
+        waitForDelegateCallback()
+        
         // Assert the controller's `poll` is up-to-date
         poll = try XCTUnwrap(controller.poll)
         XCTAssertEqual(poll.id, pollId)
@@ -180,6 +185,8 @@ final class PollController_Tests: XCTestCase {
         try client.databaseContainer.writeSynchronously { session in
             try session.savePollVotes(payload: response, query: query, cache: nil)
         }
+        
+        waitForDelegateCallback()
         
         XCTAssertEqual(controller.poll?.id, pollId)
         XCTAssertEqual(controller.ownVotes.count, ownVotes.count)
@@ -351,5 +358,25 @@ final class PollController_Tests: XCTestCase {
         
         // Assert completion is called.
         XCTAssertTrue(completionIsCalled)
+    }
+    
+    // MARK: -
+    
+    func waitForDelegateCallback() {
+        guard StreamRuntimeCheck._isBackgroundMappingEnabled else { return }
+        let delegate = DelegateWaiter()
+        controller.delegate = delegate
+        wait(for: [delegate.didUpdatePollExpectation], timeout: defaultTimeout)
+        controller.delegate = nil
+    }
+    
+    private class DelegateWaiter: PollControllerDelegate {
+        let didUpdatePollExpectation = XCTestExpectation(description: "Initial update callback")
+        
+        func pollController(_ pollController: StreamChat.PollController, didUpdatePoll poll: StreamChat.EntityChange<StreamChat.Poll>) {
+            didUpdatePollExpectation.fulfill()
+        }
+        
+        func pollController(_ pollController: StreamChat.PollController, didUpdateCurrentUserVotes votes: [StreamChat.ListChange<StreamChat.PollVote>]) {}
     }
 }

--- a/Tests/StreamChatTests/Controllers/SearchControllers/UserController/UserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/UserController/UserController_Tests.swift
@@ -174,6 +174,9 @@ final class UserController_Tests: XCTestCase {
         // Simulate updater callback
         env.userUpdater?.loadUser_completion?(nil)
 
+        // Wait for delegate callback
+        waitForDelegateCallback()
+        
         // Assert the user is loaded
         XCTAssertEqual(controller.user?.id, userId)
     }
@@ -692,6 +695,24 @@ final class UserController_Tests: XCTestCase {
 
         // Assert controller is kept alive
         AssertAsync.staysTrue(weakController != nil)
+    }
+    
+    // MARK: -
+    
+    func waitForDelegateCallback() {
+        guard StreamRuntimeCheck._isBackgroundMappingEnabled else { return }
+        let delegate = DelegateWaiter()
+        controller.delegate = delegate
+        wait(for: [delegate.didUpdateUserExpectation], timeout: defaultTimeout)
+        controller.delegate = nil
+    }
+    
+    private class DelegateWaiter: ChatUserControllerDelegate {
+        let didUpdateUserExpectation = XCTestExpectation(description: "DidChangeVotes")
+
+        func userController(_ controller: StreamChat.ChatUserController, didUpdateUser change: StreamChat.EntityChange<StreamChat.ChatUser>) {
+            didUpdateUserExpectation.fulfill()
+        }
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-4302](https://stream-io.atlassian.net/browse/PBE-4302)

### 🎯 Goal

* Use in-memory database for tests except performance tests (faster, less errors with SQLite).
* Fix skipped channel list tests
* Fix unstable tests what appeared after background mapping is the default (we need to wait delegates since updates have a delay)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-4302]: https://stream-io.atlassian.net/browse/PBE-4302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ