### PR TITLE
Fix Demo App Refresh Tokens + Connection Banner

### DIFF
--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -20,6 +20,8 @@ struct DemoAppConfig {
     var isLocationAttachmentsEnabled: Bool
     /// Set this value to define if we should mimic token refresh scenarios.
     var tokenRefreshDetails: TokenRefreshDetails?
+    /// A Boolean value that determines if a connection banner UI should be shown.
+    var shouldShowConnectionBanner: Bool
 
     /// The details to generate expirable tokens in the demo app.
     struct TokenRefreshDetails {
@@ -48,7 +50,8 @@ class AppConfig {
             isMessageDebuggerEnabled: false,
             isChannelPinningEnabled: false,
             isLocationAttachmentsEnabled: false,
-            tokenRefreshDetails: nil
+            tokenRefreshDetails: nil,
+            shouldShowConnectionBanner: false
         )
 
         if StreamRuntimeCheck.isStreamInternalConfiguration {
@@ -57,6 +60,7 @@ class AppConfig {
             demoAppConfig.isLocationAttachmentsEnabled = true
             demoAppConfig.isLocationAttachmentsEnabled = true
             demoAppConfig.isHardDeleteEnabled = true
+            demoAppConfig.shouldShowConnectionBanner = true
             StreamRuntimeCheck.assertionsEnabled = true
         }
     }
@@ -165,6 +169,7 @@ class AppConfigViewController: UITableViewController {
         case isChannelPinningEnabled
         case isLocationAttachmentsEnabled
         case tokenRefreshDetails
+        case shouldShowConnectionBanner
     }
 
     enum ComponentsConfigOption: String, CaseIterable {
@@ -315,6 +320,10 @@ class AppConfigViewController: UITableViewController {
                 cell.detailTextLabel?.text = "Disabled"
             }
             cell.accessoryType = .none
+        case .shouldShowConnectionBanner:
+            cell.accessoryView = makeSwitchButton(demoAppConfig.shouldShowConnectionBanner) { [weak self] newValue in
+                self?.demoAppConfig.shouldShowConnectionBanner = newValue
+            }
         }
     }
 

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -14,7 +14,7 @@ extension StreamChatWrapper {
         { completion in
             // Simulate API call delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                var generatedToken: Token? = _generateUserToken(
+                let generatedToken: Token? = _generateUserToken(
                     secret: refreshDetails.appSecret,
                     userID: initialToken.userId,
                     expirationDate: Date().addingTimeInterval(refreshDetails.duration)

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -26,7 +26,7 @@ extension StreamChatWrapper {
 
                 let numberOfSuccessfulRefreshes = refreshDetails.numberOfSuccessfulRefreshesBeforeFailing
                 let shouldNotFail = numberOfSuccessfulRefreshes == 0
-                if shouldNotFail || self.numberOfRefreshTokens <= numberOfSuccessfulRefreshes {
+                if shouldNotFail || self.numberOfRefreshTokens >= numberOfSuccessfulRefreshes {
                     print("Demo App Token Refreshing: New token generated successfully.")
                     let newToken = generatedToken ?? initialToken
                     completion(.success(newToken))

--- a/DemoApp/StreamChat/Components/Banner/BannerShowingConnectionDelegate.swift
+++ b/DemoApp/StreamChat/Components/Banner/BannerShowingConnectionDelegate.swift
@@ -29,11 +29,14 @@ extension BannerShowingConnectionDelegate: ChatConnectionControllerDelegate {
             bannerView.update(text: "Disconnected")
             showBanner()
         case .connected:
+            bannerView.update(text: "Connected")
             hideBanner()
         case .disconnecting:
             bannerView.update(text: "Disconnecting...")
+            showBanner()
         case .connecting:
             bannerView.update(text: "Connecting...")
+            showBanner()
         case .initialized:
             break
         }
@@ -45,7 +48,7 @@ extension BannerShowingConnectionDelegate: ChatConnectionControllerDelegate {
 private extension BannerShowingConnectionDelegate {
     func setupViews() {
         attachToTopViewIfNeeded()
-        bannerView.alpha = 0
+        bannerView.alpha = 1
         bannerView.update(text: "Connecting...")
     }
 

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -62,7 +62,9 @@ final class DemoChatChannelListVC: ChatChannelListVC {
 
         initialQuery = controller.query
 
-        connectionController.delegate = connectionDelegate
+        if AppConfig.shared.demoAppConfig.shouldShowConnectionBanner {
+            connectionController.delegate = connectionDelegate
+        }
 
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(customView: filterChannelsButton),


### PR DESCRIPTION
### 🔗 Issue Links
Related to https://stream-io.atlassian.net/browse/PBE-4780

### 🎯 Goal

Fixes the issues found in the Demo App from this [PR](https://github.com/GetStream/stream-chat-swift/pull/3303).

It is important to fix them in a separate PR, so that we can compare the new fixes vs the old implementation. Since showing the connection banner helps us understand the connecting state transitions.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
