### PR TITLE
Fix message search not showing results for new search terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a rare issue with incorrect message order when sending multiple messages while offline [#3316](https://github.com/GetStream/stream-chat-swift/issues/3316)
 - Fix sorting channel list by unread count [#3340](https://github.com/GetStream/stream-chat-swift/pull/3340)
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix message search not showing results for new search terms [#3345](https://github.com/GetStream/stream-chat-swift/pull/3345)
+
 # [4.60.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.60.0)
 _July 18, 2024_
 

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelSearchVC.swift
@@ -15,7 +15,7 @@ open class ChatChannelSearchVC: ChatChannelListSearchVC {
     // MARK: - ChatChannelListSearchVC Abstract Implementations
 
     override open var hasEmptyResults: Bool {
-        channels.isEmpty
+        controller.channels.isEmpty
     }
 
     override open func loadSearchResults(with text: String) {

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
@@ -31,7 +31,7 @@ open class ChatMessageSearchVC: ChatChannelListSearchVC, ChatMessageSearchContro
     // MARK: - ChatChannelListSearchVC Abstract Implementations
 
     override open var hasEmptyResults: Bool {
-        messages.isEmpty
+        messageSearchController.messages.isEmpty
     }
 
     override open func loadSearchResults(with text: String) {


### PR DESCRIPTION
### 🎯 Goal

Message search results were empty after logging in and quickly typing a search term 

### 📝 Summary

- Reload collection view on state change and update UI state on messages array change

### 🧪 Manual Testing Notes

1. Logout and login for clearing local DB
2. Quickly type a search term like "tes"

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
