### PR TITLE
Use background database observers for remaining controller properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ⚡ Performance
+- Use background database observers for `CurrentUserController.currentUser`, `ChatChannelMemberListController.members`, and `ChatMessageController.message` which reduces CPU usage on the main thread [#3357](https://github.com/GetStream/stream-chat-swift/pull/3357)
 ### 🐞 Fixed
 - Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
 ### 🔄 Changed

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -289,11 +289,11 @@ public extension CurrentChatUserController {
 extension CurrentChatUserController {
     struct Environment {
         var currentUserObserverBuilder: (
-            _ context: NSManagedObjectContext,
+            _ database: DatabaseContainer,
             _ fetchRequest: NSFetchRequest<CurrentUserDTO>,
             _ itemCreator: @escaping (CurrentUserDTO) throws -> CurrentChatUser,
             _ fetchedResultsControllerType: NSFetchedResultsController<CurrentUserDTO>.Type
-        ) -> EntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> = EntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> = BackgroundEntityDatabaseObserver.init
 
         var currentUserUpdaterBuilder = CurrentUserUpdater.init
     }
@@ -315,9 +315,9 @@ private extension EntityChange where Item == UnreadCount {
 }
 
 private extension CurrentChatUserController {
-    func createUserObserver() -> EntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> {
+    func createUserObserver() -> BackgroundEntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> {
         environment.currentUserObserverBuilder(
-            client.databaseContainer.viewContext,
+            client.databaseContainer,
             CurrentUserDTO.defaultFetchRequest,
             { try $0.asModel() },
             NSFetchedResultsController<CurrentUserDTO>.self

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -802,11 +802,11 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
 extension ChatMessageController {
     struct Environment {
         var messageObserverBuilder: (
-            _ context: NSManagedObjectContext,
+            _ database: DatabaseContainer,
             _ fetchRequest: NSFetchRequest<MessageDTO>,
             _ itemCreator: @escaping (MessageDTO) throws -> ChatMessage,
             _ fetchedResultsControllerType: NSFetchedResultsController<MessageDTO>.Type
-        ) -> EntityDatabaseObserver<ChatMessage, MessageDTO> = EntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<ChatMessage, MessageDTO> = BackgroundEntityDatabaseObserver.init
 
         var repliesObserverBuilder: (
             _ database: DatabaseContainer,
@@ -835,9 +835,9 @@ extension ChatMessageController {
 // MARK: - Private
 
 private extension ChatMessageController {
-    func createMessageObserver() -> EntityDatabaseObserver<ChatMessage, MessageDTO> {
+    func createMessageObserver() -> BackgroundEntityDatabaseObserver<ChatMessage, MessageDTO> {
         let observer = environment.messageObserverBuilder(
-            client.databaseContainer.viewContext,
+            client.databaseContainer,
             MessageDTO.message(withID: messageId),
             { try $0.asModel() },
             NSFetchedResultsController<MessageDTO>.self

--- a/TestTools/StreamChatTestTools/SpyPattern/QueueAware/UserController_Delegate.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/QueueAware/UserController_Delegate.swift
@@ -11,6 +11,7 @@ final class UserController_Delegate: QueueAwareDelegate, CurrentChatUserControll
     @Atomic var state: DataController.State?
     @Atomic var didChangeCurrentUser_change: EntityChange<CurrentChatUser>?
     @Atomic var didChangeCurrentUserUnreadCount_count: UnreadCount?
+    let didChangeCurrentUserUnreadCountExpectation = XCTestExpectation()
 
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
@@ -28,5 +29,6 @@ final class UserController_Delegate: QueueAwareDelegate, CurrentChatUserControll
     func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUserUnreadCount count: UnreadCount) {
         didChangeCurrentUserUnreadCount_count = count
         validateQueue()
+        didChangeCurrentUserUnreadCountExpectation.fulfill()
     }
 }

--- a/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -277,9 +277,11 @@ final class CurrentUserController_Tests: XCTestCase {
             try $0.saveCurrentUser(payload: currentUserPayload)
         }
 
+        wait(for: [delegate.didChangeCurrentUserUnreadCountExpectation], timeout: defaultTimeout)
+        
         // Assert delegate received correct unread count
         let delegateUnreadCount = delegate.didChangeCurrentUserUnreadCount_count
-        AssertAsync.willBeTrue(delegateUnreadCount?.isEqual(toPayload: unreadCount) == true)
+        XCTAssertTrue(delegateUnreadCount?.isEqual(toPayload: unreadCount) == true)
     }
 
     // MARK: - Updating current user
@@ -753,7 +755,7 @@ final class CurrentUserController_Tests: XCTestCase {
 }
 
 private class TestEnvironment {
-    var currentUserObserver: EntityDatabaseObserver_Mock<CurrentChatUser, CurrentUserDTO>!
+    var currentUserObserver: BackgroundEntityDatabaseObserver_Mock<CurrentChatUser, CurrentUserDTO>!
     var currentUserObserverItem: CurrentChatUser?
     var currentUserObserverStartUpdatingError: Error?
 
@@ -761,7 +763,7 @@ private class TestEnvironment {
 
     lazy var currentUserControllerEnvironment: CurrentChatUserController
         .Environment = .init(currentUserObserverBuilder: { [unowned self] in
-            self.currentUserObserver = .init(context: $0, fetchRequest: $1, itemCreator: $2, fetchedResultsControllerType: $3)
+            self.currentUserObserver = .init(database: $0, fetchRequest: $1, itemCreator: $2, fetchedResultsControllerType: $3)
             self.currentUserObserver.synchronizeError = self.currentUserObserverStartUpdatingError
             self.currentUserObserver.item_mock = self.currentUserObserverItem
             return self.currentUserObserver!

--- a/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
@@ -444,7 +444,7 @@ final class MemberListController_Tests: XCTestCase {
 
 private class TestEnvironment {
     @Atomic var memberListUpdater: ChannelMemberListUpdater_Mock?
-    @Atomic var memberListObserver: ListDatabaseObserver_Mock<ChatChannelMember, MemberDTO>?
+    @Atomic var memberListObserver: BackgroundListDatabaseObserver_Mock<ChatChannelMember, MemberDTO>?
     @Atomic var memberListObserverSynchronizeError: Error?
 
     lazy var environment: ChatChannelMemberListController.Environment = .init(
@@ -457,11 +457,10 @@ private class TestEnvironment {
         },
         memberListObserverBuilder: { [unowned self] in
             self.memberListObserver = .init(
-                context: $0.viewContext,
+                database: $0,
                 fetchRequest: $1,
                 itemCreator: $2,
-                itemReuseKeyPaths: (\ChatChannelMember.id, \MemberDTO.id),
-                fetchedResultsControllerType: $3
+                itemReuseKeyPaths: (\ChatChannelMember.id, \MemberDTO.id)
             )
             self.memberListObserver?.synchronizeError = self.memberListObserverSynchronizeError
             return self.memberListObserver!

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -2536,7 +2536,7 @@ private class TestDelegate: QueueAwareDelegate, ChatMessageControllerDelegate {
 private class TestEnvironment {
     var replyMessagesPaginationStateHandler: MessagesPaginationStateHandler_Mock!
     var messageUpdater: MessageUpdater_Mock!
-    var messageObserver: EntityDatabaseObserver_Mock<ChatMessage, MessageDTO>!
+    var messageObserver: BackgroundEntityDatabaseObserver_Mock<ChatMessage, MessageDTO>!
     var repliesObserver: BackgroundListDatabaseObserver_Mock<ChatMessage, MessageDTO>!
 
     var messageObserver_synchronizeError: Error?
@@ -2545,7 +2545,7 @@ private class TestEnvironment {
         .Environment = .init(
             messageObserverBuilder: { [unowned self] in
                 self.messageObserver = .init(
-                    context: $0,
+                    database: $0,
                     fetchRequest: $1,
                     itemCreator: $2,
                     fetchedResultsControllerType: $3


### PR DESCRIPTION
### 🎯 Goal

- Move last controller properties to background database observers which reduces main thread usage

### 📝 Summary

User background observers for:
- `CurrentUserController.currentUser`
- `ChatChannelMemberListController.members`
- `ChatMessageController.message`

### 🛠 Implementation

These controllers did not use background observers because at that time background observers did not support fetching its state immediately. This was added in [PR:3305](https://github.com/GetStream/stream-chat-swift/pull/3305).

### 🧪 Manual Testing Notes

Exploratory testing around mentioning users, interacting with messages using the context menu

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)