### PR TITLE
Improve performance of ChatChannel and ChatMessage equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ⚡ Performance
+- Improve performance of `ChatChannel` and `ChatMessage` equality checks [#3335](https://github.com/GetStream/stream-chat-swift/pull/3335)
 ### ✅ Added
 - Expose `MissingConnectionId` + `InvalidURL` + `InvalidJSON` Errors [#3332](https://github.com/GetStream/stream-chat-swift/pull/3332)
 

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -237,27 +237,28 @@ extension ChatChannel: AnyChannel {}
 
 extension ChatChannel: Hashable {
     public static func == (lhs: ChatChannel, rhs: ChatChannel) -> Bool {
-        lhs.cid == rhs.cid &&
-            lhs.updatedAt == rhs.updatedAt &&
-            lhs.cooldownDuration == rhs.cooldownDuration &&
-            lhs.createdAt == rhs.createdAt &&
-            lhs.createdBy == rhs.createdBy &&
-            lhs.deletedAt == rhs.deletedAt &&
-            lhs.extraData == rhs.extraData &&
-            lhs.imageURL == rhs.imageURL &&
-            lhs.isFrozen == rhs.isFrozen &&
-            lhs.isHidden == rhs.isHidden &&
-            lhs.lastMessageAt == rhs.lastMessageAt &&
-            lhs.memberCount == rhs.memberCount &&
-            lhs.membership == rhs.membership &&
-            lhs.muteDetails == rhs.muteDetails &&
-            lhs.name == rhs.name &&
-            lhs.ownCapabilities == rhs.ownCapabilities &&
-            lhs.previewMessage == rhs.previewMessage &&
-            lhs.reads == rhs.reads &&
-            lhs.team == rhs.team &&
-            lhs.truncatedAt == rhs.truncatedAt &&
-            lhs.watcherCount == rhs.watcherCount
+        guard lhs.cid == rhs.cid else { return false }
+        guard lhs.updatedAt == rhs.updatedAt else { return false }
+        guard lhs.lastMessageAt == rhs.lastMessageAt else { return false }
+        guard lhs.muteDetails == rhs.muteDetails else { return false }
+        guard lhs.reads == rhs.reads else { return false }
+        guard lhs.previewMessage == rhs.previewMessage else { return false }
+        guard lhs.name == rhs.name else { return false }
+        guard lhs.watcherCount == rhs.watcherCount else { return false }
+        guard lhs.createdAt == rhs.createdAt else { return false }
+        guard lhs.cooldownDuration == rhs.cooldownDuration else { return false }
+        guard lhs.createdBy == rhs.createdBy else { return false }
+        guard lhs.deletedAt == rhs.deletedAt else { return false }
+        guard lhs.extraData == rhs.extraData else { return false }
+        guard lhs.imageURL == rhs.imageURL else { return false }
+        guard lhs.isFrozen == rhs.isFrozen else { return false }
+        guard lhs.isHidden == rhs.isHidden else { return false }
+        guard lhs.memberCount == rhs.memberCount else { return false }
+        guard lhs.membership == rhs.membership else { return false }
+        guard lhs.team == rhs.team else { return false }
+        guard lhs.truncatedAt == rhs.truncatedAt else { return false }
+        guard lhs.ownCapabilities == rhs.ownCapabilities else { return false }
+        return true
     }
 
     public func hash(into hasher: inout Hasher) {

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -359,29 +359,30 @@ public extension ChatMessage {
 
 extension ChatMessage: Hashable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id &&
-            lhs.updatedAt == rhs.updatedAt &&
-            lhs.allAttachments == rhs.allAttachments &&
-            lhs.arguments == rhs.arguments &&
-            lhs.author == rhs.author &&
-            lhs.command == rhs.command &&
-            lhs.currentUserReactionsCount == rhs.currentUserReactionsCount &&
-            lhs.extraData == rhs.extraData &&
-            lhs.isFlaggedByCurrentUser == rhs.isFlaggedByCurrentUser &&
-            lhs.isShadowed == rhs.isShadowed &&
-            lhs.localState == rhs.localState &&
-            lhs.parentMessageId == rhs.parentMessageId &&
-            lhs.quotedMessage == rhs.quotedMessage &&
-            lhs.reactionCounts == rhs.reactionCounts &&
-            lhs.reactionGroups == rhs.reactionGroups &&
-            lhs.reactionScores == rhs.reactionScores &&
-            lhs.readByCount == rhs.readByCount &&
-            lhs.replyCount == rhs.replyCount &&
-            lhs.showReplyInChannel == rhs.showReplyInChannel &&
-            lhs.text == rhs.text &&
-            lhs.threadParticipantsCount == rhs.threadParticipantsCount &&
-            lhs.translations == rhs.translations &&
-            lhs.type == rhs.type
+        guard lhs.id == rhs.id else { return false }
+        guard lhs.localState == rhs.localState else { return false }
+        guard lhs.updatedAt == rhs.updatedAt else { return false }
+        guard lhs.allAttachments == rhs.allAttachments else { return false }
+        guard lhs.author == rhs.author else { return false }
+        guard lhs.currentUserReactionsCount == rhs.currentUserReactionsCount else { return false }
+        guard lhs.text == rhs.text else { return false }
+        guard lhs.parentMessageId == rhs.parentMessageId else { return false }
+        guard lhs.reactionCounts == rhs.reactionCounts else { return false }
+        guard lhs.reactionGroups == rhs.reactionGroups else { return false }
+        guard lhs.reactionScores == rhs.reactionScores else { return false }
+        guard lhs.readByCount == rhs.readByCount else { return false }
+        guard lhs.replyCount == rhs.replyCount else { return false }
+        guard lhs.showReplyInChannel == rhs.showReplyInChannel else { return false }
+        guard lhs.threadParticipantsCount == rhs.threadParticipantsCount else { return false }
+        guard lhs.arguments == rhs.arguments else { return false }
+        guard lhs.command == rhs.command else { return false }
+        guard lhs.extraData == rhs.extraData else { return false }
+        guard lhs.isFlaggedByCurrentUser == rhs.isFlaggedByCurrentUser else { return false }
+        guard lhs.isShadowed == rhs.isShadowed else { return false }
+        guard lhs.quotedMessage == rhs.quotedMessage else { return false }
+        guard lhs.translations == rhs.translations else { return false }
+        guard lhs.type == rhs.type else { return false }
+        return true
     }
 
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
### 🔗 Issue Links

Related to [PBE-5004](https://stream-io.atlassian.net/browse/PBE-5004)

### 🎯 Goal

* Reduce message and channel copies when calling `==`

### 📝 Summary

Time profiler shows in the SwiftUI SDK that when doing `==` checks a lot of time is spent in making copies of messages and channels. Changing the `==` to use guard let takes away a lot of this overhead.

### 🎨 Showcase

LazyCachedMapCollection's `==` is reduced from 118 ms > 11 ms  **>10** times improvement 

| Before | After |
| ------ | ----- |
|  <img width="951" alt="Before" src="https://github.com/user-attachments/assets/68f65b42-04e3-48c8-a3de-c5e9fb48cdcd">   |  <img width="770" alt="After" src="https://github.com/user-attachments/assets/ad687756-a11a-46a0-a57d-bcf1c5a634ee">  |

### 🧪 Manual Testing Notes

None

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5004]: https://stream-io.atlassian.net/browse/PBE-5004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ