### PR TITLE
Fix a rare issue with incorrect message order when sending messages offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix a rare issue with incorrect message order when sending multiple messages while offline [#3316](https://github.com/GetStream/stream-chat-swift/issues/3316)
 
 # [4.60.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.60.0)
 _July 18, 2024_

--- a/Sources/StreamChat/Database/DTOs/QueuedRequestDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/QueuedRequestDTO.swift
@@ -39,6 +39,10 @@ class QueuedRequestDTO: NSManagedObject {
 }
 
 extension NSManagedObjectContext: QueuedRequestDatabaseSession {
+    func allQueuedRequests() -> [QueuedRequestDTO] {
+        QueuedRequestDTO.loadAllPendingRequests(context: self)
+    }
+    
     func deleteQueuedRequest(id: String) {
         guard let request = QueuedRequestDTO.load(id: id, context: self) else { return }
         delete(request)

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -393,6 +393,7 @@ protocol AttachmentDatabaseSession {
 }
 
 protocol QueuedRequestDatabaseSession {
+    func allQueuedRequests() -> [QueuedRequestDTO]
     func deleteQueuedRequest(id: String)
 }
 

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -88,6 +88,47 @@ class MessageRepository {
             })
         }
     }
+    
+    /// Marks the message's local status to failed and adds it to the offline retry which sends the message when connection comes back.
+    func scheduleOfflineRetry(for messageId: MessageId, completion: @escaping (Result<ChatMessage, MessageRepositoryError>) -> Void) {
+        var dataEndpoint: DataEndpoint!
+        var messageModel: ChatMessage!
+        database.write { session in
+            guard let dto = session.message(id: messageId) else {
+                throw MessageRepositoryError.messageDoesNotExist
+            }
+            guard let channelDTO = dto.channel, let cid = try? ChannelId(cid: channelDTO.cid) else {
+                throw MessageRepositoryError.messageDoesNotHaveValidChannel
+            }
+            
+            // Send the message to offline handling
+            let requestBody = dto.asRequestBody() as MessageRequestBody
+            let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(
+                cid: cid,
+                messagePayload: requestBody,
+                skipPush: dto.skipPush,
+                skipEnrichUrl: dto.skipEnrichUrl
+            )
+            dataEndpoint = endpoint.withDataResponse
+            
+            // Mark it as failed
+            dto.localMessageState = .sendingFailed
+            messageModel = try dto.asModel()
+        } completion: { [weak self] writeError in
+            if let writeError {
+                switch writeError {
+                case let repositoryError as MessageRepositoryError:
+                    completion(.failure(repositoryError))
+                default:
+                    completion(.failure(.failedToSendMessage(writeError)))
+                }
+                return
+            }
+            // Offline repository will send it when connection comes back on, until then we show the message as failed
+            self?.apiClient.queueOfflineRequest?(dataEndpoint.withDataResponse)
+            completion(.success(messageModel))
+        }
+    }
 
     func saveSuccessfullySentMessage(
         cid: ChannelId,
@@ -126,11 +167,12 @@ class MessageRepository {
             // error code for duplicated messages.
             let isDuplicatedMessageError = errorPayload.code == 4 && errorPayload.message.contains("already exists")
             if isDuplicatedMessageError {
-                database.write {
+                database.write({
                     let messageDTO = $0.message(id: messageId)
                     messageDTO?.markMessageAsSent()
+                }, completion: { _ in
                     completion(.failure(.failedToSendMessage(error)))
-                }
+                })
                 return
             }
         }

--- a/Sources/StreamChat/Repositories/OfflineRequestsRepository.swift
+++ b/Sources/StreamChat/Repositories/OfflineRequestsRepository.swift
@@ -2,6 +2,7 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 import Foundation
 
 typealias QueueOfflineRequestBlock = (DataEndpoint) -> Void
@@ -51,24 +52,101 @@ class OfflineRequestsRepository {
     /// - If the request fails with a connection error -> The request is kept to be executed once the connection is back (we are not putting it back at the queue to make sure we respect the order)
     /// - If the request fails with any other error -> We are dismissing the request, and removing it from the queue
     func runQueuedRequests(completion: @escaping () -> Void) {
-        let readContext = database.backgroundReadOnlyContext
-        readContext.perform { [weak self] in
-            let requests = QueuedRequestDTO.loadAllPendingRequests(context: readContext).map {
-                ($0.id, $0.endpoint, $0.date as Date)
+        database.read { session in
+            let dtos = session.allQueuedRequests()
+            var requests = [Request]()
+            requests.reserveCapacity(dtos.count)
+            var requestIdsToDelete = Set<String>()
+            let currentDate = Date()
+            
+            for dto in dtos {
+                let id = dto.id
+                let endpointData = dto.endpoint
+                let date = dto.date.bridgeDate
+                
+                // Is valid
+                guard let endpoint = try? JSONDecoder.stream.decode(DataEndpoint.self, from: endpointData) else {
+                    log.error("Could not decode queued request \(id)", subsystems: .offlineSupport)
+                    requestIdsToDelete.insert(dto.id)
+                    continue
+                }
+                
+                // Is expired
+                let hoursQueued = currentDate.timeIntervalSince(date) / Constants.secondsInHour
+                let shouldBeDiscarded = hoursQueued > Double(self.maxHoursThreshold)
+                guard endpoint.shouldBeQueuedOffline && !shouldBeDiscarded else {
+                    log.error("Queued request for /\(endpoint.path.value) should not be queued", subsystems: .offlineSupport)
+                    requestIdsToDelete.insert(dto.id)
+                    continue
+                }
+                requests.append(Request(id: id, date: date, endpoint: endpoint))
             }
-            DispatchQueue.main.async {
-                self?.executeRequests(requests, completion: completion)
+            
+            // Out of valid requests, merge send message requests for the same id
+            let sendMessageIdGroups = Dictionary(grouping: requests, by: { $0.sendMessageId })
+            var mergedRequests = [Request]()
+            mergedRequests.reserveCapacity(requests.count)
+            for request in requests {
+                if let sendMessageId = request.sendMessageId {
+                    // Is it already merged into another
+                    if requestIdsToDelete.contains(request.id) {
+                        continue
+                    }
+                    if let duplicates = sendMessageIdGroups[sendMessageId], duplicates.count >= 2 {
+                        // Coalesce send message requests12 in a way that we use the latest endpoint data
+                        // because the message could have changed when there was a manual retry
+                        let sortedDuplicates = duplicates.sorted(by: { $0.date < $1.date })
+                        let earliest = sortedDuplicates.first!
+                        let latest = sortedDuplicates.last!
+                        mergedRequests.append(Request(id: earliest.id, date: earliest.date, endpoint: latest.endpoint))
+                        // All the others should be deleted
+                        requestIdsToDelete.formUnion(duplicates.dropFirst().map(\.id))
+                    } else {
+                        mergedRequests.append(request)
+                    }
+                } else {
+                    mergedRequests.append(request)
+                }
+            }
+            return (requests: mergedRequests, deleteIds: requestIdsToDelete)
+        } completion: { [weak self] result in
+            switch result {
+            case .success(let pair):
+                self?.deleteRequests(with: pair.deleteIds, completion: {
+                    self?.retryQueue.async {
+                        self?.executeRequests(pair.requests, completion: completion)
+                    }
+                })
+            case .failure(let error):
+                log.error("Failed to read queued requests with error \(error.localizedDescription)", subsystems: .offlineSupport)
+                completion()
             }
         }
     }
-
-    private func executeRequests(_ requests: [(String, Data, Date)], completion: @escaping () -> Void) {
+    
+    private func deleteRequests(with ids: Set<String>, completion: @escaping () -> Void) {
+        guard !ids.isEmpty else {
+            completion()
+            return
+        }
+        database.write { session in
+            for id in ids {
+                session.deleteQueuedRequest(id: id)
+            }
+        } completion: { _ in
+            completion()
+        }
+    }
+    
+    private func executeRequests(_ requests: [Request], completion: @escaping () -> Void) {
         log.info("\(requests.count) pending offline requests", subsystems: .offlineSupport)
 
         let database = self.database
-        let currentDate = Date()
         let group = DispatchGroup()
-        for (id, endpoint, date) in requests {
+        for request in requests {
+            let id = request.id
+            let endpoint = request.endpoint
+            
             group.enter()
             let leave = {
                 group.leave()
@@ -77,21 +155,6 @@ class OfflineRequestsRepository {
                 database.write({ session in
                     session.deleteQueuedRequest(id: id)
                 }, completion: { _ in leave() })
-            }
-
-            guard let endpoint = try? JSONDecoder.stream.decode(DataEndpoint.self, from: endpoint) else {
-                log.error("Could not decode queued request \(id)", subsystems: .offlineSupport)
-                deleteQueuedRequestAndComplete()
-                continue
-            }
-            
-            let hoursQueued = currentDate.timeIntervalSince(date) / Constants.secondsInHour
-            let shouldBeDiscarded = hoursQueued > Double(maxHoursThreshold)
-
-            guard endpoint.shouldBeQueuedOffline && !shouldBeDiscarded else {
-                log.error("Queued request for /\(endpoint.path.value) should not be queued", subsystems: .offlineSupport)
-                deleteQueuedRequestAndComplete()
-                continue
             }
 
             log.info("Executing queued offline request for /\(endpoint.path)", subsystems: .offlineSupport)
@@ -177,8 +240,36 @@ class OfflineRequestsRepository {
             database.write { _ in
                 QueuedRequestDTO.createRequest(date: date, endpoint: data, context: database.writableContext)
                 log.info("Queued request for /\(endpoint.path)", subsystems: .offlineSupport)
+            } completion: { _ in
                 completion?()
             }
+        }
+    }
+}
+
+private extension OfflineRequestsRepository {
+    struct Request {
+        let id: String
+        let date: Date
+        let endpoint: DataEndpoint
+        let sendMessageId: MessageId?
+     
+        init(id: String, date: Date, endpoint: DataEndpoint) {
+            self.id = id
+            self.date = date
+            self.endpoint = endpoint
+            
+            sendMessageId = {
+                switch endpoint.path {
+                case .sendMessage:
+                    guard let bodyData = endpoint.body as? Data else { return nil }
+                    guard let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] else { return nil }
+                    guard let message = json["message"] as? [String: Any] else { return nil }
+                    return message["id"] as? String
+                default:
+                    return nil
+                }
+            }()
         }
     }
 }

--- a/Sources/StreamChat/Repositories/OfflineRequestsRepository.swift
+++ b/Sources/StreamChat/Repositories/OfflineRequestsRepository.swift
@@ -93,7 +93,7 @@ class OfflineRequestsRepository {
                         continue
                     }
                     if let duplicates = sendMessageIdGroups[sendMessageId], duplicates.count >= 2 {
-                        // Coalesce send message requests12 in a way that we use the latest endpoint data
+                        // Coalesce send message requests in a way that we use the latest endpoint data
                         // because the message could have changed when there was a manual retry
                         let sortedDuplicates = duplicates.sorted(by: { $0.date < $1.date })
                         let earliest = sortedDuplicates.first!
@@ -108,6 +108,7 @@ class OfflineRequestsRepository {
                     mergedRequests.append(request)
                 }
             }
+            log.info("\(mergedRequests.count) pending offline requests (coalesced = \(requests.count - mergedRequests.count)", subsystems: .offlineSupport)
             return (requests: mergedRequests, deleteIds: requestIdsToDelete)
         } completion: { [weak self] result in
             switch result {
@@ -139,8 +140,6 @@ class OfflineRequestsRepository {
     }
     
     private func executeRequests(_ requests: [Request], completion: @escaping () -> Void) {
-        log.info("\(requests.count) pending offline requests", subsystems: .offlineSupport)
-
         let database = self.database
         let group = DispatchGroup()
         for request in requests {

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -132,6 +132,11 @@ class SyncRepository {
         // Enter recovery mode so no other requests are triggered.
         apiClient.enterRecoveryMode()
 
+        // Run offline actions requests as the first thing
+        if config.isLocalStorageEnabled {
+            operations.append(ExecutePendingOfflineActions(offlineRequestsRepository: offlineRequestsRepository))
+        }
+        
         // Get the existing channelIds
         let activeChannelIds = activeChannelControllers.allObjects.compactMap(\.cid)
         operations.append(GetChannelIdsOperation(database: database, context: context, activeChannelIds: activeChannelIds))
@@ -175,11 +180,6 @@ class SyncRepository {
 
         // 4. Clean up unwanted channels
         operations.append(DeleteUnwantedChannelsOperation(database: database, context: context))
-
-        // 5. Run offline actions requests
-        if config.isLocalStorageEnabled {
-            operations.append(ExecutePendingOfflineActions(offlineRequestsRepository: offlineRequestsRepository))
-        }
 
         operations.append(BlockOperation(block: { [weak self] in
             log.info("Finished recovering offline state", subsystems: .offlineSupport)

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -1418,20 +1418,3 @@ extension Chat {
         ) -> TypingEventsSender = TypingEventsSender.init
     }
 }
-
-// MARK: - Chat Client
-
-private extension ChatClient {
-    func backgroundWorker<T>(of type: T.Type) throws -> T {
-        if let worker = backgroundWorkers.compactMap({ $0 as? T }).first {
-            return worker
-        }
-        if currentUserId == nil {
-            throw ClientError.CurrentUserDoesNotExist()
-        }
-        if !config.isClientInActiveMode {
-            throw ClientError.ClientIsNotInActiveMode()
-        }
-        throw ClientError("Background worker of type \(T.self) is not set up")
-    }
-}

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -116,7 +116,7 @@ class MessageSender: Worker {
     }
     
     func didUpdateConnectionState(_ state: WebSocketConnectionState) {
-        guard case WebSocketConnectionState.connected = state else { return }
+        guard state.isConnected else { return }
         sendingDispatchQueue.async { [weak self] in
             self?.sendingQueueByCid.forEach { _, messageQueue in
                 messageQueue.webSocketConnected()

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -238,19 +238,11 @@ private class MessageSendingQueue {
                     // We hit a connection error, therefore all the remaining and upcoming requests should be scheduled for keeping the order
                     isWaitingForConnection = true
                     log.debug("Message sender started waiting for connection and forwarding messages to offline requests queue")
-                    messageRepository.scheduleOfflineRetry(for: request.messageId) { [weak self] _ in
-                        // Handle remaining messages
-                        self?.sendNextMessage()
-                    }
                 }
             }
         }
-        
         delegate?.messageSendingQueue(self, didProcess: request.messageId, result: result)
-        
-        if !isWaitingForConnection {
-            sendNextMessage()
-        }
+        sendNextMessage()
     }
 }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -360,6 +360,10 @@ class DatabaseSession_Mock: DatabaseSession {
     func saveQuery(query: MessageSearchQuery) -> MessageSearchQueryDTO {
         underlyingSession.saveQuery(query: query)
     }
+    
+    func allQueuedRequests() -> [QueuedRequestDTO] {
+        underlyingSession.allQueuedRequests()
+    }
 
     func deleteQueuedRequest(id: String) {
         underlyingSession.deleteQueuedRequest(id: id)

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -23,6 +23,7 @@ final class APIClient_Spy: APIClient, Spy {
     /// The last endpoint `recoveryRequest` function was called with.
     @Atomic var recoveryRequest_endpoint: AnyEndpoint?
     @Atomic var recoveryRequest_completion: Any?
+    @Atomic var recoveryRequest_results: [Any] = []
     @Atomic var recoveryRequest_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
 
     /// The last endpoint `unmanagedRequest` function was called with.
@@ -53,6 +54,7 @@ final class APIClient_Spy: APIClient, Spy {
         request_completion = nil
         request_results = []
         request_expectation = .init()
+        recoveryRequest_results = []
         recoveryRequest_expectation = .init()
         uploadRequest_expectation = .init()
 
@@ -104,6 +106,10 @@ final class APIClient_Spy: APIClient, Spy {
     func test_mockResponseResult<Response: Decodable>(_ responseResult: Result<Response, Error>) {
         request_results.append(responseResult)
     }
+    
+    func test_mockRecoveryResponseResult<Response: Decodable>(_ responseResult: Result<Response, Error>) {
+        recoveryRequest_results.append(responseResult)
+    }
 
     func test_mockUnmanagedResponseResult<Response: Decodable>(_ responseResult: Result<Response, Error>) {
         unmanagedRequest_result = responseResult
@@ -129,6 +135,10 @@ final class APIClient_Spy: APIClient, Spy {
         completion: @escaping (Result<Response, Error>) -> Void
     ) where Response: Decodable {
         recoveryRequest_endpoint = AnyEndpoint(endpoint)
+        if let resultIndex = recoveryRequest_results.firstIndex(where: { $0 is Result<Response, Error> }) {
+            let result = recoveryRequest_results.remove(at: resultIndex)
+            completion(result as! Result<Response, Error>)
+        }
         recoveryRequest_completion = completion
         _recoveryRequest_allRecordedCalls.mutate { $0.append((recoveryRequest_endpoint!, recoveryRequest_completion!)) }
     }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -166,6 +166,7 @@ final class APIClient_Spy: APIClient, Spy {
     @discardableResult
     func waitForRequest(timeout: Double = defaultTimeout) -> AnyEndpoint? {
         XCTWaiter().wait(for: [request_expectation], timeout: timeout)
+        request_expectation = XCTestExpectation()
         return request_endpoint
     }
 

--- a/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
@@ -439,6 +439,9 @@ final class MessageSender_Tests: XCTestCase {
         apiClient.waitForRequest()
         try resumeAPIRequestAndWaitForLocalStateChange(messageId: "2", success: false)
         
+        // We use mocked API client which does not do the automatic forwarding, therefore we simulate it here
+        apiClient.queueOfflineRequest?(DataEndpoint(path: .sendMessage(cid), method: .post))
+        
         // Since connection error was received, all the remaining queued messages are sent directly to offline repository
         wait(for: [offlineQueuingExpectation], timeout: defaultTimeout)
         

--- a/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
@@ -404,6 +404,53 @@ final class MessageSender_Tests: XCTestCase {
         AssertAsync.willBeTrue(eventsNotificationCenter.mock_processCalledWithEvents.first is NewMessageErrorEvent)
         XCTAssertCall("sendMessage(with:completion:)", on: messageRepository, times: 1)
     }
+    
+    func test_senderSendsMessages_forwardsPendingMessagesToOfflineHandlingOnConnectionError() throws {
+        // Sender with non-mock message repository
+        let nonMockMessageRepository = MessageRepository(database: database, apiClient: apiClient)
+        sender = MessageSender(
+            messageRepository: nonMockMessageRepository,
+            eventsNotificationCenter: eventsNotificationCenter,
+            database: database,
+            apiClient: apiClient
+        )
+        var queueOfflineRequestCounter = 0
+        let offlineQueuingExpectation = XCTestExpectation(description: "2, 3, 4, 5 queued")
+        apiClient.queueOfflineRequest = { _ in
+            queueOfflineRequestCounter += 1
+            guard queueOfflineRequestCounter == 4 else { return }
+            offlineQueuingExpectation.fulfill()
+        }
+        
+        // At the end of test all 5 are expected to finish successfully
+        let messageIds = (1...5).map { "\($0)" }
+        
+        try database.writeSynchronously { session in
+            for id in messageIds {
+                try self.createMessage(id: id, in: session)
+            }
+        }
+        
+        // First: success
+        apiClient.waitForRequest()
+        try resumeAPIRequestAndWaitForLocalStateChange(messageId: "1", success: true)
+        
+        // Second: connection error
+        apiClient.waitForRequest()
+        try resumeAPIRequestAndWaitForLocalStateChange(messageId: "2", success: false)
+        
+        // Since connection error was received, all the remaining queued messages are sent directly to offline repository
+        wait(for: [offlineQueuingExpectation], timeout: defaultTimeout)
+        
+        // Verify states (one successful, others failing)
+        try database.readSynchronously { session in
+            let localMessageStates = messageIds.map { session.message(id: $0)?.localMessageState }
+            let expected: [LocalMessageState?] = [nil, .sendingFailed, .sendingFailed, .sendingFailed, .sendingFailed]
+            XCTAssertEqual(expected, localMessageStates)
+        }
+        
+        // Offline repository is now responsible of sending the requests
+    }
 
     // MARK: - Life cycle tests
 
@@ -455,6 +502,38 @@ final class MessageSender_Tests: XCTestCase {
 
         // Then
         wait(for: [sessionMock.rescueMessagesExpectation], timeout: defaultTimeout)
+    }
+    
+    // MARK: -
+    
+    @discardableResult func createMessage(id: MessageId, in session: DatabaseSession) throws -> MessageId {
+        let dto = try session.createNewMessage(
+            in: cid,
+            messageId: id,
+            text: "\(id)",
+            pinning: nil,
+            quotedMessageId: nil,
+            skipPush: false,
+            skipEnrichUrl: false
+        )
+        dto.localMessageState = .pendingSend
+        return dto.id
+    }
+    
+    private func resumeAPIRequestAndWaitForLocalStateChange(messageId: MessageId, success: Bool) throws {
+        let localStateExpectation = XCTestExpectation(description: "\(messageId) - local state change")
+        database.didWrite = {
+            // Extra delay for allowing MessageSender to run the MessageRepository's completion
+            DispatchQueue.main.async {
+                localStateExpectation.fulfill()
+            }
+        }
+        if success {
+            apiClient.test_simulateResponse(.success(MessagePayload.Boxed(message: .dummy(messageId: messageId, text: "processed", cid: cid))))
+        } else {
+            apiClient.test_simulateResponse(Result<MessagePayload.Boxed, Error>.failure(NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost)))
+        }
+        wait(for: [localStateExpectation], timeout: defaultTimeout)
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-4319](https://stream-io.atlassian.net/browse/PBE-4319)

### 🎯 Goal

Fix the issue of incorrect order of messages when multiple messages are in the pending send state and connection comes back.

### 📝 Summary

- Forward queued messages to `OfflineRequestsRepository` for retrying on the next web-socket connect event (otherwise we have a race between it and `MessageSender`). Message statuses are set to `.sendingFailed`.
- When `MessageSender` is waiting for connection, it sends all the requests to the offline repository until it is notified connection status change (ensures that `MessageSender` and `OfflineRequestsRepository` are not sending messages for the came channel at the same time).
- `OfflineRequestsRepository` removes duplicate send message requests (in case or manual retries while offline)

### 🛠 Implementation

`APIClient` sends failed API requests to `SyncRepository` [here](https://github.com/GetStream/stream-chat-swift/blob/8a9d94f7ed7b9b25577a9f181c4ab881bc64fbc2/Sources/StreamChat/APIClient/APIClient.swift#L171). This will then be passed to `OfflineRequestsRepository` which uses the [shouldBeQueuedOffline for deciding if it should retry](https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/Repositories/OfflineRequestsRepository.swift#L164) the failed request.
When this happens, we have `MessageSender` and `OfflineRequestsRepository` both trying to send messages on connect. This PR eliminates this race and makes `OfflineRequestsRepository` to be solely responsible of sending messages when connection status changes. When we have connected, `MessageSender` is allowed to send messages again if user does so. But all the previous ones, are handled by `OfflineRequestsRepository`.

### 🎨 Showcase

Recorded from the point where the first request has failed with a connection issue.

| Before | After |
| ------ | ----- |
|  ![img](https://github.com/user-attachments/assets/ffea68ba-5751-431a-ad92-4759a50b88f8)   |  ![img](https://github.com/user-attachments/assets/cca8c2f2-7464-49a3-bf78-0efbba025686)  |

### 🧪 Manual Testing Notes

#### Test case 1:
1. Log in and open a channel
2. Network link conditioner to 100% loss
3. Send 5 messages
4. Wait until the failure happens (takes a while, but all 5 will get failure badge) 
5. Manually trigger retries for failed messages
6. Turn off network link conditioner in settings (I set it back to Wi-Fi, reconnection takes a bit of time as well)
7. Observe the message list > messages are sent one by one and keep the order and there is no duplicate message error in the console
8. Send some new messages > messages are sent

#### Test case 2
1. Log in and open a channel
2. Network link conditioner to 100% loss
3. Send 5 messages
4. Wait until the failure happens (takes a while, but all 5 will get failure badge) 
5. Turn off network link conditioner in settings (I set it back to Wi-Fi, reconnection takes a bit of time as well)
6. Immediately try to send some more messages

Messages are sent one by one. Currently order changes because server gives updated timestamps. Can be improved if we would like to, but I did not want to include more changes to this PR. Solution would be to update local timestamps after each message send.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-4319]: https://stream-io.atlassian.net/browse/PBE-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ