### PR TITLE
[CI] Clean up disk space on CI before downloading iOS runtimes

### DIFF
--- a/.github/actions/setup-ios-runtime/action.yml
+++ b/.github/actions/setup-ios-runtime/action.yml
@@ -6,8 +6,10 @@ runs:
     - name: Setup iOS Simulator Runtime
       shell: bash
       run: |
+        sudo rm -rfv ~/Library/Developer/CoreSimulator/* || true
         brew install blacktop/tap/ipsw
         bundle exec fastlane install_runtime ios:${{ inputs.version }}
+        sudo rm -rfv *.dmg || true
         xcrun simctl list runtimes
     - name: Create Custom iOS Simulator
       shell: bash


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/PBE-5875

### 📝 Problem

Seems like GitHub Actions reduced the size of the allowed disk space. So when we downloaded the old runtime the job crashed due to the lack of disk space.

### 🧪 Testing

https://github.com/GetStream/stream-video-swift/actions/runs/10682111795
