### PR TITLE
Fix channel search view by refreshing the view state in both delegates

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
@@ -100,8 +100,8 @@ open class ChatChannelListSearchVC: ChatChannelListVC, UISearchResultsUpdating {
 
     // MARK: - State Handling
 
-    override open func controller(_ controller: DataController, didChangeState state: DataController.State) {
-        switch state {
+    override open func handleStateChanges(_ newState: DataController.State) {
+        switch newState {
         case .initialized, .localDataFetched:
             if hasEmptyResults {
                 loadingIndicator.startAnimating()


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

Empty results view was shown for channel search (only the first time for search term X)

### 📝 Summary

- Update view state when state and channel delegate is called.

### 🛠 Implementation

Delegate call order changed in [PR:3305](https://github.com/GetStream/stream-chat-swift/pull/3305). Search view only updated empty view state when state delegate was called. ChatChannelListView on the other hand does this when channels and state change. The fix is to do the same in the search view.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

1. Log out and log in (clears local state) (also set search to search for channels)
2. Search for "Re" > results appear

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
