### PR TITLE
 Reliable access to database models while observer is processing database changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Dropped iOS 12 support [#3285](https://github.com/GetStream/stream-chat-swift/pull/3285)
 - Increase QoS for `Throttler` and `Debouncer` to `utility` [#3295](https://github.com/GetStream/stream-chat-swift/issues/3295)
-- Fetch database items immediately if the initial fetch has not finished in background database observers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
+- Provide immediate access to controller managed database items [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
 
 # [4.59.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.59.0)
 _July 10, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Dropped iOS 12 support [#3285](https://github.com/GetStream/stream-chat-swift/pull/3285)
 - Increase QoS for `Throttler` and `Debouncer` to `utility` [#3295](https://github.com/GetStream/stream-chat-swift/issues/3295)
+- Fetch database items immediately if the initial fetch has not finished in background database observers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
 
 # [4.59.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.59.0)
 _July 10, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Dropped iOS 12 support [#3285](https://github.com/GetStream/stream-chat-swift/pull/3285)
 - Increase QoS for `Throttler` and `Debouncer` to `utility` [#3295](https://github.com/GetStream/stream-chat-swift/issues/3295)
-- Reliable access to database models while observer is processing database changes [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
+- Improve reliability of accessing database models in controller provided completion handlers [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
 
 # [4.59.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.59.0)
 _July 10, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Dropped iOS 12 support [#3285](https://github.com/GetStream/stream-chat-swift/pull/3285)
 - Increase QoS for `Throttler` and `Debouncer` to `utility` [#3295](https://github.com/GetStream/stream-chat-swift/issues/3295)
-- Provide immediate access to controller managed database items [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
+- Reliable access to database models while observer is processing database changes [#3304](https://github.com/GetStream/stream-chat-swift/issues/3304)
 
 # [4.59.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.59.0)
 _July 10, 2024_

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -224,9 +224,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         ) { [weak self] result in
             switch result {
             case let .success(channels):
-                self?.channelListObserver.refreshItems { [weak self] in
-                    self?.state = .remoteDataFetched
-                }
+                self?.state = .remoteDataFetched
                 self?.hasLoadedAllPreviousChannels = channels.count < limit
                 self?.callback { completion?(nil) }
             case let .failure(error):

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -206,8 +206,7 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
             changes: changes,
             itemCreator: itemCreator,
             itemReuseKeyPaths: itemReuseKeyPaths,
-            sorting: sorting,
-            checkCancellation: { false }
+            sorting: sorting
         )
     }
 }

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -35,7 +35,7 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
 
     /// The items that have been fetched and mapped
     ///
-    /// -Note: Fetches items synchronously if the initial fetch has not finished.
+    /// - Note: Fetches items synchronously if the observer is in the middle of processing a change.
     var rawItems: [Item] {
         // When items are accessed while DB change is being processed in the background,
         // we want to return the processing change immediately.

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -34,20 +34,31 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
     private var _items: [Item] = []
 
     /// The items that have been fetched and mapped
+    ///
+    /// -Note: Fetches items synchronously if the initial fetch has not finished.
     var rawItems: [Item] {
-        queue.sync { _items }
+        // If we have already loaded initial items, return them immediately
+        if let items = queue.sync(execute: { _hasFetchedInitialItems ? _items : nil }) {
+            return items
+        }
+        // Otherwise load items synchronously if the initial fetch has not finished
+        return queue.sync(flags: .barrier) {
+            var items = [Item]()
+            frc.managedObjectContext.performAndWait {
+                items = mapItems(changes: nil, reusableItems: [])
+            }
+            _items = items
+            _hasFetchedInitialItems = true
+            return _items
+        }
     }
 
+    private var _hasFetchedInitialItems = false
+    
     private var _isInitialized: Bool = false
     private var isInitialized: Bool {
         get { queue.sync { _isInitialized } }
         set { queue.async(flags: .barrier) { self._isInitialized = newValue } }
-    }
-
-    private var _isDeletingDatabase: Bool = false
-    private var isDeletingDatabase: Bool {
-        get { queue.sync { _isDeletingDatabase }}
-        set { queue.async(flags: .barrier) { self._isDeletingDatabase = newValue } }
     }
 
     deinit {
@@ -106,7 +117,7 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
     /// Starts observing the changes in the database.
     /// - Throws: An error if the fetch  fails.
     func startObserving() throws {
-        guard !isInitialized && !isDeletingDatabase else { return }
+        guard !isInitialized else { return }
         isInitialized = true
 
         do {
@@ -118,7 +129,7 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
 
         frc.delegate = changeAggregator
 
-        /// Because this observer does not get items synchronously, we start a process to get the items, which will then notify via its blocks.
+        /// Start a process to get the items, which will then notify via its blocks.
         getInitialItems()
     }
 
@@ -154,9 +165,10 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
                 completion?()
                 return
             }
-
+            // Operation queue runs on the same `self.queue`
+            let reusableItems = _items
             self.frc.managedObjectContext.perform {
-                self.processItems(changes) {
+                self.processItems(changes, reusableItems: reusableItems) {
                     done(.continue)
                     completion?()
                 }
@@ -169,20 +181,16 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
     /// This method will process  the currently fetched objects, and will notify the listeners.
     /// When the process is done, it also updates the `_items`, which is the locally cached list of mapped items
     /// This method will be called through an operation on `processingQueue`, which will serialize the execution until `onCompletion` is called.
-    private func processItems(_ changes: [ListChange<Item>]?, onCompletion: @escaping () -> Void) {
-        mapItems(changes) { [weak self] items in
-            guard let self = self else {
-                onCompletion()
-                return
-            }
-
-            /// We want to make sure that nothing else but this block is happening in this queue when updating `_items`
-            /// This also includes finishing the operation and notifying about the update. Only once everything is done, we conclude the operation.
-            self.queue.async(flags: .barrier) {
-                self._items = items
-                let returnedChanges = changes ?? items.enumerated().map { .insert($1, index: IndexPath(item: $0, section: 0)) }
-                self.notifyDidChange(changes: returnedChanges, onCompletion: onCompletion)
-            }
+    private func processItems(_ changes: [ListChange<Item>]?, reusableItems: [Item], onCompletion: @escaping () -> Void) {
+        let items = mapItems(changes: changes, reusableItems: reusableItems)
+        
+        /// We want to make sure that nothing else but this block is happening in this queue when updating `_items`
+        /// This also includes finishing the operation and notifying about the update. Only once everything is done, we conclude the operation.
+        queue.async(flags: .barrier) {
+            self._items = items
+            self._hasFetchedInitialItems = true
+            let returnedChanges = changes ?? items.enumerated().map { .insert($1, index: IndexPath(item: $0, section: 0)) }
+            self.notifyDidChange(changes: returnedChanges, onCompletion: onCompletion)
         }
     }
 
@@ -190,17 +198,16 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
     /// This method is intended to be called from the `managedObjectContext` that is publishing the changes (The one linked to the `NSFetchedResultsController`
     /// in this case).
     /// Once the objects are mapped, those are sorted based on `sorting`
-    private func mapItems(_ changes: [ListChange<Item>]?, completion: @escaping ([Item]) -> Void) {
+    private func mapItems(changes: [ListChange<Item>]?, reusableItems: [Item]) -> [Item] {
         let objects = frc.fetchedObjects ?? []
-        let items = DatabaseItemConverter.convert(
+        return DatabaseItemConverter.convert(
             dtos: objects,
-            existing: rawItems,
+            existing: reusableItems,
             changes: changes,
             itemCreator: itemCreator,
             itemReuseKeyPaths: itemReuseKeyPaths,
             sorting: sorting,
-            checkCancellation: { [weak self] in self?.isDeletingDatabase == true }
+            checkCancellation: { false }
         )
-        completion(items)
     }
 }

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -166,7 +166,7 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
                 return
             }
             // Operation queue runs on the same `self.queue`
-            let reusableItems = _items
+            let reusableItems = self._items
             self.frc.managedObjectContext.perform {
                 self.processItems(changes, reusableItems: reusableItems) {
                     done(.continue)

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundListDatabaseObserver.swift
@@ -27,10 +27,4 @@ class BackgroundListDatabaseObserver<Item, DTO: NSManagedObject>: BackgroundData
             fetchedResultsControllerType: fetchedResultsControllerType
         )
     }
-    
-    /// Since DB updates now happen in a background thread, sometimes we need to
-    /// wait for the updates to do some action, so this function is useful for that.
-    func refreshItems(completion: @escaping () -> Void) {
-        updateItems(changes: nil, completion: completion)
-    }
 }

--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -204,9 +204,9 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
             }
 
             let error = result.error
-            self.callback { completion?(error) }
-            self.messagesObserver?.refreshItems { [weak self] in
-                self?.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.callback {
+                completion?(error)
             }
         }
     }

--- a/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
+++ b/Sources/StreamChat/Controllers/ThreadListController/ThreadListController.swift
@@ -112,15 +112,11 @@ public class ChatThreadListController: DataController, DelegateCallable, DataSto
         ) { [weak self] result in
             switch result {
             case let .success(threadListResponse):
-                self?.threadListObserver.refreshItems { [weak self] in
-                    self?.callback {
-                        self?.threadListObserver.refreshItems {
-                            self?.state = .remoteDataFetched
-                            self?.nextCursor = threadListResponse.next
-                            self?.hasLoadedAllThreads = threadListResponse.next == nil
-                            completion?(nil)
-                        }
-                    }
+                self?.callback {
+                    self?.state = .remoteDataFetched
+                    self?.nextCursor = threadListResponse.next
+                    self?.hasLoadedAllThreads = threadListResponse.next == nil
+                    completion?(nil)
                 }
             case let .failure(error):
                 self?.state = .remoteDataFetchFailed(ClientError(with: error))

--- a/Sources/StreamChat/StateLayer/DatabaseObserver/StateLayerDatabaseObserver.swift
+++ b/Sources/StreamChat/StateLayer/DatabaseObserver/StateLayerDatabaseObserver.swift
@@ -198,8 +198,7 @@ extension StateLayerDatabaseObserver where ResultType == ListResult {
             changes: changes,
             itemCreator: itemCreator,
             itemReuseKeyPaths: itemReuseKeyPaths,
-            sorting: sorting,
-            checkCancellation: { false }
+            sorting: sorting
         )
         reuseItems = items
         return items

--- a/Tests/StreamChatTests/BackgroundListDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/BackgroundListDatabaseObserver_Tests.swift
@@ -165,7 +165,7 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
         }
         
         observer = BackgroundListDatabaseObserver<String, TestManagedObject>(
-            context: database.backgroundReadOnlyContext,
+            database: database,
             fetchRequest: fetchRequest,
             itemCreator: { $0.testId },
             sorting: []
@@ -189,7 +189,7 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
         
         let initialFinishedExpectation = XCTestExpectation(description: "Initial")
         observer = BackgroundListDatabaseObserver<String, TestManagedObject>(
-            context: database.backgroundReadOnlyContext,
+            database: database,
             fetchRequest: fetchRequest,
             itemCreator: { $0.testId },
             sorting: []


### PR DESCRIPTION
### 🔗 Issue Links

Related [PBE-4853](https://stream-io.atlassian.net/browse/PBE-4853)

### 🎯 Goal

Return items reflecting the current DB state when accessing observer's items while background mapping is still running.

### 📝 Summary

- Synchronously fetch items (but reuse existing) if items are accessed while FRC's change is being processed.
- Remove `refreshItems` which was used a workaround for waiting background observer to finish processing

### 🛠 Implementation

Background observers fetch initial items and process FRC changes using a queue. It is good for pushing the model mapping to a background thread but has a shortcoming if we need to access updated items before the queue has finished processing it.
Example is that I create a controller, call synchronize, and then in the completion want to access updated items. At that time the observer is actually in the middle of processing update items and would return items before the last DB change. This makes many things hard with controllers. For fixing this, this PR starts tracking the processing state. If we access items while processing is in progress, we do a synchronous access to the DB (BUT while reusing items which does not make it slow). 

### 🧪 Manual Testing Notes

Exploratory testing

#### Case 1
1. Log out
2. Log in
3. Observe that channel list goes from loading state to list without showing empty view for a split secod

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-4853]: https://stream-io.atlassian.net/browse/PBE-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ