### PR TITLE
Deprecate `Filter.notEqual` and `Filter.notIn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Channel watching did not resume on web-socket reconnection [#3409](https://github.com/GetStream/stream-chat-swift/pull/3409)
 ### 🔄 Changed
 - Discard offline state changes when saving database changes fails [#3399](https://github.com/GetStream/stream-chat-swift/pull/3399)
+- Deprecate `Filter.notEqual` and `Filter.notIn` [#3413](https://github.com/GetStream/stream-chat-swift/pull/3413)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -300,6 +300,7 @@ public extension Filter {
     }
 
     /// Matches all values that are not equal to a specified value.
+    @available(*, deprecated, message: "The notEqual filter will be removed in the future")
     static func notEqual<Value: Encodable>(_ key: FilterKey<Scope, Value>, to value: Value) -> Filter {
         .init(
             operator: .notEqual,
@@ -366,6 +367,7 @@ public extension Filter {
     }
 
     /// Matches none of the values specified in an array.
+    @available(*, deprecated, message: "The notIn filter will be removed in the future")
     static func notIn<Value: Encodable>(_ key: FilterKey<Scope, Value>, values: [Value]) -> Filter {
         .init(
             operator: .notIn,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5681](https://stream-io.atlassian.net/browse/PBE-5681)

### 🎯 Goal

Deprecate slow filter operators

### 📝 Summary

`Filter.notEqual` and `Filter.notIn` cause performance issues and are considered to be removed in the future.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5681]: https://stream-io.atlassian.net/browse/PBE-5681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ