### PR TITLE
Add reason and extraData to flag user and extraData to flag message methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `downloadAttachment(_:)` and `deleteLocalAttachmentDownload(for:)` to `Chat` and `MessageController`
   - Add `deleteAllLocalAttachmentDownloads()` to `ConnectedUser` and `CurrentUserController`
 - Add `unset` argument to `CurrentChatUserController.updateUserData` and `ConnectedUser.update` for clearing user data fields [#3404](https://github.com/GetStream/stream-chat-swift/pull/3404)
+- Add `reason` and `extraData` arguments to `ChatUserController.flag(reason:extraData:completion:)` and `ConnectedUser.flag(_:reason:extraData:)` [#3417](https://github.com/GetStream/stream-chat-swift/pull/3417)
+- Add `extraData` argument to `ChatMessageController.flag(reason:extraData:completion:)` and `Chat.flagMessage(_:reason:extraData:)` [#3417](https://github.com/GetStream/stream-chat-swift/pull/3417)
 ### 🐞 Fixed
 - Fix Logger printing the incorrect thread name [#3382](https://github.com/GetStream/stream-chat-swift/pull/3382)
 - Channel watching did not resume on web-socket reconnection [#3409](https://github.com/GetStream/stream-chat-swift/pull/3409)

--- a/Sources/StreamChat/APIClient/Endpoints/ModerationEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ModerationEndpoints.swift
@@ -88,13 +88,23 @@ extension Endpoint {
 // MARK: - User flagging
 
 extension Endpoint {
-    static func flagUser(_ flag: Bool, with userId: UserId) -> Endpoint<FlagUserPayload> {
+    static func flagUser(
+        _ flag: Bool,
+        with userId: UserId,
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil
+    ) -> Endpoint<FlagUserPayload> {
         .init(
             path: .flagUser(flag),
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["target_user_id": userId]
+            body: FlagRequestBody(
+                reason: reason,
+                targetMessageId: nil,
+                targetUserId: userId,
+                custom: extraData
+            )
         )
     }
 }
@@ -105,20 +115,20 @@ extension Endpoint {
     static func flagMessage(
         _ flag: Bool,
         with messageId: MessageId,
-        reason: String? = nil
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil
     ) -> Endpoint<FlagMessagePayload> {
-        var body: [String: AnyEncodable] = ["target_message_id": AnyEncodable(messageId)]
-        
-        if let reason = reason {
-            body["reason"] = AnyEncodable(reason)
-        }
-            
-        return .init(
+        .init(
             path: .flagMessage(flag),
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: body
+            body: FlagRequestBody(
+                reason: reason,
+                targetMessageId: messageId,
+                targetUserId: nil,
+                custom: extraData
+            )
         )
     }
 }

--- a/Sources/StreamChat/APIClient/Endpoints/Requests/FlagRequestBody.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Requests/FlagRequestBody.swift
@@ -1,0 +1,26 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+struct FlagRequestBody: Codable, Hashable {
+    let reason: String?
+    let targetMessageId: String?
+    let targetUserId: String?
+    let custom: [String: RawJSON]?
+
+    init(reason: String? = nil, targetMessageId: String? = nil, targetUserId: String? = nil, custom: [String: RawJSON]? = nil) {
+        self.reason = reason
+        self.targetMessageId = targetMessageId
+        self.targetUserId = targetUserId
+        self.custom = custom
+    }
+    
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case reason
+        case targetMessageId = "target_message_id"
+        case targetUserId = "target_user_id"
+        case custom
+    }
+}

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -578,10 +578,15 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     ///
     /// - Parameters:
     ///   - reason: The flag reason.
+    ///   - extraData: Additional data associated with the flag request.
     ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///
-    public func flag(reason: String? = nil, completion: ((Error?) -> Void)? = nil) {
-        messageUpdater.flagMessage(true, with: messageId, in: cid, reason: reason) { error in
+    public func flag(
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        messageUpdater.flagMessage(true, with: messageId, in: cid, reason: reason, extraData: extraData) { error in
             self.callback {
                 completion?(error)
             }
@@ -593,7 +598,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///
     public func unflag(completion: ((Error?) -> Void)? = nil) {
-        messageUpdater.flagMessage(false, with: messageId, in: cid) { error in
+        messageUpdater.flagMessage(false, with: messageId, in: cid, reason: nil, extraData: nil) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController.swift
@@ -182,10 +182,18 @@ public extension ChatUserController {
     }
 
     /// Flags the user this controller manages.
-    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///
+    /// - Parameters:
+    ///   - reason: The reason of the flag request.
+    ///   - extraData: Additional data associated with the flag request.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///                         If request fails, the completion will be called with an error.
-    func flag(completion: ((Error?) -> Void)? = nil) {
-        userUpdater.flagUser(true, with: userId) { error in
+    func flag(
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        userUpdater.flagUser(true, with: userId, reason: reason, extraData: extraData) { error in
             self.callback {
                 completion?(error)
             }
@@ -196,7 +204,7 @@ public extension ChatUserController {
     /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///
     func unflag(completion: ((Error?) -> Void)? = nil) {
-        userUpdater.flagUser(false, with: userId) { error in
+        userUpdater.flagUser(false, with: userId, reason: nil, extraData: nil) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -637,17 +637,20 @@ public class Chat {
     /// - Parameters:
     /// - messageId: The id of the message to be flagged.
     /// - reason: A reason why the user was flagged.
+    /// - extraData: Additional data associated with the flag request.
     ///
     /// - Throws: An error while communicating with the Stream API.
     public func flagMessage(
         _ messageId: MessageId,
-        reason: String? = nil
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil
     ) async throws {
         try await messageUpdater.flagMessage(
             true,
             with: messageId,
             in: cid,
-            reason: reason
+            reason: reason,
+            extraData: extraData
         )
     }
     
@@ -657,7 +660,7 @@ public class Chat {
     ///
     /// - Throws: An error while communicating with the Stream API.
     public func unflagMessage(_ messageId: MessageId) async throws {
-        try await messageUpdater.flagMessage(false, with: messageId, in: cid, reason: nil)
+        try await messageUpdater.flagMessage(false, with: messageId, in: cid, reason: nil, extraData: nil)
     }
     
     // MARK: - Message Rich Content

--- a/Sources/StreamChat/StateLayer/ConnectedUser.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUser.swift
@@ -163,11 +163,18 @@ public final class ConnectedUser {
     
     /// Flags the specified user.
     ///
-    /// - Parameter userId: The id of the user to flag.
+    /// - Parameters:
+    ///   - userId: The id of the user to flag.
+    ///   - reason: The reason of the flag request.
+    ///   - extraData: Additional data associated with the flag request.
     ///
     /// - Throws: An error while communicating with the Stream API.
-    public func flag(_ userId: UserId) async throws {
-        try await userUpdater.flag(userId)
+    public func flag(
+        _ userId: UserId,
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil
+    ) async throws {
+        try await userUpdater.flag(userId, reason: reason, extraData: extraData)
     }
     
     /// Unflags the specified user.

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -344,6 +344,7 @@ class MessageUpdater: Worker {
     ///   - messageId: The identifier of a message that should be flagged or unflagged.
     ///   - cid: The identifier of the channel the message belongs to.
     ///   - reason: The flag reason.
+    ///   - extraData: Additional data associated with the flag request.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
     func flagMessage(
@@ -351,6 +352,7 @@ class MessageUpdater: Worker {
         with messageId: MessageId,
         in cid: ChannelId,
         reason: String? = nil,
+        extraData: [String: RawJSON]? = nil,
         completion: ((Error?) -> Void)? = nil
     ) {
         fetchAndSaveMessageIfNeeded(messageId, cid: cid) { error in
@@ -359,7 +361,7 @@ class MessageUpdater: Worker {
                 return
             }
 
-            let endpoint: Endpoint<FlagMessagePayload> = .flagMessage(flag, with: messageId, reason: reason)
+            let endpoint: Endpoint<FlagMessagePayload> = .flagMessage(flag, with: messageId, reason: reason, extraData: extraData)
             self.apiClient.request(endpoint: endpoint) { result in
                 switch result {
                 case let .success(payload):
@@ -1109,14 +1111,16 @@ extension MessageUpdater {
         _ flag: Bool,
         with messageId: MessageId,
         in cid: ChannelId,
-        reason: String?
+        reason: String?,
+        extraData: [String: RawJSON]?
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in
             flagMessage(
                 flag,
                 with: messageId,
                 in: cid,
-                reason: reason
+                reason: reason,
+                extraData: extraData
             ) { error in
                 continuation.resume(with: error)
             }

--- a/Sources/StreamChat/Workers/UserUpdater.swift
+++ b/Sources/StreamChat/Workers/UserUpdater.swift
@@ -132,10 +132,22 @@ class UserUpdater: Worker {
     /// - Parameters:
     ///   - flag: The indicator saying whether the user should be flagged or unflagged.
     ///   - userId: The identifier of a user that should be flagged or unflagged.
+    ///   - extraData: Additional data associated with the flag request.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func flagUser(_ flag: Bool, with userId: UserId, completion: ((Error?) -> Void)? = nil) {
-        let endpoint: Endpoint<FlagUserPayload> = .flagUser(flag, with: userId)
+    func flagUser(
+        _ flag: Bool,
+        with userId: UserId,
+        reason: String? = nil,
+        extraData: [String: RawJSON]? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        let endpoint: Endpoint<FlagUserPayload> = .flagUser(
+            flag,
+            with: userId,
+            reason: reason,
+            extraData: extraData
+        )
         apiClient.request(endpoint: endpoint) {
             switch $0 {
             case let .success(payload):
@@ -202,9 +214,18 @@ extension UserUpdater {
         }
     }
     
-    func flag(_ userId: UserId) async throws {
+    func flag(
+        _ userId: UserId,
+        reason: String?,
+        extraData: [String: RawJSON]?
+    ) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            flagUser(true, with: userId) { error in
+            flagUser(
+                true,
+                with: userId,
+                reason: reason,
+                extraData: extraData
+            ) { error in
                 continuation.resume(with: error)
             }
         }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -259,6 +259,8 @@
 		4F1BEE7F2BE38B5500B6685C /* ReactionList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1BEE7E2BE38B5500B6685C /* ReactionList_Tests.swift */; };
 		4F1FB7D62C7DE22D00C47C2A /* ChatMessageAudioAttachment_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1FB7D52C7DE22D00C47C2A /* ChatMessageAudioAttachment_Mock.swift */; };
 		4F1FB7D82C7DEC6600C47C2A /* ChatMessageVideoAttachment_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1FB7D72C7DEC6600C47C2A /* ChatMessageVideoAttachment_Mock.swift */; };
+		4F312D0E2C905A2E0073A1BC /* FlagRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */; };
+		4F312D0F2C905A2E0073A1BC /* FlagRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */; };
 		4F427F662BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F672BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F692BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
@@ -3100,6 +3102,7 @@
 		4F1BEE7E2BE38B5500B6685C /* ReactionList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionList_Tests.swift; sourceTree = "<group>"; };
 		4F1FB7D52C7DE22D00C47C2A /* ChatMessageAudioAttachment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAudioAttachment_Mock.swift; sourceTree = "<group>"; };
 		4F1FB7D72C7DEC6600C47C2A /* ChatMessageVideoAttachment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageVideoAttachment_Mock.swift; sourceTree = "<group>"; };
+		4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagRequestBody.swift; sourceTree = "<group>"; };
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
@@ -9136,21 +9139,22 @@
 			isa = PBXGroup;
 			children = (
 				884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */,
+				841BA9FA2BCE8468000C73E4 /* CastPollVoteRequestBody.swift */,
 				888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */,
 				AD483B952A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift */,
 				A3B0CFA127BBF52600F352F9 /* ChannelTruncateRequestPayload.swift */,
 				43D3F0FB28410A0200B74921 /* CreateCallRequestBody.swift */,
+				841BAA092BCE9B57000C73E4 /* CreatePollOptionRequestBody.swift */,
+				841BA9FD2BCE8E6D000C73E4 /* CreatePollRequestBody.swift */,
 				840B4FCE26A9E53100D5EFAB /* CustomEventRequestBody.swift */,
+				4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */,
 				8A0D64A524E57A520017A3C0 /* GuestUserTokenRequestPayload.swift */,
 				8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */,
 				F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */,
-				841BA9FA2BCE8468000C73E4 /* CastPollVoteRequestBody.swift */,
-				841BA9FD2BCE8E6D000C73E4 /* CreatePollRequestBody.swift */,
-				841BAA002BCE9394000C73E4 /* UpdatePollRequestBody.swift */,
 				841BAA032BCE94F8000C73E4 /* QueryPollsRequestBody.swift */,
 				841BAA062BCE9A49000C73E4 /* UpdatePartialRequestBody.swift */,
-				841BAA092BCE9B57000C73E4 /* CreatePollOptionRequestBody.swift */,
 				841BAA0C2BCE9F44000C73E4 /* UpdatePollOptionRequestBody.swift */,
+				841BAA002BCE9394000C73E4 /* UpdatePollRequestBody.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -11175,6 +11179,7 @@
 				88BDCA8A2642B02D0099AD74 /* ChatMessageAttachment.swift in Sources */,
 				841BAA4E2BD1CD76000C73E4 /* PollOptionDTO.swift in Sources */,
 				88E26D6E2580F34B00F55AB5 /* AttachmentQueueUploader.swift in Sources */,
+				4F312D0E2C905A2E0073A1BC /* FlagRequestBody.swift in Sources */,
 				88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */,
 				79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */,
 				4F05C0712C8832C40085B4B7 /* URLRequest+cURL.swift in Sources */,
@@ -12101,6 +12106,7 @@
 				C121E86D274544AF00023E4C /* DatabaseContainer.swift in Sources */,
 				C121E86E274544AF00023E4C /* DatabaseSession.swift in Sources */,
 				C121E86F274544AF00023E4C /* DataStore.swift in Sources */,
+				4F312D0F2C905A2E0073A1BC /* FlagRequestBody.swift in Sources */,
 				84355D892AB2FCAC00FD5838 /* FilesEndpoints.swift in Sources */,
 				C121E870274544AF00023E4C /* MessageReactionDTO.swift in Sources */,
 				C121E871274544AF00023E4C /* MessageDTO.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -62,6 +62,7 @@ final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var flagMessage_messageId: MessageId?
     @Atomic var flagMessage_cid: ChannelId?
     @Atomic var flagMessage_reason: String?
+    @Atomic var flagMessage_extraData: [String: RawJSON]?
     @Atomic var flagMessage_completion: ((Error?) -> Void)?
     @Atomic var flagMessage_completion_result: Result<Void, Error>?
 
@@ -181,6 +182,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         flagMessage_messageId = nil
         flagMessage_cid = nil
         flagMessage_reason = nil
+        flagMessage_extraData = nil
         flagMessage_completion = nil
         flagMessage_completion_result = nil
 
@@ -377,13 +379,15 @@ final class MessageUpdater_Mock: MessageUpdater {
         _ flag: Bool,
         with messageId: MessageId,
         in cid: ChannelId,
-        reason: String? = nil,
+        reason: String?,
+        extraData: [String: RawJSON]?,
         completion: ((Error?) -> Void)? = nil
     ) {
         flagMessage_flag = flag
         flagMessage_messageId = messageId
         flagMessage_cid = cid
         flagMessage_reason = reason
+        flagMessage_extraData = extraData
         flagMessage_completion = completion
         flagMessage_completion_result?.invoke(with: completion)
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/UserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/UserUpdater_Mock.swift
@@ -21,6 +21,8 @@ final class UserUpdater_Mock: UserUpdater {
 
     @Atomic var flagUser_flag: Bool?
     @Atomic var flagUser_userId: UserId?
+    @Atomic var flagUser_reason: String?
+    @Atomic var flagUser_extraData: [String: RawJSON]?
     @Atomic var flagUser_completion: ((Error?) -> Void)?
     @Atomic var flagUser_completion_result: Result<Void, Error>?
     
@@ -50,9 +52,11 @@ final class UserUpdater_Mock: UserUpdater {
         loadUser_completion_result?.invoke(with: completion)
     }
 
-    override func flagUser(_ flag: Bool, with userId: UserId, completion: ((Error?) -> Void)? = nil) {
+    override func flagUser(_ flag: Bool, with userId: UserId, reason: String?, extraData: [String : RawJSON]?, completion: (((any Error)?) -> Void)? = nil) {
         flagUser_flag = flag
         flagUser_userId = userId
+        flagUser_reason = reason
+        flagUser_extraData = extraData
         flagUser_completion = completion
         flagUser_completion_result?.invoke(with: completion)
     }
@@ -84,6 +88,8 @@ final class UserUpdater_Mock: UserUpdater {
         loadUser_completion_result = nil
 
         flagUser_flag = nil
+        flagUser_reason = nil
+        flagUser_extraData = nil
         flagUser_userId = nil
         flagUser_completion = nil
         flagUser_completion_result = nil

--- a/Tests/StreamChatTests/APIClient/Endpoints/ModerationEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ModerationEndpoints_Tests.swift
@@ -110,17 +110,29 @@ final class ModerationEndpoints_Tests: XCTestCase {
 
         for (flag, path) in testCases {
             let userId: UserId = .unique
-
+            let reason: String = .unique
+            let extraData: [String: RawJSON] = ["key": .string(.unique)]
+            let body = FlagRequestBody(
+                reason: reason,
+                targetMessageId: nil,
+                targetUserId: userId,
+                custom: extraData
+            )
             let expectedEndpoint = Endpoint<FlagUserPayload>(
                 path: path,
                 method: .post,
                 queryItems: nil,
                 requiresConnectionId: false,
-                body: ["target_user_id": userId]
+                body: body
             )
 
             // Build endpoint.
-            let endpoint: Endpoint<FlagUserPayload> = .flagUser(flag, with: userId)
+            let endpoint: Endpoint<FlagUserPayload> = .flagUser(
+                flag,
+                with: userId,
+                reason: reason,
+                extraData: extraData
+            )
 
             // Assert endpoint is built correctly.
             XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
@@ -136,21 +148,24 @@ final class ModerationEndpoints_Tests: XCTestCase {
 
         for (flag, path) in testCases {
             let messageId: MessageId = .unique
-            let reason = "Test"
-
+            let reason: String = .unique
+            let extraData: [String: RawJSON] = ["key": .string(.unique)]
+            let body = FlagRequestBody(
+                reason: reason,
+                targetMessageId: messageId,
+                targetUserId: nil,
+                custom: extraData
+            )
             let expectedEndpoint = Endpoint<FlagMessagePayload>(
                 path: path,
                 method: .post,
                 queryItems: nil,
                 requiresConnectionId: false,
-                body: [
-                    "target_message_id": messageId,
-                    "reason": reason
-                ]
+                body: body
             )
 
             // Build endpoint.
-            let endpoint: Endpoint<FlagMessagePayload> = .flagMessage(flag, with: messageId, reason: reason)
+            let endpoint: Endpoint<FlagMessagePayload> = .flagMessage(flag, with: messageId, reason: reason, extraData: extraData)
 
             // Assert endpoint is built correctly.
             XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -920,10 +920,14 @@ final class Chat_Tests: XCTestCase {
     
     func test_flagMessage_whenMessageUpdaterSucceeds_thenFlagMessageActionSucceeds() async throws {
         let messageId: MessageId = .unique
+        let reason: String = .unique
+        let extraData: [String: RawJSON] = ["key": .bool(true)]
         env.messageUpdaterMock.flagMessage_completion_result = .success(())
-        try await chat.flagMessage(messageId)
+        try await chat.flagMessage(messageId, reason: reason, extraData: extraData)
         XCTAssertEqual(channelId, env.messageUpdaterMock.flagMessage_cid)
         XCTAssertEqual(messageId, env.messageUpdaterMock.flagMessage_messageId)
+        XCTAssertEqual(reason, env.messageUpdaterMock.flagMessage_reason)
+        XCTAssertEqual(extraData, env.messageUpdaterMock.flagMessage_extraData)
         XCTAssertEqual(true, env.messageUpdaterMock.flagMessage_flag)
     }
     

--- a/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ConnectedUser_Tests.swift
@@ -125,9 +125,13 @@ final class ConnectedUser_Tests: XCTestCase {
         
         env.userUpdaterMock.flagUser_completion_result = .success(())
         let id = UserId.unique
-        try await connectedUser.flag(id)
+        let reason = String.unique
+        let extraData: [String: RawJSON] = ["key": .string("value")]
+        try await connectedUser.flag(id, reason: reason, extraData: extraData)
         XCTAssertEqual(true, env.userUpdaterMock.flagUser_flag)
         XCTAssertEqual(id, env.userUpdaterMock.flagUser_userId)
+        XCTAssertEqual(reason, env.userUpdaterMock.flagUser_reason)
+        XCTAssertEqual(extraData, env.userUpdaterMock.flagUser_extraData)
     }
     
     func test_unflagUser_whenUpdatedSucceeds_thenUnflagUserSucceeds() async throws {
@@ -138,6 +142,8 @@ final class ConnectedUser_Tests: XCTestCase {
         try await connectedUser.unflag(id)
         XCTAssertEqual(false, env.userUpdaterMock.flagUser_flag)
         XCTAssertEqual(id, env.userUpdaterMock.flagUser_userId)
+        XCTAssertNil(env.userUpdaterMock.flagUser_reason)
+        XCTAssertNil(env.userUpdaterMock.flagUser_extraData)
     }
     
     func test_blockUser_whenUpdatedSucceeds_thenBlockUserSucceeds() async throws {

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1209,6 +1209,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let messageId: MessageId = .unique
         let cid: ChannelId = .unique
         let reason = "Test"
+        let extraData: [String: RawJSON] = ["key": .bool(true)]
 
         // Create current user in the database
         try database.createCurrentUser(id: currentUserId)
@@ -1224,13 +1225,13 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Simulate `flagMessage` call.
         let expectation = self.expectation(description: "Flag message completion")
-        messageUpdater.flagMessage(true, with: messageId, in: cid, reason: reason) { error in
+        messageUpdater.flagMessage(true, with: messageId, in: cid, reason: reason, extraData: extraData) { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
 
         // Assert flag endpoint is called.
-        let flagEndpoint: Endpoint<FlagMessagePayload> = .flagMessage(true, with: messageId, reason: reason)
+        let flagEndpoint: Endpoint<FlagMessagePayload> = .flagMessage(true, with: messageId, reason: reason, extraData: extraData)
         AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(flagEndpoint))
 
         // Add it to DB as it is as expected after a successful getMessage call

--- a/Tests/StreamChatTests/Workers/UserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/UserUpdater_Tests.swift
@@ -249,16 +249,16 @@ final class UserUpdater_Tests: XCTestCase {
 
     func test_flagUser_makesCorrectAPICall() {
         let cases = [
-            (true, UserId.unique),
-            (false, UserId.unique)
+            (true, UserId.unique, String.unique, ["a": RawJSON.string("1")]),
+            (false, UserId.unique, String.unique, ["b": RawJSON.bool(true)])
         ]
 
-        for (flag, userId) in cases {
+        for (flag, userId, reason, extraData) in cases {
             // Simulate `flagUser` call.
-            userUpdater.flagUser(flag, with: userId)
+            userUpdater.flagUser(flag, with: userId, reason: reason, extraData: extraData)
 
             // Assert correct endpoint is called.
-            let expectedEndpoint: Endpoint<FlagUserPayload> = .flagUser(flag, with: userId)
+            let expectedEndpoint: Endpoint<FlagUserPayload> = .flagUser(flag, with: userId, reason: reason, extraData: extraData)
             XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
         }
     }
@@ -272,7 +272,7 @@ final class UserUpdater_Tests: XCTestCase {
 
         // Simulate `flagUser` call.
         var flagCompletionCalled = false
-        userUpdater.flagUser(true, with: flaggedUserId) { error in
+        userUpdater.flagUser(true, with: flaggedUserId, reason: nil, extraData: nil) { error in
             XCTAssertNil(error)
             flagCompletionCalled = true
         }
@@ -301,7 +301,7 @@ final class UserUpdater_Tests: XCTestCase {
 
         // Simulate `unflagUser` call.
         var unflagCompletionCalled = false
-        userUpdater.flagUser(false, with: flaggedUserId) { error in
+        userUpdater.flagUser(false, with: flaggedUserId, reason: nil, extraData: nil) { error in
             XCTAssertNil(error)
             unflagCompletionCalled = true
         }
@@ -319,7 +319,7 @@ final class UserUpdater_Tests: XCTestCase {
     func test_flagUser_propagatesNetworkError() {
         // Simulate `flagUser` call.
         var completionCalledError: Error?
-        userUpdater.flagUser(true, with: .unique) {
+        userUpdater.flagUser(true, with: .unique, reason: nil, extraData: nil) {
             completionCalledError = $0
         }
 
@@ -338,7 +338,7 @@ final class UserUpdater_Tests: XCTestCase {
 
         // Simulate `flagUser` call.
         var completionCalledError: Error?
-        userUpdater.flagUser(true, with: .unique) {
+        userUpdater.flagUser(true, with: .unique, reason: nil, extraData: nil) {
             completionCalledError = $0
         }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5887](https://stream-io.atlassian.net/browse/PBE-5887)

### 🎯 Goal

Add missing `reason` and `extraData` arguments to flagging methods

### 📝 Summary

- Add `reason` and `extraData` arguments to `ChatUserController.flag(reason:extraData:completion:)` and `ConnectedUser.flag(_:reason:extraData:)`
- Add `extraData` argument to `ChatMessageController.flag(reason:extraData:completion:)` and `Chat.flagMessage(_:reason:extraData:)`
- Add an internal `FlagRequestBody`

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5887]: https://stream-io.atlassian.net/browse/PBE-5887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ