### PR TITLE
[CI] Do not cache iOS Simulator Runtimes nightly

### DIFF
--- a/.github/actions/setup-ios-runtime/action.yml
+++ b/.github/actions/setup-ios-runtime/action.yml
@@ -3,13 +3,6 @@ description: 'Download and Install requested iOS Runtime'
 runs:
   using: "composite"
   steps:
-    - name: Cache iOS Simulator Runtime
-      uses: actions/cache@v4
-      id: runtime-cache
-      with:
-        path: ./*.dmg
-        key: ipsw-runtime-ios-${{ inputs.version }}
-        restore-keys: ipsw-runtime-ios-${{ inputs.version }}
     - name: Setup iOS Simulator Runtime
       shell: bash
       run: |


### PR DESCRIPTION
It seems like GitHub reduced the size of the allowed cache. 
Anyways, caching the runtimes nightly does not bring much value and can be eliminated.

![Screenshot 2024-08-30 at 11 53 44 AM](https://github.com/user-attachments/assets/8a5d5c4b-aa89-4557-bbcf-e7b620de2f4b)