### PR TITLE
Use hash for differenceIdentifier after changing equatable

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -476,4 +476,8 @@ extension ChatChannel: Differentiable {
     public func isContentEqual(to source: ChatChannel) -> Bool {
         self == source
     }
+    
+    public var differenceIdentifier: Int {
+        hashValue
+    }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -34,4 +34,8 @@ extension ChatMessage: Differentiable {
     public func isContentEqual(to source: ChatMessage) -> Bool {
         self == source
     }
+    
+    public var differenceIdentifier: Int {
+        hashValue
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

ChatChannel and ChatMessage's equatable was changed for better SwiftUI SDK integration. DiffKit uses == for uniqueness by default. For reverting back to the old behaviour, we can override differenceIdentifier.

### 🧪 Manual Testing Notes

The case of opening the demo app avatars flashing and scroll target is incorrect.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)