### PR TITLE
Fix crash in MulticastDelegate caused by concurrent accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use background database observers for `CurrentUserController.currentUser`, `ChatChannelMemberListController.members`, and `ChatMessageController.message` which reduces CPU usage on the main thread [#3357](https://github.com/GetStream/stream-chat-swift/pull/3357)
 ### 🐞 Fixed
 - Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
+- Fix rare crashes in `MulticastDelegate` when accessing it concurrently [#3361](https://github.com/GetStream/stream-chat-swift/pull/3361)
 ### 🔄 Changed
 - Made loadBlockedUsers in ConnectedUser public [#3352](https://github.com/GetStream/stream-chat-swift/pull/3352)
 

--- a/Sources/StreamChat/Utils/MulticastDelegate.swift
+++ b/Sources/StreamChat/Utils/MulticastDelegate.swift
@@ -7,6 +7,7 @@ import Foundation
 // swiftlint:disable force_cast
 /// Responsible to hold a collection of delegates and call all of them when the multicast delegate is invoked.
 struct MulticastDelegate<T> {
+    private let queue = DispatchQueue(label: "io.stream.com.multicast-delegate")
     /// We need to use a weak NSHashTable instead of a WeakReference<T> type because <T> can't
     /// be conformed to AnyObject or the rest of the codebase won't compile because of `DelegateCallable`.
     private var _additionalDelegates = NSHashTable<AnyObject>.weakObjects()
@@ -17,13 +18,17 @@ struct MulticastDelegate<T> {
 
     /// The main delegate. If a `controller.delegate` is set, the main delegate will be used.
     var mainDelegate: T? {
-        _mainDelegate.allObjects.map { $0 as! T }.first
+        queue.sync {
+            _mainDelegate.allObjects.map { $0 as! T }.first
+        }
     }
 
     /// The additional delegates. If a Combine publisher is being used,
     /// all subscribers will be added to the additional delegates.
     var additionalDelegates: [T] {
-        _additionalDelegates.allObjects.map { $0 as! T }
+        queue.sync {
+            _additionalDelegates.allObjects.map { $0 as! T }
+        }
     }
 
     /// Invokes all delegates, including the main and additional delegates.
@@ -36,30 +41,38 @@ struct MulticastDelegate<T> {
     /// Sets the main delegate. If is nil, removes the main delegate.
     /// - Parameter mainDelegate: The main delegate.
     mutating func set(mainDelegate: T?) {
-        _mainDelegate.removeAllObjects()
-
-        if let delegate = mainDelegate {
-            _mainDelegate.add(delegate as AnyObject)
+        queue.sync {
+            _mainDelegate.removeAllObjects()
+            
+            if let delegate = mainDelegate {
+                _mainDelegate.add(delegate as AnyObject)
+            }
         }
     }
 
     /// Replaces the current additional delegates with another collection of delegates.
     /// - Parameter additionalDelegates: The new additional delegates.
     mutating func set(additionalDelegates: [T]) {
-        _additionalDelegates.removeAllObjects()
-        additionalDelegates.forEach { _additionalDelegates.add($0 as AnyObject) }
+        queue.sync {
+            _additionalDelegates.removeAllObjects()
+            additionalDelegates.forEach { _additionalDelegates.add($0 as AnyObject) }
+        }
     }
 
     /// Adds a new delegate to the additional delegates.
     /// - Parameter additionalDelegate: The additional delegate.
     mutating func add(additionalDelegate: T) {
-        _additionalDelegates.add(additionalDelegate as AnyObject)
+        queue.sync {
+            _additionalDelegates.add(additionalDelegate as AnyObject)
+        }
     }
 
     /// Removes a delegate from the additional delegates.
     /// - Parameter additionalDelegate: The delegate to be removed.
     mutating func remove(additionalDelegate: T) {
-        _additionalDelegates.remove(additionalDelegate as AnyObject)
+        queue.sync {
+            _additionalDelegates.remove(additionalDelegate as AnyObject)
+        }
     }
 }
 

--- a/Tests/StreamChatTests/Utils/MulticastDelegate_Tests.swift
+++ b/Tests/StreamChatTests/Utils/MulticastDelegate_Tests.swift
@@ -141,6 +141,17 @@ final class MulticastDelegate_Tests: XCTestCase {
         XCTAssertNil(multicastDelegate.mainDelegate)
         XCTAssertTrue(multicastDelegate.additionalDelegates.isEmpty)
     }
+    
+    func test_whenAccessingConcurrently_shouldNotCrash() {
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            let newMainDelegate = TestDelegate()
+            let newAdditionalDelegates = (0..<10).map { _ in TestDelegate() }
+            multicastDelegate.set(mainDelegate: newMainDelegate)
+            multicastDelegate.set(additionalDelegates: newAdditionalDelegates)
+            _ = multicastDelegate.mainDelegate
+            _ = multicastDelegate.additionalDelegates
+        }
+    }
 }
 
 private class TestDelegate {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-5434](https://stream-io.atlassian.net/browse/PBE-5434)

### 🎯 Goal

Make `MulticastDelegate` thread-safe

### 🛠 Implementation

We got a report of crashes in the MulticastDelegate what point at multi-threading issues..
```
Fatal Exception: NSGenericException
0  CoreFoundation                 0x83f20 __exceptionPreprocess
1  libobjc.A.dylib                0x16018 objc_exception_throw
2  CoreFoundation                 0x18220c -[__NSSingleObjectEnumerator init]
3  Foundation                     0x29284 -[NSConcreteHashTable countByEnumeratingWithState:objects:count:]
4  Foundation                     0x291f8 -[NSConcreteHashTable allObjects]
5  <Redacted>                      0x87dd44 specialized MulticastDelegate.mainDelegate.getter
6  <Redacted>                       0x87f570 specialized MulticastDelegate.invoke(_:)
7  <Redacted>                       0x914c60 specialized DelegateCallable.delegateCallback(_:) + 95 (DataController.swift:95)
```

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)


[PBE-5434]: https://stream-io.atlassian.net/browse/PBE-5434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ