### PR TITLE
Add Channel List `.hasUnread` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve performance of `ChatChannel` and `ChatMessage` equality checks [#3335](https://github.com/GetStream/stream-chat-swift/pull/3335)
 ### ✅ Added
 - Expose `MissingConnectionId` + `InvalidURL` + `InvalidJSON` Errors [#3332](https://github.com/GetStream/stream-chat-swift/pull/3332)
-- Add `.hasUnread` filter key to `ChannelListQuery` [#3340](https://github.com/GetStream/stream-chat-swift/pull/3340)
+- Add support for `.hasUnread` filter key to `ChannelListQuery` [#3340](https://github.com/GetStream/stream-chat-swift/pull/3340)
 ### 🐞 Fixed
 - Fix a rare issue with incorrect message order when sending multiple messages while offline [#3316](https://github.com/GetStream/stream-chat-swift/issues/3316)
 - Fix sorting channel list by unread count [#3340](https://github.com/GetStream/stream-chat-swift/pull/3340)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve performance of `ChatChannel` and `ChatMessage` equality checks [#3335](https://github.com/GetStream/stream-chat-swift/pull/3335)
 ### ✅ Added
 - Expose `MissingConnectionId` + `InvalidURL` + `InvalidJSON` Errors [#3332](https://github.com/GetStream/stream-chat-swift/pull/3332)
+- Add `.hasUnread` filter key to `ChannelListQuery` [#3340](https://github.com/GetStream/stream-chat-swift/pull/3340)
+### 🐞 Fixed
+- Fix sorting channel list by unread count [#3340](https://github.com/GetStream/stream-chat-swift/pull/3340)
 
 # [4.60.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.60.0)
 _July 18, 2024_

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -44,7 +44,7 @@ final class DemoChatChannelListVC: ChatChannelListVC {
     lazy var unreadChannelsQuery: ChannelListQuery = .init(filter: .and([
         .containMembers(userIds: [currentUserId]),
         .hasUnread
-    ]))
+    ]), sort: [.init(key: .unreadCount, isAscending: false)])
 
     lazy var mutedChannelsQuery: ChannelListQuery = .init(filter: .and([
         .containMembers(userIds: [currentUserId]),

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -41,6 +41,11 @@ final class DemoChatChannelListVC: ChatChannelListVC {
         .equal(.hidden, to: true)
     ]))
 
+    lazy var unreadChannelsQuery: ChannelListQuery = .init(filter: .and([
+        .containMembers(userIds: [currentUserId]),
+        .hasUnread
+    ]))
+
     lazy var mutedChannelsQuery: ChannelListQuery = .init(filter: .and([
         .containMembers(userIds: [currentUserId]),
         .equal(.muted, to: true)
@@ -113,6 +118,15 @@ final class DemoChatChannelListVC: ChatChannelListVC {
             }
         )
 
+        let unreadChannelsAction = UIAlertAction(
+            title: "Unread Channels",
+            style: .default,
+            handler: { [weak self] _ in
+                self?.title = "Unread Channels"
+                self?.setUnreadChannelsQuery()
+            }
+        )
+
         let coolChannelsAction = UIAlertAction(
             title: "Cool Channels",
             style: .default,
@@ -133,7 +147,13 @@ final class DemoChatChannelListVC: ChatChannelListVC {
 
         presentAlert(
             title: "Filter Channels",
-            actions: [defaultChannelsAction, hiddenChannelsAction, mutedChannelsAction, coolChannelsAction],
+            actions: [
+                defaultChannelsAction,
+                unreadChannelsAction,
+                hiddenChannelsAction,
+                mutedChannelsAction,
+                coolChannelsAction
+            ],
             preferredStyle: .actionSheet,
             sourceView: filterChannelsButton
         )
@@ -141,6 +161,10 @@ final class DemoChatChannelListVC: ChatChannelListVC {
 
     func setHiddenChannelsQuery() {
         replaceQuery(hiddenChannelsQuery)
+    }
+
+    func setUnreadChannelsQuery() {
+        replaceQuery(unreadChannelsQuery)
     }
 
     func setMutedChannelsQuery() {

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -61,6 +61,7 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var messages: Set<MessageDTO>
     @NSManaged var pinnedMessages: Set<MessageDTO>
     @NSManaged var reads: Set<ChannelReadDTO>
+    @NSManaged var currentUserUnreadMessagesCount: Int32
     @NSManaged var watchers: Set<UserDTO>
     @NSManaged var memberListQueries: Set<ChannelMemberListQueryDTO>
     @NSManaged var previewMessage: MessageDTO?
@@ -73,6 +74,16 @@ class ChannelDTO: NSManagedObject {
 
         guard !isDeleted else {
             return
+        }
+
+        // Update the unreadMessagesCount for the current user.
+        // At the moment this computed property is used for `hasUnread` automatic channel list filtering.
+        if let currentUserId = managedObjectContext?.currentUser?.user.id {
+            let currentUserUnread = reads.first(where: { $0.user.id == currentUserId })
+            let newUnreadCount = currentUserUnread?.unreadMessageCount ?? 0
+            if newUnreadCount != currentUserUnreadMessagesCount {
+                currentUserUnreadMessagesCount = newUnreadCount
+            }
         }
 
         // Change to the `truncatedAt` value have effect on messages, we need to mark them dirty manually

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -37,6 +37,7 @@
         <attribute name="cid" attributeType="String"/>
         <attribute name="cooldownDuration" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="currentUserUnreadMessagesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="defaultSortingAt" attributeType="Date" usesScalarValueType="NO" spotlightIndexingEnabled="YES"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="extraData" attributeType="Binary"/>

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -25,6 +25,11 @@ public extension Filter where Scope: AnyChannelListFilterScope {
     static var noTeam: Filter<Scope> {
         .equal(.team, to: nil)
     }
+
+    /// Filter for fetching only the unread channels.
+    static var hasUnread: Filter<Scope> {
+        .equal(.hasUnread, to: true)
+    }
 }
 
 extension Filter where Scope: AnyChannelListFilterScope {
@@ -160,6 +165,28 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     /// Filter for the time of the last message in the channel. If the channel has no messages, then the time the channel was created.
     /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
     static var lastUpdatedAt: FilterKey<Scope, Date> { .init(rawValue: "last_updated", keyPathString: #keyPath(ChannelDTO.lastMessageAt)) }
+}
+
+/// Internal filter queries for the channel list.
+/// These ones are helpers that should be used by an higher-level filter.
+internal extension FilterKey where Scope: AnyChannelListFilterScope {
+    /// Filter for fetching only the unread channels.
+    /// Supported operators: `equal`, and only `true` is supported.
+    static var hasUnread: FilterKey<Scope, Bool> {
+        .init(
+            rawValue: "has_unread",
+            keyPathString: nil,
+            predicateMapper: { op, hasUnread in
+                let key = #keyPath(ChannelDTO.currentUserUnreadMessagesCount)
+                switch op {
+                case .equal:
+                    return NSPredicate(format: hasUnread ? "\(key) > 0" : "\(key) <= 0")
+                default:
+                    return nil
+                }
+            }
+        )
+    }
 }
 
 /// A query is used for querying specific channels from backend.

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -263,7 +263,7 @@ public struct FilterKey<Scope: FilterScope, Value: FilterValue>: ExpressibleBySt
 
     init(
         rawValue value: String,
-        keyPathString: String,
+        keyPathString: String?,
         valueMapper: TypedValueMapper? = nil,
         isCollectionFilter: Bool = false,
         predicateMapper: TypedPredicateMapper? = nil

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -49,8 +49,11 @@ public struct ChannelListSortingKey: SortingKey, Equatable {
         remoteKey: ChannelCodingKeys.cid.rawValue
     )
 
-    /// Sort channels by unread state. When using this sorting key, every unread channel weighs the same,
-    /// so they're sorted by `updatedAt`
+    /// Sort channels by unread state.
+    ///
+    /// When using this sorting key, every unread channel weighs the same, so they're sorted by `updatedAt`.
+    ///
+    /// **Note:** If you want to sort by number of unreads, you should use the `unreadCount` sorting key.
     public static let hasUnread = Self(
         keyPath: \.hasUnread,
         localKey: nil,
@@ -60,7 +63,7 @@ public struct ChannelListSortingKey: SortingKey, Equatable {
     /// Sort channels by their unread count.
     public static let unreadCount = Self(
         keyPath: \.unreadCount,
-        localKey: nil,
+        localKey: #keyPath(ChannelDTO.currentUserUnreadMessagesCount),
         remoteKey: "unread_count"
     )
 

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1020,53 +1020,6 @@ final class ChannelListController_Tests: XCTestCase {
 
     // MARK: Predicates
 
-    private func assertFilterPredicate(
-        _ filter: @autoclosure () -> Filter<ChannelListFilterScope>,
-        channelsInDB: @escaping @autoclosure () -> [ChannelPayload],
-        expectedResult: @autoclosure () -> [ChannelId],
-        file: StaticString = #file,
-        line: UInt = #line
-    ) throws {
-        /// Ensure that isChannelAutomaticFilteringEnabled is enabled
-        var config = ChatClientConfig(apiKeyString: .unique)
-        config.isChannelAutomaticFilteringEnabled = true
-        client = ChatClient.mock(config: config)
-
-        let query = ChannelListQuery(
-            filter: filter()
-        )
-        controller = ChatChannelListController(
-            query: query,
-            client: client,
-            environment: env.environment
-        )
-        controllerCallbackQueueID = UUID()
-        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
-
-        // Simulate `synchronize` call
-        controller.synchronize()
-        waitForInitialChannelsUpdate()
-
-        XCTAssertEqual(controller.channels.map(\.cid), [], file: file, line: line)
-
-        // Simulate changes in the DB:
-        _ = try waitFor {
-            writeAndWaitForChannelsUpdates({ [query] session in
-                try channelsInDB().forEach { payload in
-                    try session.saveChannel(payload: payload, query: query, cache: nil)
-                }
-            }, completion: $0)
-        }
-
-        // Assert the resulting value is updated
-        XCTAssertEqual(
-            controller.channels.map(\.cid.rawValue).sorted(),
-            expectedResult().map(\.rawValue).sorted(),
-            file: file,
-            line: line
-        )
-    }
-
     func test_filterPredicate_equal_containsExpectedItems() throws {
         let cid = ChannelId.unique
 
@@ -1598,6 +1551,52 @@ final class ChannelListController_Tests: XCTestCase {
         )
     }
 
+    func test_filterPredicate_hasUnread_returnsExpectedResults() throws {
+        let cid1 = ChannelId.unique
+        let cid2 = ChannelId.unique
+        let currentUserId = UserId.unique
+
+        try assertFilterPredicate(
+            .hasUnread,
+            currentUserId: currentUserId,
+            channelsInDB: [
+                .dummy(
+                    channel: .dummy(cid: cid1),
+                    channelReads: [
+                        .init(
+                            user: .dummy(userId: currentUserId),
+                            lastReadAt: .unique,
+                            lastReadMessageId: nil,
+                            unreadMessagesCount: 3
+                        )
+                    ]
+                ),
+                .dummy(channel: .dummy(team: .unique), channelReads: [
+                    .init(
+                        user: .dummy(userId: .unique),
+                        lastReadAt: .unique,
+                        lastReadMessageId: nil,
+                        unreadMessagesCount: 10
+                    )
+                ]),
+                .dummy(channel: .dummy(team: .unique)),
+                .dummy(channel: .dummy(team: .unique)),
+                .dummy(
+                    channel: .dummy(cid: cid2),
+                    channelReads: [
+                        .init(
+                            user: .dummy(userId: currentUserId),
+                            lastReadAt: .unique,
+                            lastReadMessageId: nil,
+                            unreadMessagesCount: 1
+                        )
+                    ]
+                )
+            ],
+            expectedResult: [cid1, cid2]
+        )
+    }
+
     func test_filterPredicate_muted_returnsExpectedResults() throws {
         let cid1 = ChannelId.unique
         let userId = memberId
@@ -1670,6 +1669,62 @@ final class ChannelListController_Tests: XCTestCase {
     }
 
     // MARK: - Private Helpers
+
+    private func assertFilterPredicate(
+        _ filter: @autoclosure () -> Filter<ChannelListFilterScope>,
+        currentUserId: UserId? = nil,
+        channelsInDB: @escaping @autoclosure () -> [ChannelPayload],
+        expectedResult: @autoclosure () -> [ChannelId],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        /// Ensure that isChannelAutomaticFilteringEnabled is enabled
+        var config = ChatClientConfig(apiKeyString: .unique)
+        config.isChannelAutomaticFilteringEnabled = true
+        client = ChatClient.mock(config: config)
+
+        if let currentUserId {
+            try database.writeSynchronously { session in
+                try session.saveCurrentUser(
+                    payload: .dummy(userId: currentUserId, role: .admin)
+                )
+            }
+        }
+
+        let query = ChannelListQuery(
+            filter: filter()
+        )
+        controller = ChatChannelListController(
+            query: query,
+            client: client,
+            environment: env.environment
+        )
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+
+        // Simulate `synchronize` call
+        controller.synchronize()
+        waitForInitialChannelsUpdate()
+
+        XCTAssertEqual(controller.channels.map(\.cid), [], file: file, line: line)
+
+        // Simulate changes in the DB:
+        _ = try waitFor {
+            writeAndWaitForChannelsUpdates({ [query] session in
+                try channelsInDB().forEach { payload in
+                    try session.saveChannel(payload: payload, query: query, cache: nil)
+                }
+            }, completion: $0)
+        }
+
+        // Assert the resulting value is updated
+        XCTAssertEqual(
+            controller.channels.map(\.cid.rawValue).sorted(),
+            expectedResult().map(\.rawValue).sorted(),
+            file: file,
+            line: line
+        )
+    }
 
     private func makeAddedChannelEvent(with channel: ChatChannel) -> NotificationAddedToChannelEvent {
         NotificationAddedToChannelEvent(

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1558,6 +1558,7 @@ final class ChannelListController_Tests: XCTestCase {
 
         try assertFilterPredicate(
             .hasUnread,
+            sort: [.init(key: .unreadCount, isAscending: false)],
             currentUserId: currentUserId,
             channelsInDB: [
                 .dummy(
@@ -1588,12 +1589,12 @@ final class ChannelListController_Tests: XCTestCase {
                             user: .dummy(userId: currentUserId),
                             lastReadAt: .unique,
                             lastReadMessageId: nil,
-                            unreadMessagesCount: 1
+                            unreadMessagesCount: 20
                         )
                     ]
                 )
             ],
-            expectedResult: [cid1, cid2]
+            expectedResult: [cid2, cid1]
         )
     }
 
@@ -1672,6 +1673,7 @@ final class ChannelListController_Tests: XCTestCase {
 
     private func assertFilterPredicate(
         _ filter: @autoclosure () -> Filter<ChannelListFilterScope>,
+        sort: [Sorting<ChannelListSortingKey>] = [],
         currentUserId: UserId? = nil,
         channelsInDB: @escaping @autoclosure () -> [ChannelPayload],
         expectedResult: @autoclosure () -> [ChannelId],
@@ -1692,7 +1694,8 @@ final class ChannelListController_Tests: XCTestCase {
         }
 
         let query = ChannelListQuery(
-            filter: filter()
+            filter: filter(),
+            sort: sort
         )
         controller = ChatChannelListController(
             query: query,

--- a/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
@@ -77,9 +77,13 @@ final class ChannelListSortingKey_Tests: XCTestCase {
                 XCTAssertEqual(key.remoteKey, "has_unread")
                 XCTAssertTrue(key.requiresRuntimeSorting)
             case .unreadCount:
-                XCTAssertNil(key.sortDescriptor(isAscending: true))
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
                 XCTAssertEqual(key.remoteKey, "unread_count")
-                XCTAssertTrue(key.requiresRuntimeSorting)
+                XCTAssertFalse(key.requiresRuntimeSorting)
+                XCTAssertEqual(
+                    key.localKey,
+                    NSExpression(forKeyPath: \ChannelDTO.currentUserUnreadMessagesCount).keyPath
+                )
             default:
                 XCTFail()
             }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://stream-io.atlassian.net/browse/PBE-5351

### 🎯 Goal

- Expose `.hasUnread` channel list filter option
- Fix sorting channel list by unread count

### 🛠 Implementation

In order to support automatic filtering, I had to add a new property to `ChannelDTO.currentUserUnreadMessagesCount` which is computed from `ChannelDTO.reads`. Otherwise, it was not possible to create an NSPredicate out of `ChannelDTO.reads`.

By adding this property, we can now make the sorting of unreadCount work properly, which was not working before as well. 

### 🎨 Showcase

Usage: `ChannelListQuery(filter: .hasUnread)`

Demo:

https://github.com/user-attachments/assets/23848a8b-781f-4f35-9eaa-64943388bd2a

### 🧪 Manual Testing Notes

**Requirements:** Use the SwiftUI API Keys. (The `hasUnread` is not working on the default keys)

1- Login
2- Tap on filters button (right top corner)
3- Tap on Unread Channels
4- Should see only unread channels and sorted by unread count

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)