### PR TITLE
Fix flakey tests due to using random reaction score and not waiting observers

### DIFF
--- a/TestTools/StreamChatTestTools/TestData/DummyData/MessageReactionPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/MessageReactionPayload.swift
@@ -8,6 +8,7 @@ import Foundation
 extension MessageReactionPayload {
     static func dummy(
         type: MessageReactionType = .init(rawValue: .unique),
+        score: Int = .random(in: 0...10),
         messageId: String,
         createdAt: Date = .unique,
         updatedAt: Date = .unique,
@@ -16,7 +17,7 @@ extension MessageReactionPayload {
     ) -> MessageReactionPayload {
         .init(
             type: type,
-            score: .random(in: 0...10),
+            score: score,
             messageId: messageId,
             createdAt: createdAt,
             updatedAt: updatedAt,


### PR DESCRIPTION
### 🎯 Goal

Some tests failed randomly in last runs.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

