### PR TITLE
Revert waiting for delegates in unstable polls tests

### DIFF
--- a/Tests/StreamChatTests/Controllers/PollsControllers/PollVoteListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/PollsControllers/PollVoteListController_Tests.swift
@@ -148,7 +148,6 @@ final class PollVoteListController_Tests: XCTestCase {
         try client.databaseContainer.writeSynchronously { session in
             try session.savePollVotes(payload: response, query: query, cache: nil)
         }
-        waitForDelegateCallback()
 
         XCTAssertEqual(controller.votes.count, votes.count)
     }
@@ -208,22 +207,5 @@ final class PollVoteListController_Tests: XCTestCase {
 
         wait(for: [exp], timeout: defaultTimeout)
         XCTAssertTrue(controller.hasLoadedAllVotes)
-    }
-    
-    // MARK: -
-    
-    func waitForDelegateCallback() {
-        let delegate = DelegateWaiter()
-        controller.delegate = delegate
-        wait(for: [delegate.didChangeVotesExpectation], timeout: defaultTimeout)
-        controller.delegate = nil
-    }
-    
-    private class DelegateWaiter: PollVoteListControllerDelegate {
-        let didChangeVotesExpectation = XCTestExpectation(description: "DidChangeVotes")
-        
-        func controller(_ controller: StreamChat.PollVoteListController, didChangeVotes changes: [StreamChat.ListChange<StreamChat.PollVote>]) {
-            didChangeVotesExpectation.fulfill()
-        }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

DB observer supports for immediate DB reads now. Therefore, the more fragile path of waiting for delegate can be removed. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
