### PR TITLE
Update channel type documentation to reflect allowed characters

### DIFF
--- a/Sources/StreamChat/Models/ChannelType.swift
+++ b/Sources/StreamChat/Models/ChannelType.swift
@@ -23,7 +23,7 @@ public enum ChannelType: Codable, Hashable {
 
     /// The type of the channel is custom.
     ///
-    /// Only small letters, underscore and numbers should be used
+    /// Only letters, underscore and numbers should be used
     case custom(String)
 
     /// A channel type title.
@@ -83,7 +83,7 @@ public enum ChannelType: Codable, Hashable {
         log.assert(
             valueCharacters.isSubset(of: allowedCharacters),
             // swiftlint:disable:next line_length
-            "Value \"\(value)\" is not valid `ChannelType.custom` identifier, allowed characters are small letters, numbers and underscore."
+            "Value \"\(value)\" is not valid `ChannelType.custom` identifier, allowed characters are letters, numbers, underscore, and hyphen."
         )
     }
 }

--- a/docusaurus/docs/iOS/common-content/reference-docs/stream-chat/models/channel-type.md
+++ b/docusaurus/docs/iOS/common-content/reference-docs/stream-chat/models/channel-type.md
@@ -70,7 +70,7 @@ The type of the channel is custom.
 case custom(String)
 ```
 
-Only small letters, underscore and numbers should be used
+Only letters, underscore, hyphen, and numbers should be used.
 
 ## Properties
 


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Reduce onboarding friction by ensuring documentation reflects current code state

### 📝 Summary

The in-code documentation for custom channel types stated that channel types should only have "small letters", which is incorrect: the code itself allowed both lowercased and uppercased letters. Since channel types are case-sensitive, customers who create a channel type with uppercase letters who follow the "small letters" requirement in their iOS code will receive errors because their spelling of the channel type is incorrect.

### 🛠 Implementation

Updated documentation to reflect the current code requirements

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![xT4uQwLt2AyurOGWFW](https://github.com/user-attachments/assets/9ed89e27-4c1c-4d1e-a27f-74ec55acd61b)
