### PR TITLE
Fix rare crashes when deleting local database content on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### 🐞 Fixed
+- Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
 ### 🔄 Changed
 - Made loadBlockedUsers in ConnectedUser public [#3352](https://github.com/GetStream/stream-chat-swift/pull/3352)
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -5377,6 +5377,38 @@ final class ChannelController_Tests: XCTestCase {
             XCTAssertEqual(4, dto.messages.count)
         }
     }
+    
+    // MARK: - Logout
+    
+    func test_channels_afterLogout() throws {
+        controller = ChatChannelController(
+            channelQuery: .init(cid: channelId),
+            channelListQuery: nil,
+            client: client,
+            environment: env.environment
+        )
+        
+        let messages: [MessagePayload] = [.dummy(), .dummy(), .dummy(), .dummy()]
+        try setupChannel(
+            channelPayload: .dummy(
+                channel: .dummy(cid: channelId),
+                messages: messages
+            )
+        )
+        
+        XCTAssertEqual(channelId, controller.cid)
+        XCTAssertEqual(4, controller.messages.count)
+        
+        let expectation = XCTestExpectation(description: "Remove")
+        client.databaseContainer.removeAllData { error in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: defaultTimeout)
+        
+        XCTAssertEqual(channelId, controller.cid)
+        XCTAssertEqual(0, controller.messages.count)
+    }
 }
 
 // MARK: Test Helpers


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-4309](https://stream-io.atlassian.net/browse/PBE-4309)

### 🎯 Goal

Fix crashes on logout related to local database access

### 📝 Summary

- Notify `NSManagedObjectContext` that data was [deleted on the SQL level](https://developer.apple.com/documentation/coredata/nsbatchdeleterequest)
- Discard any `DatabaseContainer` write requests while clearing local data

### 🛠 Implementation

Batch delete removes data on the SQL level and does not notify contexts. Contexts can be left into invalid state if we do not manually notify them.

### 🧪 Manual Testing Notes

Repeat
1. Log in
2. Do something
3. Log out

No crashes or any other odd things should appear.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)


[PBE-4309]: https://stream-io.atlassian.net/browse/PBE-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ