### PR TITLE
Add environment value for injecting logging level for development 

### DIFF
--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -14,7 +14,7 @@ extension StreamChatWrapper {
         }
 
         // Set the log level
-        LogConfig.level = .warning
+        LogConfig.level = StreamRuntimeCheck.logLevel ?? .warning
         LogConfig.formatters = [
             PrefixLogFormatter(prefixes: [.info: "ℹ️", .debug: "🛠", .warning: "⚠️", .error: "🚨"])
         ]

--- a/DemoApp/StreamRuntimeCheck+StreamInternal.swift
+++ b/DemoApp/StreamRuntimeCheck+StreamInternal.swift
@@ -9,4 +9,10 @@ extension StreamRuntimeCheck {
     static var isStreamInternalConfiguration: Bool {
         ProcessInfo.processInfo.environment["STREAM_DEV"] != nil
     }
+    
+    static var logLevel: LogLevel? {
+        guard let value = ProcessInfo.processInfo.environment["STREAM_LOG_LEVEL"] else { return nil }
+        guard let intValue = Int(value) else { return nil }
+        return LogLevel(rawValue: intValue)
+    }
 }


### PR DESCRIPTION

### 🎯 Goal

Quite often I would like to switch between logging levels and it is so much easier if I can use my development scheme for setting this value rather than making a code change which I can accidentally commit.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
