### PR TITLE
Store pending message along with regular messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CurrentChatUserController` was often recreated when sending typing events [#3372](https://github.com/GetStream/stream-chat-swift/pull/3372)
 - Reduce latency of the `BackgroundDatabaseObserver` by reducing thread switching when handling changes [#3373](https://github.com/GetStream/stream-chat-swift/pull/3373)
 ### 🐞 Fixed
+- Fix an issue where pending messages ([moderation feature](https://getstream.io/chat/docs/ios-swift/pending_messages/)) were not visible after returning to the channel [#3378](https://github.com/GetStream/stream-chat-swift/pull/3378)
 - Fix rare crashes when deleting local database content on logout [#3355](https://github.com/GetStream/stream-chat-swift/pull/3355)
 - Fix rare crashes in `MulticastDelegate` when accessing it concurrently [#3361](https://github.com/GetStream/stream-chat-swift/pull/3361)
 - Fix reading the local database state just after the initial write [#3373](https://github.com/GetStream/stream-chat-swift/pull/3373)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelListPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelListPayload.swift
@@ -37,6 +37,8 @@ struct ChannelPayload {
     let membership: MemberPayload?
 
     let messages: [MessagePayload]
+    
+    let pendingMessages: [MessagePayload]?
 
     let pinnedMessages: [MessagePayload]
 
@@ -58,6 +60,7 @@ extension ChannelPayload: Decodable {
     enum CodingKeys: String, CodingKey {
         case channel
         case messages
+        case pendingMessages = "pending_messages"
         case pinnedMessages = "pinned_messages"
         case channelReads = "read"
         case members
@@ -77,6 +80,7 @@ extension ChannelPayload: Decodable {
             members: try container.decodeArrayIgnoringFailures([MemberPayload].self, forKey: .members),
             membership: try container.decodeIfPresent(MemberPayload.self, forKey: .membership),
             messages: try container.decodeArrayIgnoringFailures([MessagePayload].self, forKey: .messages),
+            pendingMessages: try container.decodeArrayIfPresentIgnoringFailures([MessagePayload.Boxed].self, forKey: .pendingMessages)?.map(\.message),
             pinnedMessages: try container.decodeArrayIgnoringFailures([MessagePayload].self, forKey: .pinnedMessages),
             channelReads: try container.decodeArrayIfPresentIgnoringFailures([ChannelReadPayload].self, forKey: .channelReads) ?? [],
             isHidden: try container.decodeIfPresent(Bool.self, forKey: .hidden)

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -290,7 +290,8 @@ extension NSManagedObjectContext {
         dto.reads = reads
 
         try payload.messages.forEach { _ = try saveMessage(payload: $0, channelDTO: dto, syncOwnReactions: true, cache: cache) }
-
+        try payload.pendingMessages?.forEach { _ = try saveMessage(payload: $0, channelDTO: dto, syncOwnReactions: true, cache: cache) }
+        
         if dto.needsPreviewUpdate(payload) {
             dto.previewMessage = preview(for: payload.channel.cid)
         }

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Channel.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Channel.json
@@ -1191,6 +1191,52 @@
       "pinned_by": null
     }
   ],
+  "pending_messages": [
+    {
+      "user": null,
+      "channel": null,
+      "message": {
+        "id": "a55451b7-ae6d-441f-a7b2-60e895226914",
+        "text": "My pending message",
+        "html": "\\u003cp\\u003eS\\u003c/p\\u003e\\n",
+        "type": "regular",
+        "user": {
+          "id" : "broken-waterfall-5",
+          "banned" : false,
+          "unread_channels" : 0,
+          "totalUnreadCount" : 0,
+          "last_active" : "2020-06-10T13:24:00.501797Z",
+          "created_at" : "2019-12-12T15:33:46.488935Z",
+          "unreadChannels" : 0,
+          "unread_count" : 0,
+          "image" : "https:\/\/getstream.io\/random_svg\/?id=broken-waterfall-5&amp;name=Broken+waterfall",
+          "updated_at" : "2020-06-10T14:11:29.946106Z",
+          "role" : "user",
+          "total_unread_count" : 0,
+          "online" : true,
+          "name" : "broken-waterfall-5"
+        },
+        "attachments": [],
+        "latest_reactions": [],
+        "own_reactions": [],
+        "reaction_counts": {},
+        "reaction_scores": {},
+        "reaction_groups": null,
+        "reply_count": 0,
+        "deleted_reply_count": 0,
+        "cid": "messaging:general",
+        "created_at": "2024-08-14T06:52:45.66591Z",
+        "updated_at": "2024-08-14T06:52:45.66591Z",
+        "shadowed": false,
+        "mentioned_users": [],
+        "silent": false,
+        "pinned": false,
+        "pinned_at": null,
+        "pinned_by": null,
+        "pin_expires": null
+      }
+    }
+  ],
   "pinned_messages": [
       {
         "id" : "broken-waterfall-5-7aede36b-b89f-4f45-baff-c40c7c1875d9",

--- a/TestTools/StreamChatTestTools/TestData/DummyData/ChannelPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/ChannelPayload.swift
@@ -14,6 +14,7 @@ extension ChannelPayload {
         members: [MemberPayload] = [],
         membership: MemberPayload? = nil,
         messages: [MessagePayload] = [],
+        pendingMessages: [MessagePayload] = [],
         pinnedMessages: [MessagePayload] = [],
         channelReads: [ChannelReadPayload] = [],
         isHidden: Bool? = nil
@@ -25,6 +26,7 @@ extension ChannelPayload {
             members: members,
             membership: membership,
             messages: messages,
+            pendingMessages: pendingMessages,
             pinnedMessages: pinnedMessages,
             channelReads: channelReads,
             isHidden: isHidden

--- a/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
@@ -124,6 +124,7 @@ extension XCTestCase {
         watchers: [UserPayload]? = nil,
         includeMembership: Bool = true,
         messages: [MessagePayload]? = nil,
+        pendingMessages: [MessagePayload]? = nil,
         pinnedMessages: [MessagePayload] = [],
         channelConfig: ChannelConfig = .init(
             reactionsEnabled: true,
@@ -196,6 +197,7 @@ extension XCTestCase {
                 members: members,
                 membership: includeMembership ? members.first : nil,
                 messages: payloadMessages,
+                pendingMessages: pendingMessages,
                 pinnedMessages: pinnedMessages,
                 channelReads: channelReads ?? [dummyChannelRead],
                 isHidden: false
@@ -309,6 +311,7 @@ extension XCTestCase {
                 members: [member],
                 membership: member,
                 messages: [dummyMessageWithNoExtraData],
+                pendingMessages: nil,
                 pinnedMessages: [dummyMessageWithNoExtraData],
                 channelReads: [dummyChannelReadWithNoExtraData],
                 isHidden: nil

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
@@ -236,6 +236,7 @@ final class ChannelListPayload_Tests: XCTestCase {
                     isMemberBanned: false
                 ),
                 messages: messages,
+                pendingMessages: nil,
                 pinnedMessages: [],
                 channelReads: (0..<channelReadCount).map { i in
                     ChannelReadPayload(
@@ -286,6 +287,10 @@ final class ChannelPayload_Tests: XCTestCase {
         XCTAssertEqual(firstMessage.replyCount, 0)
         XCTAssertFalse(firstMessage.isSilent)
 
+        XCTAssertEqual(payload.pendingMessages?.count ?? 0, 1)
+        let pendingMessage = try XCTUnwrap(payload.pendingMessages?.first)
+        XCTAssertEqual(pendingMessage.text, "My pending message")
+        
         XCTAssertEqual(payload.pinnedMessages.map(\.id), ["broken-waterfall-5-7aede36b-b89f-4f45-baff-c40c7c1875d9"])
 
         let channel = payload.channel

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiablePayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiablePayload_Tests.swift
@@ -392,6 +392,7 @@ final class IdentifiablePayload_Tests: XCTestCase {
                     isMemberBanned: false
                 ),
                 messages: messages,
+                pendingMessages: nil,
                 pinnedMessages: [],
                 channelReads: (0..<channelReadCount).map { i in
                     ChannelReadPayload(

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -1101,6 +1101,7 @@ final class ChannelDTO_Tests: XCTestCase {
             members: [.dummy(user: currentUserPayload)],
             membership: .dummy(user: currentUserPayload),
             messages: [messageMentioningCurrentUser],
+            pendingMessages: nil,
             pinnedMessages: [],
             channelReads: [currentUserChannelReadPayload],
             isHidden: false
@@ -1156,6 +1157,7 @@ final class ChannelDTO_Tests: XCTestCase {
             members: [memberPayload],
             membership: membershipPayload,
             messages: [],
+            pendingMessages: nil,
             pinnedMessages: [],
             channelReads: [],
             isHidden: nil

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -48,6 +48,7 @@ final class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
             members: [.dummy(user: currentUserPayload), .dummy(user: anotherUserPayload)],
             membership: .dummy(user: currentUserPayload),
             messages: [],
+            pendingMessages: nil,
             pinnedMessages: [],
             channelReads: [currentUserReadPayload],
             isHidden: false


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5482](https://stream-io.atlassian.net/browse/PBE-5482)

### 🎯 Goal

Support the [pending messages](https://getstream.io/chat/docs/ios-swift/pending_messages/) moderation feature

### 📝 Summary

- Parse `pending_messages` field in the channel response and store these messages along with regular messages to the `ChannelDTO.messages` 

### 🛠 Implementation

If the pending messages feature is enabled, all the messages the current user sends, goes to a pending list. Backend needs to "commit" these messages and after committing, these messages become queryable for everyone in the channel. Until then, pending messages are only visible for the current user. Because we did not parse these messages from the payload before, coming back to the channel cleared the local storage (server sync) and all the pending messages were removed from the list of loaded messages.

### 🧪 Manual Testing Notes

Requirements (ask me to get an app id and credentials if needed): 
1. App ID which has pending messages enabled for the whole organization (can't be done using the dashboard)
2. Pending messages is enabled for a channel type on the dashboard

##### Steps
1. Log in
2. Open a channel while pending messages feature is enabled
3. Send some messages (other participants do not receive them)
4. Go to channel list
5. Go back to the channel which triggers channel sync > all the pending messages are visible

Note: Before all the pending messages were deleted from the local store when coming back to the channel.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![img](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExczBiZDRya3B4Z3E5am82aGl2cjE4bWJob3h3dXFtdzQyejh1OGx5biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NZGPwEou8bKxmMRqg7/giphy.gif)


[PBE-5482]: https://stream-io.atlassian.net/browse/PBE-5482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ