### PR TITLE
Add unset argument to update user data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Local attachment downloads ([docs](https://getstream.io/chat/docs/sdk/ios/client/attachment-downloads)) [#3393](https://github.com/GetStream/stream-chat-swift/pull/3393)
   - Add `downloadAttachment(_:)` and `deleteLocalAttachmentDownload(for:)` to `Chat` and `MessageController`
   - Add `deleteAllLocalAttachmentDownloads()` to `ConnectedUser` and `CurrentUserController`
+- Add `unset` argument to `CurrentChatUserController.updateUserData` and `ConnectedUser.update` for clearing user data fields [#3403](https://github.com/GetStream/stream-chat-swift/pull/3403)
 ### 🐞 Fixed
 - Fix Logger printing the incorrect thread name [#3382](https://github.com/GetStream/stream-chat-swift/pull/3382)
 

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -532,6 +532,20 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                 } catch {
                     self.rootViewController.presentAlert(title: error.localizedDescription)
                 }
+            }),
+            .init(title: "Reset User Image", handler: { [unowned self] _ in
+                do {
+                    let connectedUser = try self.rootViewController.controller.client.makeConnectedUser()
+                    Task {
+                        do {
+                            try await connectedUser.update(unset: ["image"])
+                        } catch {
+                            self.rootViewController.presentAlert(title: error.localizedDescription)
+                        }
+                    }
+                } catch {
+                    self.rootViewController.presentAlert(title: error.localizedDescription)
+                }
             })
         ])
     }

--- a/Sources/StreamChat/APIClient/Endpoints/UserEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/UserEndpoints.swift
@@ -18,11 +18,13 @@ extension Endpoint {
 
     static func updateUser(
         id: UserId,
-        payload: UserUpdateRequestBody
+        payload: UserUpdateRequestBody,
+        unset: [String]
     ) -> Endpoint<CurrentUserUpdateResponse> {
         let users: [String: AnyEncodable] = [
             "id": AnyEncodable(id),
-            "set": AnyEncodable(payload)
+            "set": AnyEncodable(payload),
+            "unset": AnyEncodable(unset)
         ]
         let body: [String: AnyEncodable] = [
             "users": AnyEncodable([users])

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -155,7 +155,7 @@ public extension CurrentChatUserController {
     ///
     /// By default all data is `nil`, and it won't be updated unless a value is provided.
     ///
-    /// - Note: This operation does a partial user update which keeps existing data if not modified.
+    /// - Note: This operation does a partial user update which keeps existing data if not modified. Use ``unset`` for clearing the existing state.
     ///
     /// - Parameters:
     ///   - name: Optionally provide a new name to be updated.
@@ -163,6 +163,7 @@ public extension CurrentChatUserController {
     ///   - privacySettings: The privacy settings of the user. Example: If the user does not want to expose typing events or read events.
     ///   - role: The role for the user.
     ///   - userExtraData: Optionally provide new user extra data to be updated.
+    ///   - unset: Existing values for specified properties are removed. For example, `image` or `name`.
     ///   - completion: Called when user is successfuly updated, or with error.
     func updateUserData(
         name: String? = nil,
@@ -170,6 +171,7 @@ public extension CurrentChatUserController {
         privacySettings: UserPrivacySettings? = nil,
         role: UserRole? = nil,
         userExtraData: [String: RawJSON] = [:],
+        unsetProperties: Set<String> = [],
         completion: ((Error?) -> Void)? = nil
     ) {
         guard let currentUserId = client.currentUserId else {

--- a/Sources/StreamChat/StateLayer/ConnectedUser.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUser.swift
@@ -38,7 +38,7 @@ public final class ConnectedUser {
     
     /// Updates the currently logged-in user's data.
     ///
-    /// - Note: This does partial update and only updates existing data when a non-nil value is specified.
+    /// - Note: This does partial update and only updates existing data when a non-nil value is specified. Use ``unset`` for clearing the existing state.
     ///
     /// - Parameters:
     ///   - name: The name to be set to the user.
@@ -46,6 +46,7 @@ public final class ConnectedUser {
     ///   - privacySettings: The privacy settings of the user. Example: If the user does not want to expose typing events or read events.
     ///   - role: The role for the user.
     ///   - extraData: Additional data associated with the user.
+    ///   - unset: Existing values for specified fields are removed. For example, `image` or `name`.
     ///
     /// - Throws: An error while communicating with the Stream API or when user is not logged in.
     public func update(
@@ -53,7 +54,8 @@ public final class ConnectedUser {
         imageURL: URL? = nil,
         privacySettings: UserPrivacySettings? = nil,
         role: UserRole? = nil,
-        extraData: [String: RawJSON] = [:]
+        extraData: [String: RawJSON] = [:],
+        unset: Set<String> = []
     ) async throws {
         try await currentUserUpdater.updateUserData(
             currentUserId: try currentUserId(),
@@ -61,7 +63,8 @@ public final class ConnectedUser {
             imageURL: imageURL,
             privacySettings: privacySettings,
             role: role,
-            userExtraData: extraData
+            userExtraData: extraData,
+            unset: unset
         )
     }
     

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
@@ -12,6 +12,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
     @Atomic var updateUserData_imageURL: URL?
     @Atomic var updateUserData_userExtraData: [String: RawJSON]?
     @Atomic var updateUserData_privacySettings: UserPrivacySettings?
+    @Atomic var updateUserData_unset: Set<String>?
     @Atomic var updateUserData_completion: ((Error?) -> Void)?
 
     @Atomic var addDevice_id: DeviceId?
@@ -40,6 +41,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         privacySettings: UserPrivacySettings?,
         role: UserRole?,
         userExtraData: [String: RawJSON]?,
+        unset: Set<String>,
         completion: ((Error?) -> Void)? = nil
     ) {
         updateUserData_currentUserId = currentUserId
@@ -47,6 +49,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         updateUserData_imageURL = imageURL
         updateUserData_userExtraData = userExtraData
         updateUserData_privacySettings = privacySettings
+        updateUserData_unset = unset
         updateUserData_completion = completion
     }
 
@@ -89,7 +92,9 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         updateUserData_currentUserId = nil
         updateUserData_name = nil
         updateUserData_imageURL = nil
+        updateUserData_privacySettings = nil
         updateUserData_userExtraData = nil
+        updateUserData_unset = nil
         updateUserData_completion = nil
 
         addDevice_id = nil

--- a/Tests/StreamChatTests/APIClient/Endpoints/UserEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/UserEndpoints_Tests.swift
@@ -41,10 +41,12 @@ final class UserEndpoints_Tests: XCTestCase {
             role: .anonymous,
             extraData: ["company": .string(.unique)]
         )
+        let unset = ["image", "name"]
 
         let users: [String: AnyEncodable] = [
             "id": AnyEncodable(userId),
-            "set": AnyEncodable(payload)
+            "set": AnyEncodable(payload),
+            "unset": AnyEncodable(unset)
         ]
         let body: [String: AnyEncodable] = [
             "users": AnyEncodable([users])
@@ -58,7 +60,7 @@ final class UserEndpoints_Tests: XCTestCase {
             body: body
         )
 
-        let endpoint: Endpoint<CurrentUserUpdateResponse> = .updateUser(id: userId, payload: payload)
+        let endpoint: Endpoint<CurrentUserUpdateResponse> = .updateUser(id: userId, payload: payload, unset: unset)
 
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
         XCTAssertEqual("users", endpoint.path.value)

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -100,7 +100,41 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 ),
                 role: expectedRole,
                 extraData: [:]
-            )
+            ),
+            unset: []
+        )
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+    
+    func test_updateUser_makesCorrectAPICall_whenOnlyUnsetProperties() throws {
+        // Simulate user already set
+        let userPayload: CurrentUserPayload = .dummy(userId: .unique, role: .user)
+        try database.writeSynchronously {
+            try $0.saveCurrentUser(payload: userPayload)
+        }
+        
+        currentUserUpdater.updateUserData(
+            currentUserId: userPayload.id,
+            name: nil,
+            imageURL: nil,
+            privacySettings: nil,
+            role: nil,
+            userExtraData: nil,
+            unset: ["image"],
+            completion: { _ in }
+        )
+        
+        // Assert that request is made to the correct endpoint
+        let expectedEndpoint: Endpoint<CurrentUserUpdateResponse> = .updateUser(
+            id: userPayload.id,
+            payload: .init(
+                name: nil,
+                imageURL: nil,
+                privacySettings: nil,
+                role: nil,
+                extraData: nil
+            ),
+            unset: ["image"]
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5848](https://stream-io.atlassian.net/browse/PBE-5848)

### 🎯 Goal

Add `unset` argument to `CurrentChatUserController.updateUserData` and `ConnectedUser.update` for clearing user data fields

### 🧪 Manual Testing Notes

1. Log in with an user who has an image set
2. Open a channel and its debug menu: Reset User Image
Result: User's image is reset in the channel list (image in the top left corner)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5848]: https://stream-io.atlassian.net/browse/PBE-5848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ