### PR TITLE
Xcode 16 fails to compile MessageDTO tests

### DIFF
--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -631,7 +631,7 @@ final class MessageDTO_Tests: XCTestCase {
         XCTAssertEqual(messagePayload.isShadowed, loadedMessage?.isShadowed)
         XCTAssertEqual(
             Set(messagePayload.attachmentIDs(cid: channelId)),
-            loadedMessage.flatMap { Set($0.attachments.map(\.attachmentID)) }
+            loadedMessage.flatMap { Set($0.attachments.compactMap(\.attachmentID)) }
         )
         XCTAssertEqual(messagePayload.translations?.mapKeys(\.languageCode), loadedMessage?.translations)
         XCTAssertEqual("es", loadedMessage?.originalLanguage)
@@ -782,7 +782,7 @@ final class MessageDTO_Tests: XCTestCase {
             Assert.willBeEqual(messagePayload.isSilent, loadedMessage?.isSilent)
             Assert.willBeEqual(
                 Set(messagePayload.attachmentIDs(cid: channelId)),
-                loadedMessage.flatMap { Set($0.attachments.map(\.attachmentID)) }
+                loadedMessage.flatMap { Set($0.attachments.compactMap(\.attachmentID)) }
             )
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Support building and running tests with Xcode 16 beta.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
