### PR TITLE
Fix reading the local database state just after the initial write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ⚡ Performance
 - Use background database observers for `CurrentUserController.currentUser`, `ChatChannelMemberListController.members`, and `ChatMessageController.message` which reduces CPU usage on the main thread [#3357](https://github.com/GetStream/stream-chat-swift/pull/3357)
 - `CurrentChatUserController` was often recreated when sending typing events [#3372](https://github.com/GetStream/stream-chat-swift/pull/3372)
+- Reduce latency of the `BackgroundDatabaseObserver` by reducing thread switching when handling changes [#3373](https://github.com/GetStream/stream-chat-swift/pull/3373)
 ### 🐞 Fixed
 - Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
 - Fix rare crashes in `MulticastDelegate` when accessing it concurrently [#3361](https://github.com/GetStream/stream-chat-swift/pull/3361)
+- Fix reading the local database state just after the initial write [#3373](https://github.com/GetStream/stream-chat-swift/pull/3373)
 ### 🔄 Changed
 - Made loadBlockedUsers in ConnectedUser public [#3352](https://github.com/GetStream/stream-chat-swift/pull/3352)
 - Removed Agora and 100ms related code, the recommended way to support calls is to use StreamVideo [#3364](https://github.com/GetStream/stream-chat-swift/pull/3364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
 - Fix rare crashes in `MulticastDelegate` when accessing it concurrently [#3361](https://github.com/GetStream/stream-chat-swift/pull/3361)
 - Fix reading the local database state just after the initial write [#3373](https://github.com/GetStream/stream-chat-swift/pull/3373)
+- Fix a timing issue where accessing channels in `controllerWillChangeChannels` returned already changed channels [#3373](https://github.com/GetStream/stream-chat-swift/pull/3373)
 ### 🔄 Changed
 - Made loadBlockedUsers in ConnectedUser public [#3352](https://github.com/GetStream/stream-chat-swift/pull/3352)
 - Removed Agora and 100ms related code, the recommended way to support calls is to use StreamVideo [#3364](https://github.com/GetStream/stream-chat-swift/pull/3364)

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -105,7 +105,7 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
             guard let self else { return }
             // Runs on the NSManagedObjectContext's queue, therefore skip performAndWait
             self.updateItems(changes)
-            notifyDidChange(changes: changes)
+            self.notifyDidChange(changes: changes)
         }
     }
 

--- a/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
+++ b/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
@@ -27,7 +27,7 @@ enum DatabaseItemConverter {
         let items: [Item]
         
         // Reuse converted items by id
-        if StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled, let itemReuseKeyPaths, !existing.isEmpty {
+        if StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled, let itemReuseKeyPaths {
             let existingItems = existing.map { ($0[keyPath: itemReuseKeyPaths.item], $0) }
             var lookup = Dictionary(existingItems, uniquingKeysWith: { _, second in second })
             // Changes contains newly converted items, add them to the lookup

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -29,7 +29,6 @@
         "AttachmentQueueUploader_Tests\/test_uploader_whenPostProcessorAvailable_shouldChangeTheAttachmentPayload()",
         "AttachmentQueueUploader_Tests\/test_uploader_whenUploadFails_markMessageAsFailed()",
         "ChannelController_Tests\/test_createCall_propagatesResultFromUpdater()",
-        "ChannelListController_Tests\/test_willAndDidCallbacks_areCalledInCorrectOrder()",
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_empty()",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -43,7 +43,6 @@
         "AttachmentQueueUploader_Tests\/test_uploader_whenPostProcessorAvailable_shouldChangeTheAttachmentPayload()",
         "AttachmentQueueUploader_Tests\/test_uploader_whenUploadFails_markMessageAsFailed()",
         "ChannelController_Tests\/test_createCall_propagatesResultFromUpdater()",
-        "ChannelListController_Tests\/test_willAndDidCallbacks_areCalledInCorrectOrder()",
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_empty()",


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-5519](https://stream-io.atlassian.net/browse/PBE-5519)

### 🎯 Goal

- Enable reading the local database state within `synchronize()`'s completion block when the initial DB state was empty

### 📝 Summary

- Remove the additional `OperationQueue` from the `BackgroundDatabaseObserver` (less latency)
- Process DB changes immediately on the managed context queue (less latency)
- Fix an issue where the initial observer state was set to empty although data was just written to the DB
- Fix a timing issue with will change callback what returned changed data (timing related)

### 🛠 Implementation

`BackgroundDatabaseObserver` tries to load the initial state as soon as observing starts using a background thread (less blocking of the main thread). Since it is an async operation, there is a data race between loading the initial state and the managed object context changing at the same time. For avoiding it, the observer keeps an internal state to figure out when it can use the cached items array. This internal state was incorrect if the DB was empty and there just was a DB write as well. The observer's implementation is similar to the `StateLayerDatabaseObserver` now where we use NSManagedObjectContext's thread for processing and accessing the state (better data consistency).

Account Chewbacca in the demo app:
```swift
// ComposerVC.swift:925
    quotedMessageId: content.quotingMessage?.id,
    skipEnrichUrl: content.skipEnrichUrl,
    extraData: content.extraData
  )
  test()
}

func test() {
  guard let chatClient = channelController?.client else { return }
  let identifier = ChannelId(type: .messaging, id: "D65B357E-8")
  let query = ChannelQuery(cid: identifier, pageSize: 20)
  let channelController = chatClient.channelController(for: query)
        
  channelController.synchronize { error in
    if let error {
        log.error("Failed to get messages: \(error)")
        return
     }
     // The last 20 messages should be in channelController.messages
     let messages = channelController.messages
     print(messages.count)
  }
}
``` 

### 🧪 Manual Testing Notes

Account: Chewbacca
1. Paste that snippet to somewhere which gets triggered after connecting (I used ComposerVC.swift line 925 to call this snippet, this is triggered when sending a message)
2. Logout and login with Chewbacca
3. Send a message which triggers the snippet
4. Observe the message count, it should return 20 (checking console log, best is to put a breakpoint after the print)

Exploratory testing (because DB observers affect all the controllers)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)


[PBE-5519]: https://stream-io.atlassian.net/browse/PBE-5519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ