### PR TITLE
Fix animation when opening thread list

### DIFF
--- a/Sources/StreamChatUI/ChatThreadList/ChatThreadListVC.swift
+++ b/Sources/StreamChatUI/ChatThreadList/ChatThreadListVC.swift
@@ -144,7 +144,6 @@ open class ChatThreadListVC:
         hideLoadingView()
         hideEmptyView()
         hideErrorView()
-        hideHeaderBannerView()
     }
 
     override open func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### 🔗 Issue Links
None. Spotted on QA Release.

### 🎯 Goal
Fix animation when opening the thread list. Because `hideBannerHeaderView` calls `layoufIfNeeded` on the table view, this causes the weird animation when opening the thread list. We don't need to call this on `setUp()`

### 🧪 Manual Testing Notes
Make sure white theme is enabled.

This should not happen:

https://github.com/GetStream/stream-chat-swift/assets/12814114/25aff309-5870-4542-b8e3-a0c14a479150

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
