### PR TITLE
Channel watching did not resume on web-socket reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `deleteAllLocalAttachmentDownloads()` to `ConnectedUser` and `CurrentUserController`
 ### 🐞 Fixed
 - Fix Logger printing the incorrect thread name [#3382](https://github.com/GetStream/stream-chat-swift/pull/3382)
+- Channel watching did not resume on web-socket reconnection [#3408](https://github.com/GetStream/stream-chat-swift/pull/3408)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -87,6 +87,9 @@ public class Chat {
             channelQuery: query,
             memberSorting: state.memberSorting
         )
+        // Store the watch state
+        await state.setChannelQuery(query)
+        
         client.syncRepository.startTrackingChat(self)
         // cid is retrieved from the server when we are creating new channels or there is no local state present
         guard query.cid != payload.channel.cid else { return }

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -167,8 +167,12 @@ import Foundation
 // MARK: - Internal
 
 extension ChatState {
+    func setChannelQuery(_ query: ChannelQuery) {
+        channelQuery = query
+    }
+    
     func setChannelId(_ channelId: ChannelId) {
-        channelQuery = ChannelQuery(cid: channelId, channelQuery: channelQuery)
+        setChannelQuery(ChannelQuery(cid: channelId, channelQuery: channelQuery))
         observe(channelId)
     }
     

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/State/Chat_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/State/Chat_Mock.swift
@@ -5,8 +5,9 @@
 import Foundation
 @testable import StreamChat
 
-public class Chat_Mock: Chat {
-
+public class Chat_Mock: Chat, Spy {
+    public let spyState = SpyState()
+    
     static let cid = try! ChannelId(cid: "mock:channel")
     
     init(
@@ -67,6 +68,10 @@ public class Chat_Mock: Chat {
     public var loadPageAroundMessageIdCallCount = 0
     public override func loadMessages(around messageId: MessageId, limit: Int? = nil) async throws {
         loadPageAroundMessageIdCallCount += 1
+    }
+    
+    public override func watch() async throws {
+        record()
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5899](https://stream-io.atlassian.net/browse/PBE-5899)

### 🎯 Goal

* When channel is watched and web-socket reconnection happens, we should keep watching the channel

### 📝 Summary

### 🛠 Implementation

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5899]: https://stream-io.atlassian.net/browse/PBE-5899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ