### PR TITLE
Add timeout support when connecting user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ✅ Added
+- Add an option to configure a reconnection timeout [#3303](https://github.com/GetStream/stream-chat-swift/pull/3303)
+### 🐞 Fixed
+- Improve the stability of the reconnection process [#3303](https://github.com/GetStream/stream-chat-swift/pull/3303)
+- Fix invalid token errors considered as recoverable errors [#3303](https://github.com/GetStream/stream-chat-swift/pull/3303)
 ### 🔄 Changed
 - Dropped iOS 12 support [#3285](https://github.com/GetStream/stream-chat-swift/pull/3285)
 - Increase QoS for `Throttler` and `Debouncer` to `utility` [#3295](https://github.com/GetStream/stream-chat-swift/issues/3295)
-- Improve reliability of accessing database models in controller provided completion handlers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
+- Improve reliability of accessing database models in controllers' completion handlers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
+
+## StreamChatUI
+### 🐞 Fixed
+- Fix Channel List not hiding error state view when data is available [#3303](https://github.com/GetStream/stream-chat-swift/pull/3303)
 
 # [4.59.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.59.0)
 _July 10, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Dropped iOS 12 support [#3285](https://github.com/GetStream/stream-chat-swift/pull/3285)
 - Increase QoS for `Throttler` and `Debouncer` to `utility` [#3295](https://github.com/GetStream/stream-chat-swift/issues/3295)
-- Improve reliability of accessing database models in controllers' completion handlers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
+- Improve reliability of accessing data in controllers' completion handlers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -186,6 +186,7 @@ class AppConfigViewController: UITableViewController {
     enum ChatClientConfigOption: String, CaseIterable {
         case isLocalStorageEnabled
         case staysConnectedInBackground
+        case reconnectionTimeout
         case shouldShowShadowedMessages
         case deletedMessagesVisibility
         case isChannelAutomaticFilteringEnabled
@@ -337,6 +338,9 @@ class AppConfigViewController: UITableViewController {
             cell.accessoryView = makeSwitchButton(chatClientConfig.staysConnectedInBackground) { [weak self] newValue in
                 self?.chatClientConfig.staysConnectedInBackground = newValue
             }
+        case .reconnectionTimeout:
+            cell.detailTextLabel?.text = chatClientConfig.reconnectionTimeout.map { "\($0)" } ?? "None"
+            cell.accessoryType = .disclosureIndicator
         case .shouldShowShadowedMessages:
             cell.accessoryView = makeSwitchButton(chatClientConfig.shouldShowShadowedMessages) { [weak self] newValue in
                 self?.chatClientConfig.shouldShowShadowedMessages = newValue
@@ -361,6 +365,8 @@ class AppConfigViewController: UITableViewController {
         switch option {
         case .deletedMessagesVisibility:
             pushDeletedMessagesVisibilitySelectorVC()
+        case .reconnectionTimeout:
+            pushReconnectionTimeoutSelectorVC()
         default:
             break
         }
@@ -561,6 +567,24 @@ class AppConfigViewController: UITableViewController {
         selectorViewController.didChangeSelectedOptions = { [weak self] options in
             guard let selectedOption = options.first else { return }
             UserConfig.shared.language = selectedOption
+            self?.tableView.reloadData()
+        }
+
+        navigationController?.pushViewController(selectorViewController, animated: true)
+    }
+
+    private func pushReconnectionTimeoutSelectorVC() {
+        let selectorViewController = OptionsSelectorViewController<TimeInterval?>(
+            options: [nil, 15.0, 30.0, 45.0, 60.0],
+            initialSelectedOptions: [chatClientConfig.reconnectionTimeout],
+            allowsMultipleSelection: false,
+            optionFormatter: { option in
+                option.map { "\($0)" } ?? "None"
+            }
+        )
+        selectorViewController.didChangeSelectedOptions = { [weak self] options in
+            guard let selectedOption = options.first else { return }
+            self?.chatClientConfig.reconnectionTimeout = selectedOption
             self?.tableView.reloadData()
         }
 

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -22,15 +22,17 @@ final class StreamChatWrapper {
     var client: ChatClient?
 
     // ChatClient config
-    var config: ChatClientConfig = {
-        var config = ChatClientConfig(apiKeyString: apiKeyString)
+    var config: ChatClientConfig {
+        didSet {
+            client = ChatClient(config: config)
+        }
+    }
+
+    private init() {
+        config = ChatClientConfig(apiKeyString: apiKeyString)
         config.shouldShowShadowedMessages = true
         config.applicationGroupIdentifier = applicationGroupIdentifier
         config.urlSessionConfiguration.httpAdditionalHeaders = ["Custom": "Example"]
-        return config
-    }()
-
-    private init() {
         configureUI()
     }
 }

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -26,7 +26,7 @@ extension StreamChatWrapper {
 
                 let numberOfSuccessfulRefreshes = refreshDetails.numberOfSuccessfulRefreshesBeforeFailing
                 let shouldNotFail = numberOfSuccessfulRefreshes == 0
-                if shouldNotFail || self.numberOfRefreshTokens <= numberOfSuccessfulRefreshes {
+                if shouldNotFail || self.numberOfRefreshTokens >= numberOfSuccessfulRefreshes {
                     print("Demo App Token Refreshing: New token generated successfully.")
                     let newToken = generatedToken ?? initialToken
                     completion(.success(newToken))

--- a/DemoApp/StreamChat/Components/Banner/BannerShowingConnectionDelegate.swift
+++ b/DemoApp/StreamChat/Components/Banner/BannerShowingConnectionDelegate.swift
@@ -29,11 +29,14 @@ extension BannerShowingConnectionDelegate: ChatConnectionControllerDelegate {
             bannerView.update(text: "Disconnected")
             showBanner()
         case .connected:
+            bannerView.update(text: "Connected")
             hideBanner()
         case .disconnecting:
             bannerView.update(text: "Disconnecting...")
+            showBanner()
         case .connecting:
             bannerView.update(text: "Connecting...")
+            showBanner()
         case .initialized:
             break
         }
@@ -45,7 +48,7 @@ extension BannerShowingConnectionDelegate: ChatConnectionControllerDelegate {
 private extension BannerShowingConnectionDelegate {
     func setupViews() {
         attachToTopViewIfNeeded()
-        bannerView.alpha = 0
+        bannerView.alpha = 1
         bannerView.update(text: "Connecting...")
     }
 

--- a/DemoApp/StreamChat/Components/DemoChatChannelListErrorView.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListErrorView.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatUI
+import UIKit
+
+class DemoChatChannelListErrorView: ChatChannelListErrorView {
+    override func show() {
+        UIView.animate(withDuration: 0.5) {
+            self.isHidden = false
+        }
+    }
+
+    override func hide() {
+        UIView.animate(withDuration: 0.5) {
+            self.isHidden = true
+        }
+    }
+}

--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -61,6 +61,7 @@ extension StreamChatWrapper {
         Components.default.messageActionsVC = DemoChatMessageActionsVC.self
         Components.default.messageLayoutOptionsResolver = DemoChatMessageLayoutOptionsResolver()
         Components.default.reactionsSorting = ReactionSorting.byFirstReactionAt
+        Components.default.channelListErrorView = DemoChatChannelListErrorView.self
 
         // Customize MarkdownFormatter
         let defaultFormatter = DefaultMarkdownFormatter()

--- a/Sources/StreamChat/APIClient/RequestDecoder.swift
+++ b/Sources/StreamChat/APIClient/RequestDecoder.swift
@@ -58,8 +58,8 @@ struct DefaultRequestDecoder: RequestDecoder {
                 throw ClientError.Unknown("Unknown error. Server response: \(httpResponse).")
             }
 
-            if serverError.isInvalidTokenError {
-                log.info("Request failed because of an experied token.", subsystems: .httpRequests)
+            if serverError.isExpiredTokenError {
+                log.info("Request failed because of an expired token.", subsystems: .httpRequests)
                 throw ClientError.ExpiredToken()
             }
 

--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -103,7 +103,8 @@ extension ChatClient {
             _ extensionLifecycle: NotificationExtensionLifecycle,
             _ backgroundTaskScheduler: BackgroundTaskScheduler?,
             _ internetConnection: InternetConnection,
-            _ keepConnectionAliveInBackground: Bool
+            _ keepConnectionAliveInBackground: Bool,
+            _ reconnectionTimeoutHandler: StreamTimer?
         ) -> ConnectionRecoveryHandler = {
             DefaultConnectionRecoveryHandler(
                 webSocketClient: $0,
@@ -114,7 +115,8 @@ extension ChatClient {
                 internetConnection: $5,
                 reconnectionStrategy: DefaultRetryStrategy(),
                 reconnectionTimerType: DefaultTimer.self,
-                keepConnectionAliveInBackground: $6
+                keepConnectionAliveInBackground: $6,
+                reconnectionTimeoutHandler: $7
             )
         }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -258,7 +258,7 @@ public class ChatClient {
             environment.backgroundTaskSchedulerBuilder(),
             environment.internetConnection(eventNotificationCenter, environment.internetMonitor),
             config.staysConnectedInBackground,
-            config.reconnectionTimeout.map { ScheduledStreamTimer(interval: $0, fireOnStart: false) }
+            config.reconnectionTimeout.map { ScheduledStreamTimer(interval: $0, fireOnStart: false, repeats: false) }
         )
     }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -288,6 +288,8 @@ public class ChatClient {
         tokenProvider: @escaping TokenProvider,
         completion: ((Error?) -> Void)? = nil
     ) {
+        connectionRecoveryHandler?.start()
+
         authenticationRepository.connectUser(
             userInfo: userInfo,
             tokenProvider: tokenProvider,
@@ -437,6 +439,7 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers. No further updates from the servers
     /// are received.
     public func disconnect(completion: @escaping () -> Void) {
+        connectionRecoveryHandler?.stop()
         connectionRepository.disconnect(source: .userInitiated) {
             log.info("The `ChatClient` has been disconnected.", subsystems: .webSocket)
             completion()

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -288,8 +288,6 @@ public class ChatClient {
         tokenProvider: @escaping TokenProvider,
         completion: ((Error?) -> Void)? = nil
     ) {
-        connectionRecoveryHandler?.start()
-
         authenticationRepository.connectUser(
             userInfo: userInfo,
             tokenProvider: tokenProvider,
@@ -439,7 +437,6 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers. No further updates from the servers
     /// are received.
     public func disconnect(completion: @escaping () -> Void) {
-        connectionRecoveryHandler?.stop()
         connectionRepository.disconnect(source: .userInitiated) {
             log.info("The `ChatClient` has been disconnected.", subsystems: .webSocket)
             completion()

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -257,7 +257,8 @@ public class ChatClient {
             extensionLifecycle,
             environment.backgroundTaskSchedulerBuilder(),
             environment.internetConnection(eventNotificationCenter, environment.internetMonitor),
-            config.staysConnectedInBackground
+            config.staysConnectedInBackground,
+            config.reconnectionTimeout.map { ScheduledStreamTimer(interval: $0, fireOnStart: false) }
         )
     }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -289,6 +289,8 @@ public class ChatClient {
         tokenProvider: @escaping TokenProvider,
         completion: ((Error?) -> Void)? = nil
     ) {
+        connectionRecoveryHandler?.start()
+
         authenticationRepository.connectUser(
             userInfo: userInfo,
             tokenProvider: tokenProvider,
@@ -380,6 +382,7 @@ public class ChatClient {
         userInfo: UserInfo,
         completion: ((Error?) -> Void)? = nil
     ) {
+        connectionRecoveryHandler?.start()
         authenticationRepository.connectGuestUser(userInfo: userInfo, completion: { completion?($0) })
     }
     
@@ -403,6 +406,7 @@ public class ChatClient {
     /// Connects an anonymous user
     /// - Parameter completion: The completion that will be called once the **first** user session for the given token is setup.
     public func connectAnonymousUser(completion: ((Error?) -> Void)? = nil) {
+        connectionRecoveryHandler?.start()
         authenticationRepository.connectAnonymousUser(
             completion: { completion?($0) }
         )
@@ -438,6 +442,7 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers. No further updates from the servers
     /// are received.
     public func disconnect(completion: @escaping () -> Void) {
+        connectionRecoveryHandler?.stop()
         connectionRepository.disconnect(source: .userInitiated) {
             log.info("The `ChatClient` has been disconnected.", subsystems: .webSocket)
             completion()

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -183,6 +183,10 @@ public struct ChatClientConfig {
     /// It controls how long (in seconds) a network task should wait for additional data to arrive before giving up
     public var timeoutIntervalForRequest: TimeInterval = 30
 
+    /// The maximum time in seconds the SDK will wait until it reconnects successfully, in case it was disconnected by a recoverable error.
+    /// By default there is no timeout, so the SDK will keep trying to connect for an undetermined time.
+    public var reconnectionTimeout: TimeInterval?
+
     /// Enable/Disable local filtering for Channel lists. When enabled,
     /// whenever a new channel is created,/updated the SDK will try to
     /// match the channel list filter automatically.

--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -57,7 +57,7 @@ extension ErrorPayload {
 
 extension ClosedRange where Bound == Int {
     /// The error codes for token-related errors. Typically, a refreshed token is required to recover.
-    static let tokenInvalidErrorCodes: Self = StreamErrorCode.expiredToken...StreamErrorCode.invalidTokenSignature
+    static let tokenInvalidErrorCodes: Self = StreamErrorCode.notYetValidToken...StreamErrorCode.invalidTokenSignature
 
     /// The range of HTTP request status codes for client errors.
     static let clientErrorCodes: Self = 400...499

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -140,10 +140,8 @@ class ConnectionRepository {
         case let .connected(connectionId: id):
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
-        case let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
-            if source.serverError?.isExpiredTokenError == true {
-                onExpiredToken()
-            }
+        case let .disconnected(source) where source.serverError?.isExpiredTokenError == true:
+            onExpiredToken()
             shouldNotifyConnectionIdWaiters = false
             connectionId = nil
         case .disconnected:

--- a/Sources/StreamChat/Utils/StreamTimer/ScheduledStreamTimer.swift
+++ b/Sources/StreamChat/Utils/StreamTimer/ScheduledStreamTimer.swift
@@ -6,6 +6,7 @@ import Foundation
 
 public class ScheduledStreamTimer: StreamTimer {
     let interval: TimeInterval
+    let fireOnStart: Bool
     var runLoop = RunLoop.current
     var timer: Foundation.Timer?
     public var onChange: (() -> Void)?
@@ -14,8 +15,9 @@ public class ScheduledStreamTimer: StreamTimer {
         timer?.isValid ?? false
     }
 
-    public init(interval: TimeInterval) {
+    public init(interval: TimeInterval, fireOnStart: Bool = true) {
         self.interval = interval
+        self.fireOnStart = fireOnStart
     }
 
     public func start() {
@@ -28,7 +30,9 @@ public class ScheduledStreamTimer: StreamTimer {
             self.onChange?()
         }
         runLoop.add(timer!, forMode: .common)
-        timer?.fire()
+        if fireOnStart {
+            timer?.fire()
+        }
     }
 
     public func stop() {

--- a/Sources/StreamChat/Utils/StreamTimer/ScheduledStreamTimer.swift
+++ b/Sources/StreamChat/Utils/StreamTimer/ScheduledStreamTimer.swift
@@ -5,19 +5,22 @@
 import Foundation
 
 public class ScheduledStreamTimer: StreamTimer {
-    let interval: TimeInterval
-    let fireOnStart: Bool
     var runLoop = RunLoop.current
     var timer: Foundation.Timer?
     public var onChange: (() -> Void)?
 
-    public var isRunning: Bool {
-        timer?.isValid ?? false
-    }
+    let interval: TimeInterval
+    let fireOnStart: Bool
+    let repeats: Bool
 
-    public init(interval: TimeInterval, fireOnStart: Bool = true) {
+    public init(interval: TimeInterval, fireOnStart: Bool = true, repeats: Bool = true) {
         self.interval = interval
         self.fireOnStart = fireOnStart
+        self.repeats = repeats
+    }
+
+    public var isRunning: Bool {
+        timer?.isValid ?? false
     }
 
     public func start() {
@@ -25,7 +28,7 @@ public class ScheduledStreamTimer: StreamTimer {
 
         timer = Foundation.Timer.scheduledTimer(
             withTimeInterval: interval,
-            repeats: true
+            repeats: repeats
         ) { _ in
             self.onChange?()
         }

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -53,12 +53,12 @@ typealias ConnectionId = String
 /// A web socket connection state.
 enum WebSocketConnectionState: Equatable {
     /// Provides additional information about the source of disconnecting.
-    enum DisconnectionSource: Equatable {
+    indirect enum DisconnectionSource: Equatable {
         /// A user initiated web socket disconnecting.
         case userInitiated
 
         /// The connection timed out while trying to connect.
-        case timeout
+        case timeout(from: WebSocketConnectionState)
 
         /// A server initiated web socket disconnecting, an optional error object is provided.
         case serverInitiated(error: ClientError? = nil)

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -59,6 +59,9 @@ enum WebSocketConnectionState: Equatable {
         /// A user initiated web socket disconnecting.
         case userInitiated
 
+        /// The connection timed out while trying to connect.
+        case timeout
+
         /// A server initiated web socket disconnecting, an optional error object is provided.
         case serverInitiated(error: ClientError? = nil)
 
@@ -140,6 +143,8 @@ enum WebSocketConnectionState: Equatable {
         case .noPongReceived:
             return true
         case .userInitiated:
+            return false
+        case .timeout:
             return false
         }
     }

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -42,9 +42,7 @@ extension ConnectionStatus {
             self = .disconnecting
 
         case let .disconnected(source):
-            let isWaitingForReconnect = webSocketConnectionState.isAutomaticReconnectionEnabled || source.serverError?
-                .isInvalidTokenError == true
-
+            let isWaitingForReconnect = webSocketConnectionState.isAutomaticReconnectionEnabled
             self = isWaitingForReconnect ? .connecting : .disconnected(error: source.serverError)
         }
     }

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -129,8 +129,9 @@ enum WebSocketConnectionState: Equatable {
                     return false
                 }
 
-                if serverInitiatedError.isClientError {
-                    // Don't reconnect on client side errors
+                if serverInitiatedError.isClientError && !serverInitiatedError.isExpiredTokenError {
+                    // Don't reconnect on client side errors unless it is an expired token
+                    // Expired tokens return 401, so it is considered client error.
                     return false
                 }
             }

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -142,6 +142,10 @@ class WebSocketClient {
             eventsBatcher.processImmediately(completion: completion)
         }
     }
+
+    func timeout() {
+        connectionState = .disconnected(source: .timeout)
+    }
 }
 
 protocol ConnectionStateDelegate: AnyObject {

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -144,7 +144,9 @@ class WebSocketClient {
     }
 
     func timeout() {
-        connectionState = .disconnected(source: .timeout)
+        let previousState = connectionState
+        connectionState = .disconnected(source: .timeout(from: previousState))
+        log.error("Connection timed out. `\(connectionState)", subsystems: .webSocket)
     }
 }
 

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -146,6 +146,11 @@ class WebSocketClient {
     func timeout() {
         let previousState = connectionState
         connectionState = .disconnected(source: .timeout(from: previousState))
+        engineQueue.async { [engine, eventsBatcher] in
+            engine?.disconnect()
+
+            eventsBatcher.processImmediately {}
+        }
         log.error("Connection timed out. `\(connectionState)", subsystems: .webSocket)
     }
 }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -6,7 +6,13 @@ import CoreData
 import Foundation
 
 /// The type that keeps track of active chat components and asks them to reconnect when it's needed
-protocol ConnectionRecoveryHandler: ConnectionStateDelegate {}
+protocol ConnectionRecoveryHandler: ConnectionStateDelegate {
+    // Start connection recovery background process.
+    func start()
+    
+    // Stop connection recovery background process.
+    func stop()
+}
 
 /// The type is designed to obtain missing events that happened in watched channels while user
 /// was not connected to the web-socket.
@@ -57,14 +63,21 @@ final class DefaultConnectionRecoveryHandler: ConnectionRecoveryHandler {
         self.reconnectionStrategy = reconnectionStrategy
         self.reconnectionTimerType = reconnectionTimerType
         self.keepConnectionAliveInBackground = keepConnectionAliveInBackground
+    }
 
+    func start() {
         subscribeOnNotifications()
     }
 
-    deinit {
+    func stop() {
         unsubscribeFromNotifications()
+        reconnectionStrategy.resetConsecutiveFailures()
         cancelReconnectionTimer()
         reconnectionTimeoutHandler.stop()
+    }
+
+    deinit {
+        stop()
     }
 }
 
@@ -96,6 +109,12 @@ private extension DefaultConnectionRecoveryHandler {
         internetConnection.notificationCenter.removeObserver(
             self,
             name: .internetConnectionStatusDidChange,
+            object: nil
+        )
+
+        internetConnection.notificationCenter.removeObserver(
+            self,
+            name: .internetConnectionAvailabilityDidChange,
             object: nil
         )
     }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -88,7 +88,6 @@ private extension DefaultConnectionRecoveryHandler {
 
         reconnectionTimeoutHandler?.onChange = { [weak self] in
             self?.webSocketClient.timeout()
-            self?.reconnectionTimeoutHandler?.stop()
             self?.cancelReconnectionTimer()
         }
     }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -147,12 +147,18 @@ extension DefaultConnectionRecoveryHandler {
     }
 
     @objc private func internetConnectionAvailabilityDidChange(_ notification: Notification) {
-        if let isAvailable = notification.internetConnectionStatus?.isAvailable {
-            log.debug("Internet -> \(isAvailable ? "✅" : "❌")", subsystems: .webSocket)
+        guard let isAvailable = notification.internetConnectionStatus?.isAvailable else {
+            return
         }
 
-        if canReconnectFromOffline {
-            webSocketClient.connect()
+        log.debug("Internet -> \(isAvailable ? "✅" : "❌")", subsystems: .webSocket)
+
+        if isAvailable {
+            if canReconnectFromOffline {
+                webSocketClient.connect()
+            }
+        } else {
+            disconnectIfNeeded()
         }
     }
 

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -6,7 +6,10 @@ import CoreData
 import Foundation
 
 /// The type that keeps track of active chat components and asks them to reconnect when it's needed
-protocol ConnectionRecoveryHandler: ConnectionStateDelegate {}
+protocol ConnectionRecoveryHandler: ConnectionStateDelegate {
+    func start()
+    func stop()
+}
 
 /// The type is designed to obtain missing events that happened in watched channels while user
 /// was not connected to the web-socket.
@@ -59,14 +62,20 @@ final class DefaultConnectionRecoveryHandler: ConnectionRecoveryHandler {
         self.reconnectionTimerType = reconnectionTimerType
         self.keepConnectionAliveInBackground = keepConnectionAliveInBackground
         self.reconnectionTimeoutHandler = reconnectionTimeoutHandler
+    }
 
+    func start() {
         subscribeOnNotifications()
     }
 
-    deinit {
+    func stop() {
         unsubscribeFromNotifications()
         cancelReconnectionTimer()
         reconnectionTimeoutHandler?.stop()
+    }
+
+    deinit {
+        stop()
     }
 }
 

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -6,13 +6,7 @@ import CoreData
 import Foundation
 
 /// The type that keeps track of active chat components and asks them to reconnect when it's needed
-protocol ConnectionRecoveryHandler: ConnectionStateDelegate {
-    // Start connection recovery background process.
-    func start()
-    
-    // Stop connection recovery background process.
-    func stop()
-}
+protocol ConnectionRecoveryHandler: ConnectionStateDelegate {}
 
 /// The type is designed to obtain missing events that happened in watched channels while user
 /// was not connected to the web-socket.
@@ -63,21 +57,14 @@ final class DefaultConnectionRecoveryHandler: ConnectionRecoveryHandler {
         self.reconnectionStrategy = reconnectionStrategy
         self.reconnectionTimerType = reconnectionTimerType
         self.keepConnectionAliveInBackground = keepConnectionAliveInBackground
-    }
 
-    func start() {
         subscribeOnNotifications()
     }
 
-    func stop() {
+    deinit {
         unsubscribeFromNotifications()
-        reconnectionStrategy.resetConsecutiveFailures()
         cancelReconnectionTimer()
         reconnectionTimeoutHandler.stop()
-    }
-
-    deinit {
-        stop()
     }
 }
 
@@ -109,12 +96,6 @@ private extension DefaultConnectionRecoveryHandler {
         internetConnection.notificationCenter.removeObserver(
             self,
             name: .internetConnectionStatusDidChange,
-            object: nil
-        )
-
-        internetConnection.notificationCenter.removeObserver(
-            self,
-            name: .internetConnectionAvailabilityDidChange,
             object: nil
         )
     }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -160,7 +160,9 @@ extension DefaultConnectionRecoveryHandler {
         switch state {
         case .connecting:
             cancelReconnectionTimer()
-            reconnectionTimeoutHandler.start()
+            if !reconnectionTimeoutHandler.isRunning {
+                reconnectionTimeoutHandler.start()
+            }
 
         case .connected:
             extensionLifecycle.setAppState(isReceivingEvents: true)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -437,6 +437,7 @@ open class ChatChannelListVC: _ViewController,
             case .remoteDataFetched:
                 isLoading = false
                 shouldHideEmptyView = !controller.channels.isEmpty
+                channelListErrorView.hide()
             case .localDataFetchFailed, .remoteDataFetchFailed:
                 shouldHideEmptyView = emptyView.isHidden
                 isLoading = false

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1591,6 +1591,7 @@
 		AD99C909279B0E9D009DD9C5 /* MessageDateSeparatorFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD99C906279B0C9B009DD9C5 /* MessageDateSeparatorFormatter.swift */; };
 		AD99C90C279B136B009DD9C5 /* UserLastActivityFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD99C90A279B1363009DD9C5 /* UserLastActivityFormatter.swift */; };
 		AD99C90D279B136D009DD9C5 /* UserLastActivityFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD99C90A279B1363009DD9C5 /* UserLastActivityFormatter.swift */; };
+		ADA2D64A2C46B66E001D2B44 /* DemoChatChannelListErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA2D6492C46B66E001D2B44 /* DemoChatChannelListErrorView.swift */; };
 		ADA3572F269C807A004AD8E9 /* ChatChannelHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA3572D269C562A004AD8E9 /* ChatChannelHeaderView.swift */; };
 		ADA5A0F8276790C100E1C465 /* ChatMessageListDateSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA5A0F7276790C100E1C465 /* ChatMessageListDateSeparatorView.swift */; };
 		ADA5A0F9276790C100E1C465 /* ChatMessageListDateSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA5A0F7276790C100E1C465 /* ChatMessageListDateSeparatorView.swift */; };
@@ -4232,6 +4233,7 @@
 		AD99C906279B0C9B009DD9C5 /* MessageDateSeparatorFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDateSeparatorFormatter.swift; sourceTree = "<group>"; };
 		AD99C90A279B1363009DD9C5 /* UserLastActivityFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLastActivityFormatter.swift; sourceTree = "<group>"; };
 		AD9BE32526680E4200A6D284 /* Stream.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Stream.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		ADA2D6492C46B66E001D2B44 /* DemoChatChannelListErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatChannelListErrorView.swift; sourceTree = "<group>"; };
 		ADA3572D269C562A004AD8E9 /* ChatChannelHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelHeaderView.swift; sourceTree = "<group>"; };
 		ADA5A0F7276790C100E1C465 /* ChatMessageListDateSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListDateSeparatorView.swift; sourceTree = "<group>"; };
 		ADA8EBE828CFD52F00DB9B03 /* TextViewUserMentionsHandler_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewUserMentionsHandler_Mock.swift; sourceTree = "<group>"; };
@@ -6620,6 +6622,7 @@
 				A3227E77284A4CAD00EBE6CC /* DemoChatMessageContentView.swift */,
 				79B8B64A285CBDC00059FB2D /* DemoChatMessageLayoutOptionsResolver.swift */,
 				A3227E71284A4BF700EBE6CC /* HiddenChannelListVC.swift */,
+				ADA2D6492C46B66E001D2B44 /* DemoChatChannelListErrorView.swift */,
 				AD053B982B33581A003612B6 /* CustomAttachments */,
 				A3227E67284A4AA400EBE6CC /* Banner */,
 			);
@@ -10813,6 +10816,7 @@
 				7933060B256FF94800FBB586 /* DemoChatChannelListRouter.swift in Sources */,
 				AD82903D2A7C5A8F00396782 /* DemoChatChannelListItemView.swift in Sources */,
 				A3227E69284A4AE800EBE6CC /* AvatarView.swift in Sources */,
+				ADA2D64A2C46B66E001D2B44 /* DemoChatChannelListErrorView.swift in Sources */,
 				A3227E5B284A489000EBE6CC /* UIViewController+Alert.swift in Sources */,
 				A3227E6D284A4B6A00EBE6CC /* UserCredentialsCell.swift in Sources */,
 				84A33ABA28F86B8500CEC8FD /* StreamChatWrapper+DemoApp.swift in Sources */,

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -536,6 +536,8 @@ extension UserRobot {
     @discardableResult
     func setConnectivity(to state: SwitchState) -> Self {
         setSwitchState(Settings.isConnected.element, state: state)
+        Settings.isConnected.element.wait(timeout: 2)
+        return self
     }
 }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -148,6 +148,9 @@ extension ChatClient {
                         deletedMessagesVisibility: $4,
                         shouldShowShadowedMessages: $5
                     )
+                }, 
+                internetConnection: { center, _ in
+                    InternetConnection_Mock(notificationCenter: center)
                 },
                 authenticationRepositoryBuilder: AuthenticationRepository_Mock.init
             )

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
@@ -21,6 +21,8 @@ final class WebSocketClient_Mock: WebSocketClient {
     var disconnect_called: Bool { disconnect_calledCounter > 0 }
     var disconnect_completion: (() -> Void)?
 
+    var timeout_callCount = 0
+
 
     var mockedConnectionState: WebSocketConnectionState?
 
@@ -74,6 +76,10 @@ final class WebSocketClient_Mock: WebSocketClient {
         _disconnect_calledCounter { $0 += 1 }
         disconnect_source = source
         disconnect_completion = completion
+    }
+
+    override func timeout() {
+        timeout_callCount += 1
     }
 
     var mockEventsBatcher: EventBatcher_Mock {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
@@ -13,10 +13,10 @@ final class WebSocketClient_Mock: WebSocketClient {
     let init_eventNotificationCenter: EventNotificationCenter
     let init_environment: WebSocketClient.Environment
 
-    @Atomic var connect_calledCounter = 0
+    var connect_calledCounter = 0
     var connect_called: Bool { connect_calledCounter > 0 }
 
-    @Atomic var disconnect_calledCounter = 0
+    var disconnect_calledCounter = 0
     var disconnect_source: WebSocketConnectionState.DisconnectionSource?
     var disconnect_called: Bool { disconnect_calledCounter > 0 }
     var disconnect_completion: (() -> Void)?
@@ -66,14 +66,14 @@ final class WebSocketClient_Mock: WebSocketClient {
     }
 
     override func connect() {
-        _connect_calledCounter { $0 += 1 }
+        connect_calledCounter += 1
     }
 
     override func disconnect(
         source: WebSocketConnectionState.DisconnectionSource = .userInitiated,
         completion: @escaping () -> Void
     ) {
-        _disconnect_calledCounter { $0 += 1 }
+        disconnect_calledCounter += 1
         disconnect_source = source
         disconnect_completion = completion
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/Background/ConnectionRecoveryHandler_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/Background/ConnectionRecoveryHandler_Mock.swift
@@ -7,6 +7,17 @@ import XCTest
 
 /// Mock implementation of `ConnectionRecoveryHandler`
 final class ConnectionRecoveryHandler_Mock: ConnectionRecoveryHandler {
+    var startCallCount = 0
+    var stopCallCount = 0
+
+    func start() {
+        startCallCount += 1
+    }
+    
+    func stop() {
+        stopCallCount += 1
+    }
+    
     lazy var mock_webSocketClientDidUpdateConnectionState = MockFunc.mock(for: webSocketClient)
 
     func webSocketClient(_ client: WebSocketClient, didUpdateConnectionState state: WebSocketConnectionState) {

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -276,7 +276,7 @@ final class ConnectionRepository_Tests: XCTestCase {
             (.disconnecting(source: .noPongReceived), .disconnecting),
             (.disconnected(source: .userInitiated), .disconnected(error: nil)),
             (.disconnected(source: .systemInitiated), .connecting),
-            (.disconnected(source: .serverInitiated(error: invalidTokenError)), .connecting)
+            (.disconnected(source: .serverInitiated(error: invalidTokenError)), .disconnected(error: invalidTokenError))
         ]
 
         for (webSocketState, connectionStatus) in pairs {

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -287,7 +287,13 @@ final class ConnectionRepository_Tests: XCTestCase {
 
     func test_handleConnectionUpdate_shouldNotifyWaitersWhenNeeded() {
         let invalidTokenError = ClientError(with: ErrorPayload(
-            code: .random(in: ClosedRange.tokenInvalidErrorCodes),
+            code: StreamErrorCode.accessKeyInvalid,
+            message: .unique,
+            statusCode: .unique
+        ))
+
+        let expiredTokenError = ClientError(with: ErrorPayload(
+            code: StreamErrorCode.expiredToken,
             message: .unique,
             statusCode: .unique
         ))
@@ -301,7 +307,8 @@ final class ConnectionRepository_Tests: XCTestCase {
             (.disconnecting(source: .noPongReceived), false),
             (.disconnected(source: .userInitiated), true),
             (.disconnected(source: .systemInitiated), true),
-            (.disconnected(source: .serverInitiated(error: invalidTokenError)), false)
+            (.disconnected(source: .serverInitiated(error: invalidTokenError)), true),
+            (.disconnected(source: .serverInitiated(error: expiredTokenError)), false)
         ]
 
         for (webSocketState, shouldNotify) in pairs {

--- a/Tests/StreamChatTests/WebSocketClient/ConnectionStatus_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/ConnectionStatus_Tests.swift
@@ -143,6 +143,23 @@ final class WebSocketConnectionState_Tests: XCTestCase {
         XCTAssertFalse(state.isAutomaticReconnectionEnabled)
     }
 
+    func test_isAutomaticReconnectionEnabled_whenDisconnectedByServerWithExpiredToken_returnsTrue() {
+        // Create expired token error
+        let expiredTokenError = ErrorPayload(
+            code: StreamErrorCode.expiredToken,
+            message: .unique,
+            statusCode: .unique
+        )
+
+        // Create disconnected state intiated by the server with invalid token error
+        let state: WebSocketConnectionState = .disconnected(
+            source: .serverInitiated(error: ClientError(with: expiredTokenError))
+        )
+
+        // Assert `isAutomaticReconnectionEnabled` returns true
+        XCTAssertTrue(state.isAutomaticReconnectionEnabled)
+    }
+
     func test_isAutomaticReconnectionEnabled_whenDisconnectedByServerWithClientError_returnsFalse() {
         // Create client error
         let clientError = ErrorPayload(

--- a/Tests/StreamChatTests/WebSocketClient/ConnectionStatus_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/ConnectionStatus_Tests.swift
@@ -26,7 +26,7 @@ final class ChatClientConnectionStatus_Tests: XCTestCase {
             (.disconnected(source: .noPongReceived), .connecting),
             (.disconnected(source: .serverInitiated(error: nil)), .connecting),
             (.disconnected(source: .serverInitiated(error: testError)), .connecting),
-            (.disconnected(source: .serverInitiated(error: invalidTokenError)), .connecting),
+            (.disconnected(source: .serverInitiated(error: invalidTokenError)), .disconnected(error: invalidTokenError)),
             (.connected(connectionId: .unique), .connected),
             (.disconnecting(source: .noPongReceived), .disconnecting),
             (.disconnecting(source: .serverInitiated(error: testError)), .disconnecting),

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -638,6 +638,7 @@ private extension ConnectionRecoveryHandler_Tests {
             keepConnectionAliveInBackground: keepConnectionAliveInBackground,
             reconnectionTimeoutHandler: withReconnectionTimeout ? mockReconnectionTimeoutHandler : nil
         )
+        handler.start()
 
         // Make a handler a delegate to simlulate real life chain when
         // connection changes are propagated back to the handler.

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -130,6 +130,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Assert no reconnect timer
         XCTAssertTrue(mockTime.scheduledTimers.isEmpty)
 
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
+
         // Internet -> ON
         mockInternetConnection.monitorMock.status = .available(.great)
 

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -72,6 +72,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Assert no reconnect timer
         XCTAssertTrue(mockTime.scheduledTimers.isEmpty)
 
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
+
         // Internet -> ON
         mockInternetConnection.monitorMock.status = .available(.great)
 
@@ -96,6 +98,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertFalse(mockBackgroundTaskScheduler.beginBackgroundTask_called)
         // Assert no reconnect timer
         XCTAssertTrue(mockTime.scheduledTimers.isEmpty)
+
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
 
         // App -> foreground
         mockBackgroundTaskScheduler.simulateAppGoingToForeground()
@@ -165,6 +169,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Assert no reconnect timer
         XCTAssertTrue(mockTime.scheduledTimers.isEmpty)
 
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
+
         // App -> foregorund
         mockBackgroundTaskScheduler.simulateAppGoingToForeground()
 
@@ -191,6 +197,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertFalse(mockBackgroundTaskScheduler.beginBackgroundTask_called)
         // Assert no reconnect timer
         XCTAssertTrue(mockTime.scheduledTimers.isEmpty)
+
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
 
         // Disconnect (system initiated)
         disconnectWebSocket(source: .systemInitiated)
@@ -223,6 +231,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertTrue(mockBackgroundTaskScheduler.beginBackgroundTask_called)
         // Assert no reconnect timer
         XCTAssertTrue(mockTime.scheduledTimers.isEmpty)
+
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
 
         // App -> foregorund
         mockBackgroundTaskScheduler.simulateAppGoingToForeground()
@@ -337,13 +347,14 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Disconnect (system initiated)
         disconnectWebSocket(source: .systemInitiated)
 
-        // Reset disconnect calls count
+        // Reset calls counts
         mockChatClient.mockWebSocketClient.disconnect_calledCounter = 0
+        mockChatClient.mockWebSocketClient.connect_calledCounter = 0
 
         // Internet -> ON
         mockInternetConnection.monitorMock.status = .available(.great)
 
-        // Assert no reconnect in backround
+        // Assert no reconnect in background
         XCTAssertFalse(mockChatClient.mockWebSocketClient.connect_called)
 
         // Internet -> OFF

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -14,6 +14,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
     var mockBackgroundTaskScheduler: BackgroundTaskScheduler_Mock!
     var mockRetryStrategy: RetryStrategy_Spy!
     var mockTime: VirtualTime { VirtualTimeTimer.time }
+    var mockReconnectionTimeoutHandler: ScheduledStreamTimer_Mock!
 
     override func setUp() {
         super.setUp()
@@ -24,6 +25,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         mockBackgroundTaskScheduler = BackgroundTaskScheduler_Mock()
         mockRetryStrategy = RetryStrategy_Spy()
         mockInternetConnection = .init(notificationCenter: mockChatClient.eventNotificationCenter)
+        mockReconnectionTimeoutHandler = ScheduledStreamTimer_Mock()
     }
 
     override func tearDown() {
@@ -593,7 +595,8 @@ private extension ConnectionRecoveryHandler_Tests {
             internetConnection: mockInternetConnection,
             reconnectionStrategy: mockRetryStrategy,
             reconnectionTimerType: VirtualTimeTimer.self,
-            keepConnectionAliveInBackground: keepConnectionAliveInBackground
+            keepConnectionAliveInBackground: keepConnectionAliveInBackground,
+            reconnectionTimeoutHandler: nil
         )
 
         // Make a handler a delegate to simlulate real life chain when


### PR DESCRIPTION
### 🔗 Issue Links
https://stream-io.atlassian.net/browse/PBE-4780

### 🎯 Goal

Add support for timing out reconnection.

### 📝 Summary

SDK:
- Add an option to configure reconnection timeout
- Fix Channel List not hiding error view when data is available
- Fix not trying to connect if the network is not available (This can cause edge cases, according to Apple)
- Ignore network status since it is not reliable, even on the device sometimes network status is not returned correctly
- Fix invalid token errors considered as possible to reconnect

DemoApp:
- Fix the demo app not showing the connection bar
- Fixes fake token failures in the demo app not working
- Fix Demo App channel list error view animation

### 🛠 Implementation

An alternative approach to https://github.com/GetStream/stream-chat-swift/pull/3302 uses a separate entity to control the timeout, independent of the exponential backoff mechanism.

It uses a separate timeout handler to timeout the reconnection logic instead of using a number of retries of the existing backoff retry mechanism. The 2 main reasons for using a separate timeout handler are the following:
- It is clearer for the customer to expose a maximum timeout time than a maximum number of retries.
- It has less impact in the implementation of `RetryStrategy`, which at the moment has some flaws, described in this document: https://www.notion.so/stream-wiki/Reconnection-Problems-63eeaaab19d94d50b9922b76ebb414ab

### 🧪 Manual Testing Notes

**With timeout**
1. Go To Demo App Configuration Screen
2. Set reconnection timeout, ex: 15s
3. Disable Network on your device
4. Login
5. Should show "Connecting..." banner
6. After 15s
7. Should show "Disconnect" banner
8. Enable Network on your device
9. Should show "Connecting.." and then "Connected" and then disappear
10. Tap on Error View to reload the channel list
11. Should load channel list

**Without timeout**
1. Go To Demo App Configuration Screen
2. Disable timeout (By default)
3. Disable Network on your device
4. Login
5. Should show "Connecting..." banner
6. Wait 60s
7. Should still show "Connecting..." banner
8. Enable Network on your device
9. Should show "Connected" and then disappear
10. Tap on Error View to reload the channel list
11. Should load channel list

**Retest token refresh**:
1. Open Demo App Configuration
2. Edit tokenRefreshDetails
3. Add a fake App Secret
4. Set the duration, ex: 10
5. Set the number of refreshes, ex: 3
6. Login
7. Should see "Demo App Token Refreshing: Token refresh failed." 3x in Xcode Console
8. Should see "Disconnected"
9. Logout
10. Put a valid App Secret from Stream's Dashboard
11. Should see "Demo App Token Refreshing: Token refresh failed." 3x in Xcode Console
12. Then you should see "Connected"
13. For each 10 seconds, the banner should show "Connecting" -> "Connected"

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
