### PR TITLE
Run offline state sync in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Made loadBlockedUsers in ConnectedUser public [#3352](https://github.com/GetStream/stream-chat-swift/pull/3352)
 - Removed Agora and 100ms related code, the recommended way to support calls is to use StreamVideo [#3364](https://github.com/GetStream/stream-chat-swift/pull/3364)
+- Run offline state sync in the background instead of pausing other API requests while it runs [#3367](https://github.com/GetStream/stream-chat-swift/pull/3367)
 
 # [4.61.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.61.0)
 _July 30, 2024_

--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -124,8 +124,6 @@ extension ChatClient {
 
         var syncRepositoryBuilder: (
             _ config: ChatClientConfig,
-            _ activeChannelControllers: ThreadSafeWeakCollection<ChatChannelController>,
-            _ activeChannelListControllers: ThreadSafeWeakCollection<ChatChannelListController>,
             _ offlineRequestsRepository: OfflineRequestsRepository,
             _ eventNotificationCenter: EventNotificationCenter,
             _ database: DatabaseContainer,
@@ -134,13 +132,11 @@ extension ChatClient {
         ) -> SyncRepository = {
             SyncRepository(
                 config: $0,
-                activeChannelControllers: $1,
-                activeChannelListControllers: $2,
-                offlineRequestsRepository: $3,
-                eventNotificationCenter: $4,
-                database: $5,
-                apiClient: $6,
-                channelListUpdater: $7
+                offlineRequestsRepository: $1,
+                eventNotificationCenter: $2,
+                database: $3,
+                apiClient: $4,
+                channelListUpdater: $5
             )
         }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -46,10 +46,6 @@ public class ChatClient {
     /// work if needed (i.e. when a new message pending sent appears in the database, a worker tries to send it.)
     private(set) var backgroundWorkers: [Worker] = []
 
-    /// Keeps a weak reference to the active channel list controllers to ensure a proper recovery when coming back online
-    private(set) var activeChannelListControllers = ThreadSafeWeakCollection<ChatChannelListController>()
-    private(set) var activeChannelControllers = ThreadSafeWeakCollection<ChatChannelController>()
-
     /// Background worker that takes care about client connection recovery when the Internet comes back OR app transitions from background to foreground.
     private(set) var connectionRecoveryHandler: ConnectionRecoveryHandler?
 
@@ -167,8 +163,6 @@ public class ChatClient {
         )
         let syncRepository = environment.syncRepositoryBuilder(
             config,
-            activeChannelControllers,
-            activeChannelListControllers,
             offlineRequestsRepository,
             eventNotificationCenter,
             databaseContainer,
@@ -469,8 +463,6 @@ public class ChatClient {
         authenticationRepository.logOutUser()
 
         // Stop tracking active components
-        activeChannelControllers.removeAllObjects()
-        activeChannelListControllers.removeAllObjects()
         syncRepository.removeAllTracked()
 
         let group = DispatchGroup()
@@ -589,29 +581,6 @@ public class ChatClient {
                 attachmentPostProcessor: config.uploadedAttachmentPostProcessor
             )
         ]
-    }
-
-    func startTrackingChannelController(_ channelController: ChatChannelController) {
-        // If it is already tracking, do nothing.
-        guard !activeChannelControllers.contains(channelController) else {
-            return
-        }
-        activeChannelControllers.add(channelController)
-    }
-
-    func stopTrackingChannelController(_ channelController: ChatChannelController) {
-        activeChannelControllers.remove(channelController)
-    }
-
-    func startTrackingChannelListController(_ channelListController: ChatChannelListController) {
-        guard !activeChannelListControllers.contains(channelListController) else {
-            return
-        }
-        activeChannelListControllers.add(channelListController)
-    }
-
-    func stopTrackingChannelListController(_ channelListController: ChatChannelListController) {
-        activeChannelListControllers.remove(channelListController)
     }
 
     func completeConnectionIdWaiters(connectionId: String?) {

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -31,4 +31,9 @@ public enum StreamRuntimeCheck {
     ///
     /// Enables reusing unchanged converted items in database observers.
     public static var _isDatabaseObserverItemReusingEnabled = true
+    
+    /// For *internal use* only
+    ///
+    /// Uses vresion 2 for offline state sync.
+    public static var _isSyncV2Enabled = true
 }

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -34,6 +34,6 @@ public enum StreamRuntimeCheck {
     
     /// For *internal use* only
     ///
-    /// Uses vresion 2 for offline state sync.
+    /// Uses version 2 for offline state sync.
     public static var _isSyncV2Enabled = true
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -229,7 +229,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     }
 
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
-        client.startTrackingChannelController(self)
+        client.syncRepository.startTrackingChannelController(self)
         synchronize(isInRecoveryMode: false, completion)
     }
 
@@ -1030,7 +1030,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             return
         }
 
-        client.startTrackingChannelController(self)
+        client.syncRepository.startTrackingChannelController(self)
 
         updater.startWatching(cid: cid, isInRecoveryMode: isInRecoveryMode) { error in
             self.state = error.map { .remoteDataFetchFailed(ClientError(with: $0)) } ?? .remoteDataFetched
@@ -1064,7 +1064,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             return
         }
 
-        client.stopTrackingChannelController(self)
+        client.syncRepository.stopTrackingChannelController(self)
 
         updater.stopWatching(cid: cid) { error in
             self.state = error.map { .remoteDataFetchFailed(ClientError(with: $0)) } ?? .localDataFetched

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -144,7 +144,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
         startChannelListObserverIfNeeded()
         channelListLinker.start(with: client.eventNotificationCenter)
-        client.startTrackingChannelListController(self)
+        client.syncRepository.startTrackingChannelListController(self)
         updateChannelList(completion)
     }
 
@@ -191,6 +191,11 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
 
     // MARK: - Internal
 
+    func refreshLoadedChannels(completion: @escaping (Result<Set<ChannelId>, Error>) -> Void) {
+        let channelCount = channelListObserver.items.count
+        worker.refreshLoadedChannels(for: query, channelCount: channelCount, completion: completion)
+    }
+    
     func resetQuery(
         watchedAndSynchedChannelIds: Set<ChannelId>,
         synchedChannelIds: Set<ChannelId>,

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -11,13 +11,104 @@ final class SyncContext {
     var synchedChannelIds: Set<ChannelId> = Set()
     var watchedAndSynchedChannelIds: Set<ChannelId> = Set()
     var unwantedChannelIds: Set<ChannelId> = Set()
+    var missingEventSyncSuccessful = false
 
     init(lastSyncAt: Date) {
         self.lastSyncAt = lastSyncAt
     }
+    
+    var canRefreshChannelLists: Bool {
+        !missingEventSyncSuccessful
+    }
 }
 
 private let syncOperationsMaximumRetries = 2
+
+final class ActiveChannelIdsOperation: AsyncOperation {
+    init(
+        syncRepository: SyncRepository,
+        context: SyncContext
+    ) {
+        super.init(maxRetries: syncOperationsMaximumRetries) { [weak syncRepository] _, done in
+            guard let syncRepository else {
+                done(.continue)
+                return
+            }
+            
+            context.localChannelIds.append(contentsOf: syncRepository.activeChannelControllers.allObjects.compactMap(\.cid))
+            context.localChannelIds.append(contentsOf:
+                syncRepository.activeChannelListControllers.allObjects
+                    .map(\.channels)
+                    .flatMap { $0 }
+                    .map(\.cid)
+            )
+            
+            // Main actor requirement
+            DispatchQueue.main.async {
+                context.localChannelIds.append(contentsOf: syncRepository.activeChats.allObjects.compactMap { try? $0.cid })
+                context.localChannelIds.append(contentsOf:
+                    syncRepository.activeChannelLists.allObjects
+                        .map(\.state.channels)
+                        .flatMap { $0 }
+                        .map(\.cid)
+                )
+                context.localChannelIds = Array(Set(context.localChannelIds))
+                log.info("Found \(context.localChannelIds.count) active channels", subsystems: .offlineSupport)
+                done(.continue)
+            }
+        }
+    }
+}
+
+final class RefreshChannelListOperation: AsyncOperation {
+    init(controller: ChatChannelListController, context: SyncContext) {
+        super.init(maxRetries: syncOperationsMaximumRetries) { [weak controller] _, done in
+            guard context.canRefreshChannelLists else {
+                done(.continue)
+                return
+            }
+            guard let controller = controller, controller.canBeRecovered else {
+                done(.continue)
+                return
+            }
+            controller.refreshLoadedChannels { result in
+                switch result {
+                case .success(let channelIds):
+                    log.debug("Synced \(channelIds.count) channels in a channel list controller (\(controller.query.filter)", subsystems: .offlineSupport)
+                    context.synchedChannelIds.formUnion(channelIds)
+                    done(.continue)
+                case .failure(let error):
+                    log.error("Failed refreshing channel list controller (\(controller.query.filter) with error \(error)", subsystems: .offlineSupport)
+                    done(.retry)
+                }
+            }
+        }
+    }
+    
+    init(channelList: ChannelList, context: SyncContext) {
+        super.init(maxRetries: syncOperationsMaximumRetries) { [weak channelList] _, done in
+            guard context.canRefreshChannelLists else {
+                done(.continue)
+                return
+            }
+            guard let channelList else {
+                done(.continue)
+                return
+            }
+            Task {
+                do {
+                    let channelIds = try await channelList.refreshLoadedChannels()
+                    log.debug("Synced \(channelIds.count) channels in a channel list (\(channelList.query.filter)", subsystems: .offlineSupport)
+                    context.synchedChannelIds.formUnion(channelIds)
+                    done(.continue)
+                } catch {
+                    log.error("Failed refreshing channel list (\(channelList.query.filter) with error \(error)", subsystems: .offlineSupport)
+                    done(.retry)
+                }
+            }
+        }
+    }
+}
 
 final class GetChannelIdsOperation: AsyncOperation {
     init(database: DatabaseContainer, context: SyncContext, activeChannelIds: [ChannelId]) {
@@ -39,7 +130,7 @@ final class GetChannelIdsOperation: AsyncOperation {
 }
 
 final class SyncEventsOperation: AsyncOperation {
-    init(syncRepository: SyncRepository, context: SyncContext) {
+    init(syncRepository: SyncRepository, context: SyncContext, recovery: Bool) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak syncRepository] _, done in
             log.info(
                 "1. Call `/sync` endpoint and get missing events for all locally existed channels",
@@ -49,14 +140,16 @@ final class SyncEventsOperation: AsyncOperation {
             syncRepository?.syncChannelsEvents(
                 channelIds: context.localChannelIds,
                 lastSyncAt: context.lastSyncAt,
-                isRecovery: true
+                isRecovery: recovery
             ) { result in
                 switch result {
                 case let .success(channelIds):
                     context.synchedChannelIds = Set(channelIds)
+                    context.missingEventSyncSuccessful = true
                     done(.continue)
                 case let .failure(error):
                     context.synchedChannelIds = Set([])
+                    context.missingEventSyncSuccessful = false
                     done(error.shouldRetry ? .retry : .continue)
                 }
             }
@@ -182,7 +275,7 @@ final class DeleteUnwantedChannelsOperation: AsyncOperation {
 final class ExecutePendingOfflineActions: AsyncOperation {
     init(offlineRequestsRepository: OfflineRequestsRepository) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak offlineRequestsRepository] _, done in
-            log.info("5. Running offline actions requests", subsystems: .offlineSupport)
+            log.info("Running offline actions requests", subsystems: .offlineSupport)
             offlineRequestsRepository?.runQueuedRequests {
                 done(.continue)
             }

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -156,9 +156,8 @@ class SyncRepository {
     ///
     /// Background mode (other regular API requests are allowed to run at the same time)
     /// 1. Collect all the **active** channel ids (from instances of `Chat`, `ChannelList`, `ChatChannelController`, `ChatChannelListController`)
-    /// 2. Ask updates from the /sync endpoint for these channels
-    /// 2.a Apply changes
-    /// 2.b When there are too many events, just refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)
+    /// 2. Apply updates from the /sync endpoint for these channels
+    /// 3. Refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)
     private func syncLocalStateV2(lastSyncAt: Date, completion: @escaping () -> Void) {
         let context = SyncContext(lastSyncAt: lastSyncAt)
         var operations: [Operation] = []
@@ -186,7 +185,7 @@ class SyncRepository {
         // 2. /sync
         operations.append(SyncEventsOperation(syncRepository: self, context: context, recovery: false))
         
-        // 2.b.1 (these run only if sync was not possible in the previous step)
+        // 3. Refresh channel lists (required even after applying events)
         operations.append(contentsOf: activeChannelLists.allObjects.map { RefreshChannelListOperation(channelList: $0, context: context) })
         operations.append(contentsOf: activeChannelListControllers.allObjects.map { RefreshChannelListOperation(controller: $0, context: context) })
         

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -87,6 +87,7 @@ public class Chat {
             channelQuery: query,
             memberSorting: state.memberSorting
         )
+        client.syncRepository.startTrackingChat(self)
         // cid is retrieved from the server when we are creating new channels or there is no local state present
         guard query.cid != payload.channel.cid else { return }
         await state.setChannelId(payload.channel.cid)
@@ -102,8 +103,8 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     public func watch() async throws {
-        // Note that watching is started in ChatClient+Chat when channel updater's update is called.
         try await channelUpdater.startWatching(cid: cid, isInRecoveryMode: false)
+        client.syncRepository.startTrackingChat(self)
     }
     
     /// Stop watching the channel which disables server-side events.
@@ -113,6 +114,7 @@ public class Chat {
     /// - Throws: An error while communicating with the Stream API.
     public func stopWatching() async throws {
         try await channelUpdater.stopWatching(cid: cid)
+        client.syncRepository.stopTrackingChat(self)
     }
     
     // MARK: - Deleting the Channel

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -35,9 +35,7 @@ extension ChatClient {
         with query: ChannelListQuery,
         dynamicFilter: ((ChatChannel) -> Bool)? = nil
     ) -> ChannelList {
-        let channelList = ChannelList(query: query, dynamicFilter: dynamicFilter, client: self)
-        syncRepository.trackChannelListQuery { [weak channelList] in channelList?.query }
-        return channelList
+        ChannelList(query: query, dynamicFilter: dynamicFilter, client: self)
     }
 }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ChatChannelListController_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ChatChannelListController_Mock.swift
@@ -10,6 +10,7 @@ public class ChatChannelListController_Mock: ChatChannelListController, Spy {
     public var loadNextChannelsIsCalled = false
     public var loadNextChannelsCallCount = 0
     public var resetChannelsQueryResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>?
+    public var refreshLoadedChannelsResult: Result<Set<ChannelId>, any Error>?
 
     /// Creates a new mock instance of `ChatChannelListController`.
     public static func mock(client: ChatClient? = nil) -> ChatChannelListController_Mock {
@@ -32,6 +33,11 @@ public class ChatChannelListController_Mock: ChatChannelListController, Spy {
         loadNextChannelsIsCalled = true
     }
 
+    override public func refreshLoadedChannels(completion: @escaping (Result<Set<ChannelId>, any Error>) -> Void) {
+        record()
+        refreshLoadedChannelsResult.map(completion)
+    }
+    
     override public func resetQuery(
         watchedAndSynchedChannelIds: Set<ChannelId>,
         synchedChannelIds: Set<ChannelId>,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
@@ -17,8 +17,6 @@ final class SyncRepository_Mock: SyncRepository, Spy {
         let apiClient = APIClient_Spy()
         let database = DatabaseContainer_Spy()
         self.init(config: .init(apiKeyString: ""),
-                  activeChannelControllers: ThreadSafeWeakCollection<ChatChannelController>(),
-                  activeChannelListControllers: ThreadSafeWeakCollection<ChatChannelListController>(),
                   offlineRequestsRepository: OfflineRequestsRepository_Mock(),
                   eventNotificationCenter: EventNotificationCenter_Mock(database: database),
                   database: database,
@@ -26,8 +24,22 @@ final class SyncRepository_Mock: SyncRepository, Spy {
                   channelListUpdater: ChannelListUpdater_Spy(database: database, apiClient: apiClient))
     }
 
-    override init(config: ChatClientConfig, activeChannelControllers: ThreadSafeWeakCollection<ChatChannelController>, activeChannelListControllers: ThreadSafeWeakCollection<ChatChannelListController>, offlineRequestsRepository: OfflineRequestsRepository, eventNotificationCenter: EventNotificationCenter, database: DatabaseContainer, apiClient: APIClient, channelListUpdater: ChannelListUpdater) {
-        super.init(config: config, activeChannelControllers: activeChannelControllers, activeChannelListControllers: activeChannelListControllers, offlineRequestsRepository: offlineRequestsRepository, eventNotificationCenter: eventNotificationCenter, database: database, apiClient: apiClient, channelListUpdater: channelListUpdater)
+    override init(
+        config: ChatClientConfig,
+        offlineRequestsRepository: OfflineRequestsRepository,
+        eventNotificationCenter: EventNotificationCenter,
+        database: DatabaseContainer,
+        apiClient: APIClient,
+        channelListUpdater: ChannelListUpdater
+    ) {
+        super.init(
+            config: config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater
+        )
     }
 
     override func syncLocalState(completion: @escaping () -> Void) {

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -183,6 +183,7 @@ final class APIClient_Spy: APIClient, Spy {
     @discardableResult
     func waitForRecoveryRequest(timeout: Double = defaultTimeout) -> AnyEndpoint? {
         XCTWaiter().wait(for: [recoveryRequest_expectation], timeout: timeout)
+        recoveryRequest_expectation = XCTestExpectation()
         return recoveryRequest_endpoint
     }
 

--- a/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
@@ -118,6 +118,7 @@ extension XCTestCase {
 
     func dummyPayload(
         with channelId: ChannelId,
+        name: String = .unique,
         numberOfMessages: Int = 1,
         members: [MemberPayload] = [.unique],
         watchers: [UserPayload]? = nil,
@@ -170,7 +171,7 @@ extension XCTestCase {
             .init(
                 channel: .init(
                     cid: channelId,
-                    name: .unique,
+                    name: name,
                     imageURL: .unique(),
                     extraData: channelExtraData,
                     typeRawValue: channelId.type.rawValue,

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -307,11 +307,11 @@ final class ChatClient_Tests: XCTestCase {
         )
         let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
         connectionRepository.disconnectResult = .success(())
-        client.startTrackingChannelController(ChannelControllerSpy())
-        client.startTrackingChannelListController(ChatChannelListController_Mock.mock())
+        client.syncRepository.startTrackingChannelController(ChannelControllerSpy())
+        client.syncRepository.startTrackingChannelListController(ChatChannelListController_Mock.mock())
 
-        XCTAssertEqual(client.activeChannelControllers.count, 1)
-        XCTAssertEqual(client.activeChannelListControllers.count, 1)
+        XCTAssertEqual(client.syncRepository.activeChannelControllers.count, 1)
+        XCTAssertEqual(client.syncRepository.activeChannelListControllers.count, 1)
 
         // WHEN
         let expectation = self.expectation(description: "logout completes")
@@ -321,8 +321,8 @@ final class ChatClient_Tests: XCTestCase {
         waitForExpectations(timeout: defaultTimeout)
 
         // THEN
-        XCTAssertEqual(client.activeChannelControllers.count, 0)
-        XCTAssertEqual(client.activeChannelListControllers.count, 0)
+        XCTAssertEqual(client.syncRepository.activeChannelControllers.count, 0)
+        XCTAssertEqual(client.syncRepository.activeChannelListControllers.count, 0)
     }
 
     func test_apiClient_usesInjectedURLSessionConfiguration() {
@@ -823,70 +823,6 @@ final class ChatClient_Tests: XCTestCase {
         }
 
         XCTAssertEqual(streamHeader, SystemEnvironment.xStreamClientHeader)
-    }
-
-    // MARK: - Active Controller
-
-    func test_startTrackingChannelController() {
-        let client = ChatClient(config: .init())
-
-        let controller = ChatChannelController_Mock.mock()
-        client.startTrackingChannelController(controller)
-
-        XCTAssertTrue(client.activeChannelControllers.allObjects.first === controller)
-    }
-
-    func test_startTrackingChannelController_whenAlreadyExists_thenDoNotDuplicate() {
-        let client = ChatClient(config: .init())
-
-        let controller = ChatChannelController_Mock.mock()
-        client.startTrackingChannelController(controller)
-        client.startTrackingChannelController(controller)
-
-        XCTAssertTrue(client.activeChannelControllers.allObjects.first === controller)
-        XCTAssertEqual(client.activeChannelControllers.allObjects.count, 1)
-    }
-
-    func test_stopTrackingChannelController() {
-        let client = ChatClient(config: .init())
-        let controller = ChatChannelController_Mock.mock()
-        client.startTrackingChannelController(controller)
-        XCTAssertEqual(client.activeChannelControllers.allObjects.count, 1)
-
-        client.stopTrackingChannelController(controller)
-
-        XCTAssertTrue(client.activeChannelControllers.allObjects.isEmpty)
-    }
-
-    func test_startTrackingChannelListController() {
-        let client = ChatClient(config: .init())
-
-        let controller = ChatChannelListController_Mock.mock()
-        client.startTrackingChannelListController(controller)
-
-        XCTAssertTrue(client.activeChannelListControllers.allObjects.first === controller)
-    }
-
-    func test_startTrackingChannelListController_whenAlreadyExists_thenDoNotDuplicate() {
-        let client = ChatClient(config: .init())
-
-        let controller = ChatChannelListController_Mock.mock()
-        client.startTrackingChannelListController(controller)
-        client.startTrackingChannelListController(controller)
-
-        XCTAssertTrue(client.activeChannelListControllers.allObjects.first === controller)
-        XCTAssertEqual(client.activeChannelListControllers.allObjects.count, 1)
-    }
-
-    func test_stopTrackingChannelListController() {
-        let client = ChatClient(config: .init())
-        let controller = ChatChannelListController_Mock.mock()
-        client.startTrackingChannelListController(controller)
-        XCTAssertEqual(client.activeChannelListControllers.allObjects.count, 1)
-
-        client.stopTrackingChannelListController(controller)
-
-        XCTAssertTrue(client.activeChannelListControllers.allObjects.isEmpty)
     }
 }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -4597,12 +4597,12 @@ final class ChannelController_Tests: XCTestCase {
             channelListQuery: channelListQuery,
             client: client
         )
-        XCTAssert(client.activeChannelControllers.allObjects.isEmpty)
+        XCTAssert(client.syncRepository.activeChannelControllers.allObjects.isEmpty)
 
         controller.startWatching(isInRecoveryMode: false)
         XCTAssert(controller.client === client)
-        XCTAssert(client.activeChannelControllers.count == 1)
-        XCTAssert(client.activeChannelControllers.allObjects.first === controller)
+        XCTAssert(client.syncRepository.activeChannelControllers.count == 1)
+        XCTAssert(client.syncRepository.activeChannelControllers.allObjects.first === controller)
     }
 
     func test_startWatching_propagatesErrorFromUpdater() {
@@ -4783,10 +4783,10 @@ final class ChannelController_Tests: XCTestCase {
             client: client
         )
         controller.synchronize()
-        XCTAssert(client.activeChannelControllers.count == 1)
+        XCTAssert(client.syncRepository.activeChannelControllers.count == 1)
 
         controller.stopWatching()
-        XCTAssert(client.activeChannelControllers.allObjects.isEmpty == true)
+        XCTAssert(client.syncRepository.activeChannelControllers.allObjects.isEmpty == true)
     }
 
     // MARK: - Freeze channel
@@ -5137,8 +5137,8 @@ final class ChannelController_Tests: XCTestCase {
         controller.synchronize()
 
         XCTAssert(controller.client === client)
-        XCTAssert(client.activeChannelControllers.count == 1)
-        XCTAssert(client.activeChannelControllers.allObjects.first === controller)
+        XCTAssert(client.syncRepository.activeChannelControllers.count == 1)
+        XCTAssert(client.syncRepository.activeChannelControllers.allObjects.first === controller)
     }
 
     // MARK: shouldSendTypingEvents

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1014,8 +1014,8 @@ final class ChannelListController_Tests: XCTestCase {
         controller.synchronize()
 
         XCTAssert(controller.client === client)
-        XCTAssert(client.activeChannelListControllers.count == 1)
-        XCTAssert(client.activeChannelListControllers.allObjects.first === controller)
+        XCTAssert(client.syncRepository.activeChannelListControllers.count == 1)
+        XCTAssert(client.syncRepository.activeChannelListControllers.allObjects.first === controller)
     }
 
     // MARK: Predicates

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -80,7 +80,7 @@ final class SyncOperations_Tests: XCTestCase {
         try database.writeSynchronously { session in
             session.currentUser?.lastSynchedEventDate = originalDate.bridgeDate
         }
-        let operation = SyncEventsOperation(syncRepository: syncRepository, context: context)
+        let operation = SyncEventsOperation(syncRepository: syncRepository, context: context, recovery: false)
         syncRepository.syncMissingEventsResult = .failure(.syncEndpointFailed(ClientError("")))
 
         operation.startAndWaitForCompletion()
@@ -101,7 +101,7 @@ final class SyncOperations_Tests: XCTestCase {
             session.currentUser?.lastSynchedEventDate = DBDate().addingTimeInterval(-3600)
         }
 
-        let operation = SyncEventsOperation(syncRepository: syncRepository, context: context)
+        let operation = SyncEventsOperation(syncRepository: syncRepository, context: context, recovery: false)
         syncRepository.syncMissingEventsResult = .success([.unique, .unique])
 
         operation.startAndWaitForCompletion()

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -6,9 +6,14 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class SyncRepository_Tests: XCTestCase {
-    var _activeChannelControllers: ThreadSafeWeakCollection<ChatChannelController>!
-    var _activeChannelListControllers: ThreadSafeWeakCollection<ChatChannelListController>!
+class SyncRepositoryV2_Tests: SyncRepository_Tests {
+    override func setUp() {
+        super.setUp()
+        repository.usesV2Sync = true
+    }
+}
+
+class SyncRepository_Tests: XCTestCase {
     var client: ChatClient_Mock!
     var offlineRequestsRepository: OfflineRequestsRepository_Mock!
     var database: DatabaseContainer_Spy!
@@ -24,8 +29,6 @@ final class SyncRepository_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        _activeChannelControllers = ThreadSafeWeakCollection<ChatChannelController>()
-        _activeChannelListControllers = ThreadSafeWeakCollection<ChatChannelListController>()
         var config = ChatClientConfig(apiKeyString: .unique)
         config.isLocalStorageEnabled = true
         client = ChatClient_Mock(config: config)
@@ -41,20 +44,17 @@ final class SyncRepository_Tests: XCTestCase {
 
         repository = SyncRepository(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: client.eventNotificationCenter,
             database: database,
             apiClient: apiClient,
             channelListUpdater: channelListUpdater
         )
+        repository.usesV2Sync = false
     }
 
     override func tearDown() {
         super.tearDown()
-        _activeChannelControllers = nil
-        _activeChannelListControllers = nil
         client.cleanUp()
         client = nil
         offlineRequestsRepository.clear()
@@ -93,8 +93,6 @@ final class SyncRepository_Tests: XCTestCase {
         let client = ChatClient_Mock(config: config)
         repository = SyncRepository(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -127,8 +125,6 @@ final class SyncRepository_Tests: XCTestCase {
         let client = ChatClient_Mock(config: config)
         repository = SyncRepository(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -171,6 +167,8 @@ final class SyncRepository_Tests: XCTestCase {
     }
 
     func test_syncLocalState_localStorageEnabled_pendingConnectionDate_channels() throws {
+        try XCTSkipIf(repository.usesV2Sync, "V2 only syncs if there are active controllers")
+        
         let channelId = ChannelId.unique
         try prepareForSyncLocalStorage(
             createUser: true,
@@ -206,7 +204,7 @@ final class SyncRepository_Tests: XCTestCase {
 
         let chatController = ChatChannelController_Spy(client: client)
         chatController.state = .remoteDataFetched
-        _activeChannelControllers.add(chatController)
+        repository.startTrackingChannelController(chatController)
 
         let eventDate = Date.unique
         waitForSyncLocalStateRun(requestResult: .success(messageEventPayload(cid: cid, with: [eventDate])))
@@ -216,10 +214,17 @@ final class SyncRepository_Tests: XCTestCase {
         // Write: API Response, lastSyncAt
         XCTAssertEqual(database.writeSessionCounter, 2)
         XCTAssertEqual(repository.activeChannelControllers.count, 1)
-        XCTAssertCall("recoverWatchedChannel(completion:)", on: chatController, times: 1)
+        if !repository.usesV2Sync {
+            XCTAssertCall("recoverWatchedChannel(completion:)", on: chatController, times: 1)
+        }
         XCTAssertEqual(repository.activeChannelListControllers.count, 0)
-        XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 1)
-        XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
+        if repository.usesV2Sync {
+            XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 0)
+            XCTAssertEqual(apiClient.request_allRecordedCalls.count, 1)
+        } else {
+            XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 1)
+            XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
+        }
         XCTAssertCall("runQueuedRequests(completion:)", on: offlineRequestsRepository, times: 1)
     }
 
@@ -234,8 +239,13 @@ final class SyncRepository_Tests: XCTestCase {
 
         let chatListController = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
         chatListController.state = .remoteDataFetched
-        _activeChannelListControllers.add(chatListController)
-        chatListController.resetChannelsQueryResult = .success(([], []))
+        chatListController.channels_mock = [.mock(cid: cid)]
+        repository.startTrackingChannelListController(chatListController)
+        if repository.usesV2Sync {
+            chatListController.refreshLoadedChannelsResult = .success(Set())
+        } else {
+            chatListController.resetChannelsQueryResult = .success(([], []))
+        }
 
         let eventDate = Date.unique
         waitForSyncLocalStateRun(requestResult: .success(messageEventPayload(cid: cid, with: [eventDate])))
@@ -246,17 +256,28 @@ final class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(database.writeSessionCounter, 2)
         XCTAssertEqual(repository.activeChannelControllers.count, 0)
         XCTAssertEqual(repository.activeChannelListControllers.count, 1)
-        XCTAssertCall(
-            "resetQuery(watchedAndSynchedChannelIds:synchedChannelIds:completion:)", on: chatListController,
-            times: 1
-        )
-        XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 1)
-        XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
+        if repository.usesV2Sync {
+            // refresh can only happen when /sync fails
+            XCTAssertNotCall(
+                "refreshLoadedChannels(completion:)", on: chatListController
+            )
+            XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 0)
+            XCTAssertEqual(apiClient.request_allRecordedCalls.count, 1)
+        } else {
+            XCTAssertCall(
+                "resetQuery(watchedAndSynchedChannelIds:synchedChannelIds:completion:)", on: chatListController,
+                times: 1
+            )
+            XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 1)
+            XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
+        }
         XCTAssertCall("runQueuedRequests(completion:)", on: offlineRequestsRepository, times: 1)
     }
 
     func test_syncLocalState_localStorageEnabled_pendingConnectionDate_channels_activeRemoteChannelListController_unwantedChannels(
     ) throws {
+        try XCTSkipIf(repository.usesV2Sync, "V2 does not handle unwanted channels")
+
         let cid = ChannelId.unique
         try prepareForSyncLocalStorage(
             createUser: true,
@@ -267,7 +288,7 @@ final class SyncRepository_Tests: XCTestCase {
 
         let chatListController = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
         chatListController.state = .remoteDataFetched
-        _activeChannelListControllers.add(chatListController)
+        repository.startTrackingChannelListController(chatListController)
         let unwantedId = ChannelId.unique
         chatListController.resetChannelsQueryResult = .success(([], [unwantedId]))
 
@@ -298,6 +319,14 @@ final class SyncRepository_Tests: XCTestCase {
             createChannel: true,
             cid: cid
         )
+        
+        // At least one active controller is needed for sync to happen
+        let chatListController = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
+        if repository.usesV2Sync {
+            chatListController.state = .remoteDataFetched
+            chatListController.channels_mock = [.mock(cid: cid)]
+            repository.startTrackingChannelListController(chatListController)
+        }
 
         let firstDate = lastSyncDate.addingTimeInterval(1)
         let secondDate = lastSyncDate.addingTimeInterval(2)
@@ -311,6 +340,8 @@ final class SyncRepository_Tests: XCTestCase {
         waitForSyncLocalStateRun(requestResult: .success(eventsPayload2))
 
         XCTAssertNearlySameDate(lastSyncAtValue, thirdDate)
+        
+        repository.stopTrackingChannelListController(chatListController)
     }
 
     // MARK: - Sync existing channels events
@@ -533,8 +564,6 @@ final class SyncRepository_Tests: XCTestCase {
         let client = ChatClient_Mock(config: config)
         repository = SyncRepository(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -561,8 +590,6 @@ final class SyncRepository_Tests: XCTestCase {
         let client = ChatClient_Mock(config: config)
         repository = SyncRepository(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -600,8 +627,6 @@ final class SyncRepository_Tests: XCTestCase {
         // GIVEN
         let mock = CancelRecoveryFlowTracker(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -625,8 +650,6 @@ final class SyncRepository_Tests: XCTestCase {
         // GIVEN
         var mock: CancelRecoveryFlowTracker? = .init(
             config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -658,12 +681,12 @@ final class SyncRepository_Tests: XCTestCase {
         let channelQuery = ChannelQuery(cid: .unique)
         let channelController = ChatChannelController(channelQuery: channelQuery, channelListQuery: nil, client: client)
         channelController.state = .remoteDataFetched
-        _activeChannelControllers.add(channelController)
+        repository.startTrackingChannelController(channelController)
 
         // Add active channel list component
         let channelListController = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
         channelListController.state = .remoteDataFetched
-        _activeChannelListControllers.add(channelListController)
+        repository.startTrackingChannelListController(channelListController)
 
         // Sync local state
         var completionCalled = false
@@ -672,7 +695,11 @@ final class SyncRepository_Tests: XCTestCase {
         }
 
         // Wait for /sync to be called
-        AssertAsync.willBeTrue(apiClient.recoveryRequest_completion != nil)
+        if repository.usesV2Sync {
+            apiClient.waitForRequest()
+        } else {
+            apiClient.waitForRecoveryRequest()
+        }
 
         // Let /sync operation to complete
         let syncResponse = Result<MissingEventsPayload, Error>.success(.init(eventPayloads: []))
@@ -680,7 +707,9 @@ final class SyncRepository_Tests: XCTestCase {
         apiClient.recoveryRequest_completion = nil
 
         // Wait for watch operation
-        AssertAsync.willBeTrue(apiClient.recoveryRequest_completion != nil)
+        if !repository.usesV2Sync {
+            AssertAsync.willBeTrue(apiClient.recoveryRequest_completion != nil)
+        }
 
         // Cancel recovery flow
         repository.cancelRecoveryFlow()
@@ -694,6 +723,60 @@ final class SyncRepository_Tests: XCTestCase {
             Assert.staysTrue(channelListController.recordedFunctions.isEmpty)
             Assert.staysFalse(completionCalled)
         }
+    }
+    
+    // MARK: - Tracking
+
+    func test_startTrackingChannelController() {
+        let controller = ChatChannelController_Mock.mock()
+        repository.startTrackingChannelController(controller)
+
+        XCTAssertTrue(repository.activeChannelControllers.allObjects.first === controller)
+    }
+
+    func test_startTrackingChannelController_whenAlreadyExists_thenDoNotDuplicate() {
+        let controller = ChatChannelController_Mock.mock()
+        repository.startTrackingChannelController(controller)
+        repository.startTrackingChannelController(controller)
+
+        XCTAssertTrue(repository.activeChannelControllers.allObjects.first === controller)
+        XCTAssertEqual(repository.activeChannelControllers.allObjects.count, 1)
+    }
+
+    func test_stopTrackingChannelController() {
+        let controller = ChatChannelController_Mock.mock()
+        repository.startTrackingChannelController(controller)
+        XCTAssertEqual(repository.activeChannelControllers.allObjects.count, 1)
+
+        repository.stopTrackingChannelController(controller)
+
+        XCTAssertTrue(repository.activeChannelControllers.allObjects.isEmpty)
+    }
+
+    func test_startTrackingChannelListController() {
+        let controller = ChatChannelListController_Mock.mock()
+        repository.startTrackingChannelListController(controller)
+
+        XCTAssertTrue(repository.activeChannelListControllers.allObjects.first === controller)
+    }
+
+    func test_startTrackingChannelListController_whenAlreadyExists_thenDoNotDuplicate() {
+        let controller = ChatChannelListController_Mock.mock()
+        repository.startTrackingChannelListController(controller)
+        repository.startTrackingChannelListController(controller)
+
+        XCTAssertTrue(repository.activeChannelListControllers.allObjects.first === controller)
+        XCTAssertEqual(repository.activeChannelListControllers.allObjects.count, 1)
+    }
+
+    func test_stopTrackingChannelListController() {
+        let controller = ChatChannelListController_Mock.mock()
+        repository.startTrackingChannelListController(controller)
+        XCTAssertEqual(repository.activeChannelListControllers.allObjects.count, 1)
+
+        repository.stopTrackingChannelListController(controller)
+
+        XCTAssertTrue(repository.activeChannelListControllers.allObjects.isEmpty)
     }
 }
 
@@ -741,21 +824,32 @@ extension SyncRepository_Tests {
             expectation.fulfill()
         }
 
-        AssertAsync.willBeTrue(
-            "enterRecoveryMode()".wasCalled(on: apiClient, times: 1)
-        )
+        if !repository.usesV2Sync {
+            AssertAsync.willBeTrue(
+                "enterRecoveryMode()".wasCalled(on: apiClient, times: 1)
+            )
+        }
 
         if let result = requestResult {
             // Simulate API Failure
-            AssertAsync.willBeTrue(apiClient.recoveryRequest_completion != nil)
-            guard let callback = apiClient.recoveryRequest_completion as? (Result<MissingEventsPayload, Error>) -> Void else {
-                XCTFail("A request for /sync should have been executed")
-                return
+            if repository.usesV2Sync {
+                apiClient.waitForRequest()
+                guard let callback = apiClient.request_completion as? (Result<MissingEventsPayload, Error>) -> Void else {
+                    XCTFail("A request for /sync should have been executed")
+                    return
+                }
+                callback(result)
+            } else {
+                apiClient.waitForRecoveryRequest()
+                guard let callback = apiClient.recoveryRequest_completion as? (Result<MissingEventsPayload, Error>) -> Void else {
+                    XCTFail("A request for /sync should have been executed")
+                    return
+                }
+                callback(result)
             }
-            callback(result)
         }
 
-        waitForExpectations(timeout: 10000, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
         XCTAssertCall("exitRecoveryMode()", on: apiClient)
     }
 

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -793,7 +793,7 @@ extension SyncRepository_Tests {
         })
     }
 
-    private func prepareForSyncLocalStorage(
+    func prepareForSyncLocalStorage(
         createUser: Bool,
         lastSynchedEventDate: Date?,
         createChannel: Bool,
@@ -815,7 +815,7 @@ extension SyncRepository_Tests {
         database.writeSessionCounter = 0
     }
 
-    private func waitForSyncLocalStateRun(requestResult: Result<MissingEventsPayload, Error>? = nil) {
+    func waitForSyncLocalStateRun(requestResult: Result<MissingEventsPayload, Error>? = nil) {
         database.writeSessionCounter = 0
         apiClient.clear()
 

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -257,9 +257,9 @@ class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.activeChannelControllers.count, 0)
         XCTAssertEqual(repository.activeChannelListControllers.count, 1)
         if repository.usesV2Sync {
-            // refresh can only happen when /sync fails
-            XCTAssertNotCall(
-                "refreshLoadedChannels(completion:)", on: chatListController
+            XCTAssertCall(
+                "refreshLoadedChannels(completion:)", on: chatListController,
+                times: 1
             )
             XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 0)
             XCTAssertEqual(apiClient.request_allRecordedCalls.count, 1)
@@ -326,6 +326,8 @@ class SyncRepository_Tests: XCTestCase {
             chatListController.state = .remoteDataFetched
             chatListController.channels_mock = [.mock(cid: cid)]
             repository.startTrackingChannelListController(chatListController)
+            
+            chatListController.refreshLoadedChannelsResult = .success(Set([cid]))
         }
 
         let firstDate = lastSyncDate.addingTimeInterval(1)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-4293](https://stream-io.atlassian.net/browse/PBE-4293)

Resolves [stream-chat-swift/issues/2021](https://github.com/GetStream/stream-chat-swift/issues/2021)

### 🎯 Goal

Allow regular API calls to be made while offline sync is running which gives quicker UI updates when UI update requires API call to finish.

### 📝 Summary

- Add a sync v2 implementation controllable with a `StreamRuntimeCheck._isSyncV2Enabled`

### 🛠 Implementation

Adds a new version of the offline state sync which only pauses regular API requests when handling automatic retries. The sync is more lightweight and only syncs currently active channels (active = server state has been requested in this session aka calling synchronize). If sync is not possible (too many events), then data is fully refreshed for active channel lists (same as synchronize but not resetting to the first page). 

#### Improvements
- Does not block other API requests if sync takes a bit of time (in debug and up-to-date data it runs <0.5 seconds)
- Less data exchanges as it only syncs active channels (for other channels we use controller synchronize or get methods anyway)

#### Notes
- These changes do not touch the code (direct call to `syncExistingChannelsEvents`) which is triggered by the `ChatRemoteNotificationHandler`. This code path triggers the `request.fetchLimit = 100` case which the regular sync actually does not. We should look this in a separate task.
- I kept refreshing channel lists in V2 because UI-tests were relying on these (and probably some other hidden cases as well). Could be changed in next iterations.

#### Summary of the V2 mode
*Recovery mode (pauses regular API requests while it is running)*
1. Enter recovery
2. Runs offline API requests
3. Exit recovery

*Background mode (other regular API requests are allowed to run at the same time)*
1. Collect all the **active** channel ids (from instances of `Chat`, `ChannelList`, `ChatChannelController`, `ChatChannelListController`)
2. Ask updates from the /sync endpoint for these channels
2.a Apply changes
2.b When there are too many events, just refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)

#### Comparison

| Description | V1 | V2 |
|--------|--------|--------|
| Channel list sync | All in the local storage | Only active channel lists |
| Resets channel list to the first page | Yes, always | No, refreshes currently loaded channels, UI does not just when data changes |
| Always starts watching channels | Yes | No |
| Deletes channels | Yes, when reseting channel list and channel not referenced by active instances | No |
| Blocks regular API requests | Yes | Only when retrying offline requests, otherwise no | 

### 🧪 Manual Testing Notes

#### Case 1: Channel list updates
1. Log in, go offline
2. Other user triggers channel list updates (sends new messages etc)
3. Come back online, channel list updates

#### Case 2: Sending messages while offline
1. Log in, go offline
2. Send some messages, edit some, add reactions etc
3. Come back online, messages are sent and edits are visible for other participants

#### Case 3: Not resetting channel list (https://github.com/GetStream/stream-chat-swift/issues/2021)
1. Log in
2. Scroll down in the channel list to load multiple pages
3. Go offline
4. Trigger updates using a different account (for verifying that channel list updates when coming back online)
5. Come back online. Channel list does not reset to the first page.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-4293]: https://stream-io.atlassian.net/browse/PBE-4293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ