### PR TITLE
High CPU usage while typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ⚡ Performance
 - Use background database observers for `CurrentUserController.currentUser`, `ChatChannelMemberListController.members`, and `ChatMessageController.message` which reduces CPU usage on the main thread [#3357](https://github.com/GetStream/stream-chat-swift/pull/3357)
+- `CurrentChatUserController` was often recreated when sending typing events [#3372](https://github.com/GetStream/stream-chat-swift/pull/3372)
 ### 🐞 Fixed
 - Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
 - Fix rare crashes in `MulticastDelegate` when accessing it concurrently [#3361](https://github.com/GetStream/stream-chat-swift/pull/3361)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -51,6 +51,9 @@ public class ChatClient {
 
     /// The notification center used to send and receive notifications about incoming events.
     private(set) var eventNotificationCenter: EventNotificationCenter
+    
+    private var _sharedCurrentUserController: CurrentChatUserController?
+    private let queue = DispatchQueue(label: "io.getstream.chat-client")
 
     /// The registry that contains all the attachment payloads associated with their attachment types.
     /// For the meantime this is a static property to avoid breaking changes. On v5, this can be changed.
@@ -461,6 +464,7 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers and removes all the local data related.
     public func logout(completion: @escaping () -> Void) {
         authenticationRepository.logOutUser()
+        resetSharedCurrentUserController()
 
         // Stop tracking active components
         syncRepository.removeAllTracked()
@@ -596,6 +600,24 @@ public class ChatClient {
     private func refreshToken(completion: ((Error?) -> Void)?) {
         authenticationRepository.refreshToken {
             completion?($0)
+        }
+    }
+    
+    /// A shared user controller for an easy access to the current user.
+    var sharedCurrentUserController: CurrentChatUserController {
+        queue.sync {
+            if let controller = _sharedCurrentUserController {
+                return controller
+            }
+            let controller = currentUserController()
+            _sharedCurrentUserController = controller
+            return controller
+        }
+    }
+    
+    func resetSharedCurrentUserController() {
+        queue.async {
+            self._sharedCurrentUserController = nil
         }
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -147,7 +147,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// It is `true` if the channel typing events are enabled as well as the user privacy settings.
     internal var shouldSendTypingEvents: Bool {
         /// Ignore if user typing indicators privacy settings are disabled. By default, they are enabled.
-        let currentUserPrivacySettings = client.currentUserController().currentUser?.privacySettings
+        let currentUserPrivacySettings = client.sharedCurrentUserController.currentUser?.privacySettings
         let isTypingIndicatorsForCurrentUserEnabled = currentUserPrivacySettings?.typingIndicators?.enabled ?? true
         let isChannelTypingEventsEnabled = channel?.canSendTypingEvents ?? true
         return isTypingIndicatorsForCurrentUserEnabled && isChannelTypingEventsEnabled

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -99,6 +99,8 @@ final class ChatClient_Mock: ChatClient {
     // MARK: - Clean Up
 
     func cleanUp() {
+        resetSharedCurrentUserController()
+        
         (apiClient as? APIClient_Spy)?.cleanUp()
 
         fetchCurrentUserIdFromDatabase_called = false

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -36,6 +36,7 @@ final class ChannelController_Tests: XCTestCase {
     }
 
     override func tearDown() {
+        client?.cleanUp()
         env?.channelUpdater?.cleanUp()
         env?.eventSender?.cleanUp()
         env = nil


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-5497](https://stream-io.atlassian.net/browse/PBE-5497)

### 🎯 Goal

Reduce CPU usage caused by recreating `CurrentChatUserController` when sending typing events

### 📝 Summary

* Add `ChatClient.UserSession` for reusing objects from connect to logout
* User the shared `CurrentChatUserController` for reading privacy settings 

### 🛠 Implementation

We check if we should send typing events using an internal property in the `ChatChannelController` which created a new instance of the `CurrentChatUserController`. This is called often when typing to a channel. This led to high CPU usage because controller is created and the local database is read on every character change. If the current user has, for example, a lot of muted channels, then recreating `CurrentChatUser` gets really expensive.
```swift
internal var shouldSendTypingEvents: Bool {
  let currentUserPrivacySettings = client.currentUserController().currentUser?.privacySettings
  …
}      
```

### 🎨 Showcase

iPhone 12 Pro Max (low power mode was on)
An account with 10 muted channels (important). I used Chewbacca.
1. Open a channel
2. Type 10 characters 
3. Investigate main thread usage, especially `shouldSendTypingEvents`

| Before | After |
| ------ | ----- |
| 666 ms | 56 ms |
| ------ | ----- |
|  <img width="1074" alt="Before" src="https://github.com/user-attachments/assets/09842f99-51e5-4395-b411-5684d2f8aa34">   |  <img width="1053" alt="After" src="https://github.com/user-attachments/assets/4d5e1891-97c6-42c6-8c76-a133f17baccc">  |

`shouldSendTypingEvents` does not spend ~66 ms per character change just for checking this property. Instead, there is a single ~56 ms cost once (or almost none if the shared controller had been already created. Currently it is created on demand.)

### 🧪 Manual Testing Notes

- Try typing events and make sure these appear as expected.
- Log in and log out, trigger more typing events

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5497]: https://stream-io.atlassian.net/browse/PBE-5497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ