### PR TITLE
Local database integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `deleteAllLocalAttachmentDownloads()` to `ConnectedUser` and `CurrentUserController`
 ### 🐞 Fixed
 - Fix Logger printing the incorrect thread name [#3382](https://github.com/GetStream/stream-chat-swift/pull/3382)
+### 🔄 Changed
+- Discard offline state changes when saving database changes fails [#3399](https://github.com/GetStream/stream-chat-swift/pull/3399)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -10,6 +10,8 @@ import Foundation
 ///
 /// Typically, an app contains just one instance of `ChatClient`. However, it's possible to have multiple instances if your use
 /// case requires it (i.e. more than one window with different workspaces in a Slack-like app).
+///
+/// - Important: When using multiple instances of `ChatClient` at the same time, it is required to use a different ``ChatClientConfig/localStorageFolderURL`` for each instance. For example, adding an additional path component to the default URL.
 public class ChatClient {
     /// The `UserId` of the currently logged in user.
     public var currentUserId: UserId? {

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -173,9 +173,7 @@ class DatabaseContainer: NSPersistentContainer {
 
         FetchCache.clear()
 
-        if LogConfig.level == .debug {
-            setupLoggerForDatabaseChanges()
-        }
+        setupLoggerForDatabaseChanges()
     }
 
     deinit {

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -58,6 +58,17 @@ final class ChatClient_Tests: XCTestCase {
 
     // MARK: - Database stack tests
 
+    func test_multipleInstance_whenLocalStorageURLIsTheSame() {
+        let client1 = ChatClient(config: ChatClientConfig(apiKeyString: "123"))
+        let client2 = ChatClient(config: ChatClientConfig(apiKeyString: "123"))
+        XCTAssertEqual(1, ChatClient.activeLocalStorageURLs.count)
+        // We only log an error when misuse happens
+        XCTAssertEqual(
+            client1.databaseContainer.persistentStoreDescriptions.compactMap(\.url),
+            client2.databaseContainer.persistentStoreDescriptions.compactMap(\.url)
+        )
+    }
+    
     func test_clientDatabaseStackInitialization_whenLocalStorageEnabled_respectsConfigValues() {
         // Prepare a config with the local storage
         let storeFolderURL = URL.newTemporaryDirectoryURL()


### PR DESCRIPTION
### 🔗 Issue Links

[PBE-5686](https://stream-io.atlassian.net/browse/PBE-5686)

### 🎯 Goal

Clear NSManagedObjectContext state when saving fails (e.g. validation errors)

### 📝 Summary

- Clear changes in the writableContext when save fails
- Add better documentation about using multiple `ChatClient` instances
- Remove the canWriteData check because it does not help (serial queue)
- Add an error message when multiple ChatClient instances is detected
```
[ERROR] [main] [ChatClient.swift:270] [validateIntegrity()] > There are multiple ChatClient instances using the same `ChatClientConfig.localStorageFolderURL` - this is disallowed.
Either create a shared instance or make sure the previous instance of `ChatClient` is deallocated.
```

### 🛠 Implementation

Resetting the context helps to clear invalid save state. 

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5686]: https://stream-io.atlassian.net/browse/PBE-5686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ