### PR TITLE
Improve database container read and reset

### DIFF
--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -203,15 +203,16 @@ extension CurrentChatUser {
     fileprivate static func create(fromDTO dto: CurrentUserDTO) throws -> CurrentChatUser {
         let user = dto.user
 
-        let extraData: [String: RawJSON]
-        do {
-            extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dto.user.extraData)
-        } catch {
-            log.error(
-                "Failed to decode extra data for user with id: <\(dto.user.id)>, using default value instead. "
-                    + "Error: \(error)"
-            )
-            extraData = [:]
+        var extraData = [String: RawJSON]()
+        if !dto.user.extraData.isEmpty {
+            do {
+                extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dto.user.extraData)
+            } catch {
+                log.error(
+                    "Failed to decode extra data for user with id: <\(dto.user.id)>, using default value instead. "
+                        + "Error: \(error)"
+                )
+            }
         }
         
         let mutedUsers: [ChatUser] = try dto.mutedUsers.map { try $0.asModel() }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -1154,6 +1154,53 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             $0.localState = .pendingUpload
         }
     }
+    
+    func loadMessage(
+        before id: MessageId,
+        cid: String
+    ) throws -> MessageDTO? {
+        try MessageDTO.loadMessage(
+            before: id,
+            cid: cid,
+            deletedMessagesVisibility: deletedMessagesVisibility ?? .alwaysVisible,
+            shouldShowShadowedMessages: shouldShowShadowedMessages ?? true,
+            context: self
+        )
+    }
+    
+    func loadMessages(
+        from fromIncludingDate: Date,
+        to toIncludingDate: Date,
+        in cid: ChannelId,
+        sortAscending: Bool
+    ) throws -> [MessageDTO] {
+        try MessageDTO.loadMessages(
+            from: fromIncludingDate,
+            to: toIncludingDate,
+            in: cid,
+            sortAscending: sortAscending,
+            deletedMessagesVisibility: deletedMessagesVisibility ?? .alwaysVisible,
+            shouldShowShadowedMessages: shouldShowShadowedMessages ?? true,
+            context: self
+        )
+    }
+    
+    func loadReplies(
+        from fromIncludingDate: Date,
+        to toIncludingDate: Date,
+        in messageId: MessageId,
+        sortAscending: Bool
+    ) throws -> [MessageDTO] {
+        try MessageDTO.loadReplies(
+            from: fromIncludingDate,
+            to: toIncludingDate,
+            in: messageId,
+            sortAscending: sortAscending,
+            deletedMessagesVisibility: deletedMessagesVisibility ?? .alwaysVisible,
+            shouldShowShadowedMessages: shouldShowShadowedMessages ?? true,
+            context: self
+        )
+    }
 }
 
 extension MessageDTO {

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -194,6 +194,20 @@ protocol MessageDatabaseSession {
     /// to avoid those from being stuck there in limbo.
     /// Messages can get stuck in `.sending` state if the network request to send them takes to much, and the app is backgrounded or killed.
     func rescueMessagesStuckInSending()
+    
+    func loadMessages(
+        from fromIncludingDate: Date,
+        to toIncludingDate: Date,
+        in cid: ChannelId,
+        sortAscending: Bool
+    ) throws -> [MessageDTO]
+    
+    func loadReplies(
+        from fromIncludingDate: Date,
+        to toIncludingDate: Date,
+        in messageId: MessageId,
+        sortAscending: Bool
+    ) throws -> [MessageDTO]
 }
 
 extension MessageDatabaseSession {

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -333,15 +333,12 @@ class MessageRepository {
 extension MessageRepository {
     /// Fetches messages from the database with a date range.
     func messages(from fromDate: Date, to toDate: Date, in cid: ChannelId) async throws -> [ChatMessage] {
-        try await database.read { context in
-            try MessageDTO.loadMessages(
+        try await database.read { session in
+            try session.loadMessages(
                 from: fromDate,
                 to: toDate,
                 in: cid,
-                sortAscending: true,
-                deletedMessagesVisibility: context.deletedMessagesVisibility ?? .alwaysVisible,
-                shouldShowShadowedMessages: context.shouldShowShadowedMessages ?? true,
-                context: context
+                sortAscending: true
             )
             .map { try $0.asModel() }
         }
@@ -349,15 +346,12 @@ extension MessageRepository {
     
     /// Fetches replies from the database with a date range.
     func replies(from fromDate: Date, to toDate: Date, in message: MessageId) async throws -> [ChatMessage] {
-        try await database.read { context in
-            try MessageDTO.loadReplies(
+        try await database.read { session in
+            try session.loadReplies(
                 from: fromDate,
                 to: toDate,
                 in: message,
-                sortAscending: true,
-                deletedMessagesVisibility: context.deletedMessagesVisibility ?? .alwaysVisible,
-                shouldShowShadowedMessages: context.shouldShowShadowedMessages ?? true,
-                context: context
+                sortAscending: true
             )
             .map { try $0.asModel() }
         }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -718,8 +718,8 @@ extension ChannelUpdater {
             }
         }
         guard let ids = payload.watchers?.map(\.id) else { return [] }
-        return try await database.read { context in
-            try ids.compactMap { try UserDTO.load(id: $0, context: context)?.asModel() }
+        return try await database.read { session in
+            try ids.compactMap { try session.user(id: $0)?.asModel() }
         }
     }
     

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -215,6 +215,14 @@ class DatabaseSession_Mock: DatabaseSession {
     func rescueMessagesStuckInSending() {
         underlyingSession.rescueMessagesStuckInSending()
     }
+    
+    func loadMessages(from fromIncludingDate: Date, to toIncludingDate: Date, in cid: ChannelId, sortAscending: Bool) throws -> [MessageDTO] {
+        try underlyingSession.loadMessages(from: fromIncludingDate, to: toIncludingDate, in: cid, sortAscending: sortAscending)
+    }
+    
+    func loadReplies(from fromIncludingDate: Date, to toIncludingDate: Date, in messageId: MessageId, sortAscending: Bool) throws -> [MessageDTO] {
+        try underlyingSession.loadReplies(from: fromIncludingDate, to: toIncludingDate, in: messageId, sortAscending: sortAscending)
+    }
 
     func reaction(messageId: MessageId, userId: UserId, type: MessageReactionType) -> MessageReactionDTO? {
         underlyingSession.reaction(messageId: messageId, userId: userId, type: type)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-5422](https://stream-io.atlassian.net/browse/PBE-5422)

### 🎯 Goal

Fix issues around database read wrappers and context resets

### 📝 Summary

- One DatabaseContainer read uses DatabaseSession, the async one NSManagedObjectContext > unify to use DatabaseSession
- Fix and issue where after logout contexts are not reset (keep referencing deleted objects)
- Change the read assert to trigger only based on counts (did not find a way how to fix the issue of it keeping tracking deleted objects)

### 🧪 Manual Testing Notes

Case 1:
Log in and log out

Case 2:
1. Open Demo Configuration Screen
2. Enable Hard Delete Message
3. Open a channel
4. Hard delete a message
5. Go to background
6. Wait 1min ( or as soon as web-socket's disconnect is logged)
7. Open the app again
8. :boom: 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5422]: https://stream-io.atlassian.net/browse/PBE-5422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ