### PR TITLE
Unstable test_databaseContainer_removesAllData_whenShouldFlushOnStartIsTrue test

### DIFF
--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -265,6 +265,7 @@ final class DatabaseContainer_Tests: XCTestCase {
             modelName: "TestDataModel",
             bundle: .testTools
         )
+        database?.shouldCleanUpTempDBFiles = false
 
         // Insert a new object
         try database!.writeSynchronously {


### PR DESCRIPTION
### 🎯 Goal

* Fix test which had race between one instance deleting the local DB file and another instance reading it

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)