### PR TITLE
Sorting order in lists with equal sorting criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ✅ Added
+- Add `ChannelMemberListSortingKey.userId` for sorting channel members by id [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
 ### 🐞 Fixed
 - Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
   - Recommendation: Always add at least one unique key to the query's sort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
+  - Recommendation: Always add at least one unique key to the query's sort
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.63.0)
 _September 12, 2024_

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -21,6 +21,8 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var updatedAt: DBDate
     @NSManaged var lastMessageAt: DBDate?
 
+    @NSManaged var localInsertionAt: DBDate
+    
     // The oldest message of the channel we have locally coming from a regular channel query.
     // This property only lives locally, and it is useful to filter out older pinned/quoted messages
     // that do not belong to the regular channel query.
@@ -155,6 +157,7 @@ class ChannelDTO: NSManagedObject {
 
         let new = NSEntityDescription.insertNewObject(into: context, for: request)
         new.cid = cid.rawValue
+        new.localInsertionAt = DBDate()
         return new
     }
 }
@@ -371,9 +374,13 @@ extension ChannelDTO {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
 
         // Fetch results controller requires at least one sorting descriptor.
-        let sortDescriptors = query.sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
-        request.sortDescriptors = sortDescriptors.isEmpty ? [ChannelListSortingKey.defaultSortDescriptor] : sortDescriptors
-
+        var sortDescriptors = query.sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        sortDescriptors = sortDescriptors.isEmpty ? [ChannelListSortingKey.defaultSortDescriptor] : sortDescriptors
+        
+        // For consistent order, we need to have a sort descriptor which breaks ties
+        sortDescriptors.append(NSSortDescriptor(keyPath: \ChannelDTO.localInsertionAt, ascending: true))
+        request.sortDescriptors = sortDescriptors
+        
         let matchingQuery = NSPredicate(format: "ANY queries.filterHash == %@", query.filter.filterHash)
         let notDeleted = NSPredicate(format: "deletedAt == nil")
 

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A335" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -48,6 +48,7 @@
         <attribute name="isFrozen" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lastMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="localInsertionAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="newestMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -179,6 +180,7 @@
         <attribute name="isBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isInvited" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isShadowBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="localInsertionAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="notificationsMuted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -48,7 +48,6 @@
         <attribute name="isFrozen" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lastMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="localInsertionAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="newestMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -180,7 +179,6 @@
         <attribute name="isBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isInvited" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isShadowBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="localInsertionAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="notificationsMuted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -62,7 +62,7 @@ public struct ChannelListSortingKey: SortingKey, Equatable {
 
     /// Sort channels by their unread count.
     public static let unreadCount = Self(
-        keyPath: \.unreadCount,
+        keyPath: \.unreadCount.messages,
         localKey: #keyPath(ChannelDTO.currentUserUnreadMessagesCount),
         remoteKey: "unread_count"
     )

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -124,7 +124,7 @@ extension Array where Element == Sorting<ChannelListSortingKey> {
     }
 }
 
-private extension Sorting where Key == ChannelListSortingKey {
+extension Sorting where Key == ChannelListSortingKey {
     var sortValue: SortValue<ChatChannel>? {
         SortValue(keyPath: key.keyPath, isAscending: isAscending)
     }

--- a/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
@@ -6,8 +6,12 @@ import Foundation
 
 /// `ChannelMemberListSortingKey` describes the keys by which you can get sorted channel members after query.
 public enum ChannelMemberListSortingKey: String, SortingKey {
+    /// Sort channels by creation date.
     case createdAt = "memberCreatedAt"
 
+    /// Sort channels by user id.
+    case userId = "user.id"
+    
     /// Sort channel members by name.
     ///
     /// - Warning: This option is heavy for the backend and can slow down API requests' response time. If there's no explicit requirement for this sorting option consider using a different one.
@@ -21,6 +25,7 @@ public enum ChannelMemberListSortingKey: String, SortingKey {
         /// Sort channel members by date they were created.
         case .createdAt: value = "created_at"
         case .name: value = "name"
+        case .userId: value = "user_id"
         }
 
         try container.encode(value)

--- a/Sources/StreamChat/Query/Sorting/SortValue.swift
+++ b/Sources/StreamChat/Query/Sorting/SortValue.swift
@@ -23,15 +23,15 @@ extension Array {
                 // These are type-erased, therefore we need to manually cast them
                 if let result = nilComparison(lhs: lhsValue, rhs: rhsValue, isAscending: isAscending) {
                     return result
+                } else if let result = areInIncreasingOrder(lhs: lhsValue, rhs: rhsValue, type: Date.self, isAscending: isAscending) {
+                    return result
                 } else if let result = areInIncreasingOrder(lhs: lhsValue, rhs: rhsValue, type: String.self, isAscending: isAscending) {
                     return result
                 } else if let result = areInIncreasingOrder(lhs: lhsValue, rhs: rhsValue, type: Int.self, isAscending: isAscending) {
                     return result
                 } else if let result = areInIncreasingOrder(lhs: lhsValue, rhs: rhsValue, type: Double.self, isAscending: isAscending) {
                     return result
-                } else if let result = areInIncreasingOrder(lhs: lhsValue, rhs: rhsValue, type: Date.self, isAscending: isAscending) {
-                    return result
-                } else if let lBool = lhs as? Bool, let rBool = rhs as? Bool, lBool != rBool {
+                } else if let lBool = lhsValue as? Bool, let rBool = rhsValue as? Bool, lBool != rBool {
                     // Backend considers boolean sorting in reversed order.
                     return isAscending ? lBool && !rBool : !lBool && rBool
                 }
@@ -43,8 +43,11 @@ extension Array {
     /// Dedicated nil handling for Any type which returns false if we do `lhs == nil`.
     private func nilComparison(lhs: Any, rhs: Any, isAscending: Bool) -> Bool? {
         func isAnyNil(_ value: Any) -> Bool {
-            let mirror = Mirror(reflecting: value)
-            return mirror.displayStyle == .optional && mirror.children.isEmpty
+            if case Optional<Any>.none = value {
+                return true
+            } else {
+                return false
+            }
         }
         switch (isAnyNil(lhs), isAnyNil(rhs)) {
         case (true, true): return nil
@@ -54,7 +57,7 @@ extension Array {
         }
     }
     
-    /// Nil, if type mismatches or typed values are equal and we need to consider the next sorting key instead.
+    /// Nil, if type mismatch or typed values are equal and we need to consider the next sorting key instead.
     private func areInIncreasingOrder<T>(lhs: Any, rhs: Any, type: T.Type, isAscending: Bool) -> Bool? where T: Comparable {
         guard let lhs = lhs as? T, let rhs = rhs as? T else { return nil }
         guard lhs != rhs else { return nil }

--- a/Sources/StreamChat/StateLayer/UserSearchState.swift
+++ b/Sources/StreamChat/StateLayer/UserSearchState.swift
@@ -45,7 +45,7 @@ extension UserSearchState {
             let incomingIds = Set(incomingUsers.map(\.id))
             let incomingRemovedUsers = users.filter { !incomingIds.contains($0.id) }
             let sortValues = completedQuery.sort.map(\.sortValue)
-            result = StreamCollection((incomingRemovedUsers + incomingUsers).sort(using: sortValues))
+            result = StreamCollection((incomingRemovedUsers + incomingUsers).sorted(using: sortValues))
         }
         users = result
     }

--- a/Sources/StreamChat/Utils/Codable+Extensions.swift
+++ b/Sources/StreamChat/Utils/Codable+Extensions.swift
@@ -167,11 +167,11 @@ extension DateFormatter {
     }
 }
 
-private extension ISO8601DateFormatter {
+extension ISO8601DateFormatter {
     func dateWithMicroseconds(from string: String) -> Date? {
         guard let date = date(from: string) else { return nil }
         // Manually parse microseconds and nanoseconds, because ISO8601DateFormatter is limited to ms.
-        // Note that Date timeIntervalSince1970 rounds to 0.000_000_1
+        // Note that Date's timeIntervalSince1970 rounds to 0.000_000_1
         guard let index = string.lastIndex(of: ".") else { return date }
         let range = string.suffix(from: index)
             .dropFirst(4) // . and ms part
@@ -181,7 +181,7 @@ private extension ISO8601DateFormatter {
             fractionWithoutMilliseconds = fractionWithoutMilliseconds.padding(toLength: 3, withPad: "0", startingAt: 0)
         }
         guard let microseconds = TimeInterval("0.000".appending(fractionWithoutMilliseconds)) else { return date }
-        return date.addingTimeInterval(microseconds)
+        return Date(timeIntervalSince1970: date.timeIntervalSince1970 + microseconds)
     }
 }
 

--- a/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
+++ b/Sources/StreamChat/Utils/Database/DatabaseItemConverter.swift
@@ -48,6 +48,6 @@ enum DatabaseItemConverter {
                 try itemCreator(dto)
             }
         }
-        return sorting.isEmpty ? items : items.sort(using: sorting)
+        return sorting.isEmpty ? items : items.sorted(using: sorting)
     }
 }

--- a/Sources/StreamChat/Utils/Sequence+CompactMapLoggingError.swift
+++ b/Sources/StreamChat/Utils/Sequence+CompactMapLoggingError.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-extension Collection {
+extension Sequence {
     @inlinable
     func compactMapLoggingError<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) -> [ElementOfResult] {
         compactMap {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -2233,8 +2233,8 @@
 		C14A46562845064E00EF498E /* ThreadSafeWeakCollection_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A46552845064E00EF498E /* ThreadSafeWeakCollection_Tests.swift */; };
 		C14A46582846636900EF498E /* SDKIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A46572846636900EF498E /* SDKIdentifier.swift */; };
 		C14A46592846636900EF498E /* SDKIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A46572846636900EF498E /* SDKIdentifier.swift */; };
-		C14D27B62869EEE40063F6F2 /* Array+CompactMapLoggingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14D27B52869EEE40063F6F2 /* Array+CompactMapLoggingError.swift */; };
-		C14D27B72869EEE40063F6F2 /* Array+CompactMapLoggingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14D27B52869EEE40063F6F2 /* Array+CompactMapLoggingError.swift */; };
+		C14D27B62869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14D27B52869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift */; };
+		C14D27B72869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14D27B52869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift */; };
 		C152F5FE27C65C18003B4805 /* MessageRepository_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C152F5FD27C65C18003B4805 /* MessageRepository_Tests.swift */; };
 		C15C8838286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */; };
 		C15C8839286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */; };
@@ -4377,7 +4377,7 @@
 		C14A46522845043300EF498E /* ThreadSafeWeakCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeWeakCollection.swift; sourceTree = "<group>"; };
 		C14A46552845064E00EF498E /* ThreadSafeWeakCollection_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeWeakCollection_Tests.swift; sourceTree = "<group>"; };
 		C14A46572846636900EF498E /* SDKIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKIdentifier.swift; sourceTree = "<group>"; };
-		C14D27B52869EEE40063F6F2 /* Array+CompactMapLoggingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+CompactMapLoggingError.swift"; sourceTree = "<group>"; };
+		C14D27B52869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+CompactMapLoggingError.swift"; sourceTree = "<group>"; };
 		C152F5FB27C3DC53003B4805 /* MessageRepository_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository_Mock.swift; sourceTree = "<group>"; };
 		C152F5FD27C65C18003B4805 /* MessageRepository_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository_Tests.swift; sourceTree = "<group>"; };
 		C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundListDatabaseObserver.swift; sourceTree = "<group>"; };
@@ -5459,42 +5459,42 @@
 		792A4F3A247FFB7600EAF71D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				8AE335A324FCF95D002B6677 /* InternetConnection */,
 				F6D61D992510B3E300EB0624 /* Database */,
-				ADE2093B29FBEC88007D0FF3 /* MessagesPaginationStateHandling */,
+				8AE335A324FCF95D002B6677 /* InternetConnection */,
 				79BF83EA248F8EC0007611A1 /* Logger */,
+				ADE2093B29FBEC88007D0FF3 /* MessagesPaginationStateHandling */,
 				C1E8AD5A278DDEBB0041B775 /* Operations */,
 				CF324E762832FC1200E5BBE6 /* StreamTimer */,
 				40D3962D2A0910DE0020DDC9 /* Array+Sampling.swift */,
-				40789D3B29F6AD9C0018C2BB /* Debouncer.swift */,
-				AD0F7F162B6139D500914C4C /* TextLinkDetector.swift */,
 				79280F6F2487CD2B00CDEB89 /* Atomic.swift */,
 				797A756724814F0D003CF16D /* Bundle+Extensions.swift */,
 				792A4F3D247FFDE700EAF71D /* Codable+Extensions.swift */,
 				CF6E489E282341F2008416DC /* CountdownTracker.swift */,
 				792A4F3E247FFDE700EAF71D /* Data+Gzip.swift */,
+				40789D3B29F6AD9C0018C2BB /* Debouncer.swift */,
 				88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */,
 				84CF9C72274D473D00BCDE2D /* EventBatcher.swift */,
+				C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */,
 				DBCAFE2325C44B920015AD58 /* LazyCachedMapCollection.swift */,
 				7985BDA9252B1E53002B8C30 /* MainQueue+Synchronous.swift */,
 				79CD959124F9380B00E87377 /* MulticastDelegate.swift */,
 				881506EB258212BF0013935B /* MultipartFormData.swift */,
+				C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */,
 				E7DD8EC025E4083B0059A322 /* OptionalDecodable.swift */,
 				792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */,
 				DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */,
 				DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */,
+				C14D27B52869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift */,
 				4FDAD05D2BC8179E004048E8 /* StateBuilder.swift */,
 				4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */,
 				797A756524814EF8003CF16D /* SystemEnvironment.swift */,
 				CFA41B6527DA724400427602 /* SystemEnvironment+XStreamClient.swift */,
+				AD0F7F162B6139D500914C4C /* TextLinkDetector.swift */,
 				C14A46522845043300EF498E /* ThreadSafeWeakCollection.swift */,
 				792A4F3B247FFBB400EAF71D /* Timers.swift */,
+				79D5CDD027EA1BA100BE7D8B /* TranslationLanguage.swift */,
 				797E10A724EAF6DE00353791 /* UniqueId.swift */,
 				4F910C6B2BEE1BDC00214EB9 /* UnreadMessageLookup.swift */,
-				C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */,
-				79D5CDD027EA1BA100BE7D8B /* TranslationLanguage.swift */,
-				C14D27B52869EEE40063F6F2 /* Array+CompactMapLoggingError.swift */,
-				C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -11277,7 +11277,7 @@
 				792A4F39247FFACB00EAF71D /* WebSocketEngine.swift in Sources */,
 				4F97F26D2BA858E9001C4D66 /* UserSearch.swift in Sources */,
 				79280F422484F4EC00CDEB89 /* Event.swift in Sources */,
-				C14D27B62869EEE40063F6F2 /* Array+CompactMapLoggingError.swift in Sources */,
+				C14D27B62869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift in Sources */,
 				79682C4A24BF37C80071578E /* MessagePayloads.swift in Sources */,
 				8AAB1C6624CB39F2009B783F /* UnreadCount.swift in Sources */,
 				79877A282498E50D00015F8B /* UserDTO.swift in Sources */,
@@ -12000,7 +12000,7 @@
 				C121E82B274544AD00023E4C /* APIPathConvertible.swift in Sources */,
 				AD8FEE5C2AA8E1E400273F88 /* ChatClientFactory.swift in Sources */,
 				40789D2E29F6AC500018C2BB /* AudioRecordingState.swift in Sources */,
-				C14D27B72869EEE40063F6F2 /* Array+CompactMapLoggingError.swift in Sources */,
+				C14D27B72869EEE40063F6F2 /* Sequence+CompactMapLoggingError.swift in Sources */,
 				C121E82C274544AD00023E4C /* APIClient.swift in Sources */,
 				AD0CC0322BDC1964005E2C66 /* ReactionListQueryDTO.swift in Sources */,
 				C121E82D274544AD00023E4C /* CDNClient.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 		4F1FB7D82C7DEC6600C47C2A /* ChatMessageVideoAttachment_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1FB7D72C7DEC6600C47C2A /* ChatMessageVideoAttachment_Mock.swift */; };
 		4F312D0E2C905A2E0073A1BC /* FlagRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */; };
 		4F312D0F2C905A2E0073A1BC /* FlagRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */; };
+		4F3554982C9C0F7200479229 /* StreamJSONDecoder_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3554972C9C0F6500479229 /* StreamJSONDecoder_Tests.swift */; };
 		4F427F662BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F672BA2F43200D92238 /* ConnectedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F652BA2F43200D92238 /* ConnectedUser.swift */; };
 		4F427F692BA2F52100D92238 /* ConnectedUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F427F682BA2F52100D92238 /* ConnectedUserState.swift */; };
@@ -3103,6 +3104,7 @@
 		4F1FB7D52C7DE22D00C47C2A /* ChatMessageAudioAttachment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAudioAttachment_Mock.swift; sourceTree = "<group>"; };
 		4F1FB7D72C7DEC6600C47C2A /* ChatMessageVideoAttachment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageVideoAttachment_Mock.swift; sourceTree = "<group>"; };
 		4F312D0D2C905A2E0073A1BC /* FlagRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagRequestBody.swift; sourceTree = "<group>"; };
+		4F3554972C9C0F6500479229 /* StreamJSONDecoder_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamJSONDecoder_Tests.swift; sourceTree = "<group>"; };
 		4F427F652BA2F43200D92238 /* ConnectedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUser.swift; sourceTree = "<group>"; };
 		4F427F682BA2F52100D92238 /* ConnectedUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedUserState.swift; sourceTree = "<group>"; };
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
@@ -7398,7 +7400,11 @@
 		A364D0BB27D12AD50029857A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				ADEDA1F92B2BC46C00020460 /* RepeatingTimer_Tests.swift */,
+				A364D0BD27D12C600029857A /* Database */,
+				A3F65E3B27EB7357003F6256 /* EquatableEvent */,
+				A364D0BE27D12C950029857A /* InternetConnection */,
+				ADF617662A09925300E70307 /* MessagesPaginationStateHandling */,
+				A364D0C127D12EC30029857A /* Operations */,
 				40D3962B2A0910CF0020DDC9 /* ArraySampling_Tests.swift */,
 				CF1F1D442824243F002E2977 /* CooldownTracker_Tests.swift */,
 				40789D3E29F6AFC40018C2BB /* Debouncer_Tests.swift */,
@@ -7407,16 +7413,13 @@
 				BCE48068C1C02C0689BEB64E /* JSONDecoder_Tests.swift */,
 				BCE489A4B136D48249DD6969 /* JSONEncoder_Tests.swift */,
 				DB842E4425C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift */,
+				AD5BCCC82AB22A6600456CD9 /* Logger_Tests.swift */,
 				79CD959324F9381700E87377 /* MulticastDelegate_Tests.swift */,
 				C163ECFD2992B06C006D6124 /* NotificationExtensionLifecycle_Tests.swift */,
-				C14A46552845064E00EF498E /* ThreadSafeWeakCollection_Tests.swift */,
-				AD5BCCC82AB22A6600456CD9 /* Logger_Tests.swift */,
-				ADF617662A09925300E70307 /* MessagesPaginationStateHandling */,
-				A364D0BD27D12C600029857A /* Database */,
-				A3F65E3B27EB7357003F6256 /* EquatableEvent */,
-				A364D0BE27D12C950029857A /* InternetConnection */,
-				A364D0C127D12EC30029857A /* Operations */,
+				ADEDA1F92B2BC46C00020460 /* RepeatingTimer_Tests.swift */,
+				4F3554972C9C0F6500479229 /* StreamJSONDecoder_Tests.swift */,
 				AD0F7F1B2B616DD000914C4C /* TextLinkDetector_Tests.swift */,
+				C14A46552845064E00EF498E /* ThreadSafeWeakCollection_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -11485,6 +11488,7 @@
 				A34ECB4827F5C9FA00A804C1 /* UserEvents_IntegrationTests.swift in Sources */,
 				AD6E32962BBB10890073831B /* ThreadListPayload_Tests.swift in Sources */,
 				8A0175F425013B6400570345 /* TypingEventSender_Tests.swift in Sources */,
+				4F3554982C9C0F7200479229 /* StreamJSONDecoder_Tests.swift in Sources */,
 				C149B744282A61FF00F25BED /* NSManagedObject+Validation_Tests.swift in Sources */,
 				AD94905A2BF5702700E69224 /* ThreadsRepository_Tests.swift in Sources */,
 				8875CF9B2587A89F00BBA6AC /* AttachmentId_Tests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Extensions/String+Date.swift
+++ b/TestTools/StreamChatTestTools/Extensions/String+Date.swift
@@ -8,6 +8,9 @@ import Foundation
 public extension String {
     /// Converst a string to `Date`. Only for testing!
     func toDate() -> Date {
-        DateFormatter.Stream.rfc3339Date(from: self)!
+        if let date = JSONDecoder.stream.iso8601formatter.dateWithMicroseconds(from: self) {
+            return date
+        }
+        return DateFormatter.Stream.rfc3339Date(from: self)!
     }
 }

--- a/TestTools/StreamChatTestTools/TestData/DummyData/UserPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/UserPayload.swift
@@ -9,7 +9,7 @@ extension UserPayload {
     /// Returns a dummy user payload with the given `id` and `extraData`
     static func dummy(
         userId: UserId,
-        name: String = .unique,
+        name: String? = .unique,
         imageUrl: URL? = .unique(),
         role: UserRole = .admin,
         extraData: [String: RawJSON] = [:],

--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -339,6 +339,26 @@ final class DatabaseContainer_Tests: XCTestCase {
         }
     }
     
+    func test_storingMicrosecondsDate() throws {
+        let expectedCreatedAt = Date(timeIntervalSinceReferenceDate: 0.000123123)
+        let currentUserId = String.unique
+        let container = DatabaseContainer_Spy()
+        try container.writeSynchronously { session in
+            try session.saveCurrentUser(
+                payload: .dummy(
+                    userId: currentUserId,
+                    createdAt: expectedCreatedAt,
+                    role: .admin
+                )
+            )
+        }
+        let user = try container.readSynchronously { session in
+            try XCTUnwrap(session.currentUser).asModel()
+        }
+        // Note! Date limits precision to 0.000_000_1
+        XCTAssertEqual(978_307_200.000_123_1, user.userCreatedAt.timeIntervalSince1970, "Microseconds date is not stored correctly")
+    }
+    
     // MARK: -
     
     private func writeDataForAllEntities(to container: DatabaseContainer) throws {

--- a/Tests/StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
@@ -11,7 +11,7 @@ final class ChannelMemberListSortingKey_Tests: XCTestCase {
     func test_sortDescriptor_keyPaths_areValid() throws {
         // Put all `ChannelMemberListSortingKey`s in an array
         // We don't use `CaseIterable` since we only need this for tests
-        let sortingKeys: [ChannelMemberListSortingKey] = [.createdAt, .name]
+        let sortingKeys: [ChannelMemberListSortingKey] = [.createdAt, .name, .userId]
 
         // Iterate over keys...
         for key in sortingKeys {
@@ -24,6 +24,8 @@ final class ChannelMemberListSortingKey_Tests: XCTestCase {
                     ChannelMemberListSortingKey.name.rawValue,
                     NSExpression(forKeyPath: \MemberDTO.user.name).keyPath
                 )
+            case .userId:
+                XCTAssertEqual(key.rawValue, NSExpression(forKeyPath: \MemberDTO.user.id).keyPath)
             }
         }
     }

--- a/Tests/StreamChatTests/Query/Sorting/SortingValue_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/SortingValue_Tests.swift
@@ -28,7 +28,7 @@ final class SortingValue_Tests: XCTestCase {
             channel3,
             channel4,
             channel5
-        ].sort(using: sorting)
+        ].sorted(using: sorting)
 
         XCTAssertEqual(result.map(\.name), ["A", "B", "C", "D", "E"])
     }
@@ -44,7 +44,7 @@ final class SortingValue_Tests: XCTestCase {
             channel3,
             channel4,
             channel5
-        ].sort(using: sorting)
+        ].sorted(using: sorting)
 
         XCTAssertEqual(result.map(\.name), ["B", "D", "A", "E", "C"])
     }
@@ -61,7 +61,7 @@ final class SortingValue_Tests: XCTestCase {
             channel3,
             channel4,
             channel5
-        ].sort(using: sorting)
+        ].sorted(using: sorting)
 
         XCTAssertEqual(result.map(\.name), ["D", "B", "E", "A", "C"])
     }
@@ -70,20 +70,20 @@ final class SortingValue_Tests: XCTestCase {
     
     func test_sortingValue_channelList_whenNonNilValues_thenEqualsToNSSortDesciptorSorting() {
         let channels = [
-            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 15),
-            makeChannel(cidIndex: 2, lastMessageAtOffset: 2, updatedAtOffset: 14),
-            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, updatedAtOffset: 13),
-            makeChannel(cidIndex: 4, lastMessageAtOffset: 4, updatedAtOffset: 12),
-            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, updatedAtOffset: 11)
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, createdAtOffset: 15),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: 2, createdAtOffset: 14),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, createdAtOffset: 13),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: 4, createdAtOffset: 12),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, createdAtOffset: 11)
         ]
         let sortingKeys: [Sorting<ChannelListSortingKey>] = [
             Sorting(key: .lastMessageAt, isAscending: false),
-            Sorting(key: .updatedAt, isAscending: false)
+            Sorting(key: .createdAt, isAscending: false)
         ]
         let runtimeSortResult = channels
-            .sort(using: sortingKeys.compactMap(\.sortValue))
+            .sorted(using: sortingKeys.compactMap(\.sortValue))
             .map(\.cid.id)
-        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let nsArrayChannels = NSArray(array: channels.map { ChannelBoxed(channel: $0) })
         let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
         let expectedIds = ["5", "4", "3", "2", "1"]
@@ -93,23 +93,23 @@ final class SortingValue_Tests: XCTestCase {
     
     func test_sortingValue_channelList_whenSomeNilValues_thenEqualsToNSSortDesciptorSorting() {
         let channels = [
-            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 15),
-            makeChannel(cidIndex: 2, lastMessageAtOffset: nil, updatedAtOffset: 14),
-            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, updatedAtOffset: 13),
-            makeChannel(cidIndex: 4, lastMessageAtOffset: nil, updatedAtOffset: 12),
-            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, updatedAtOffset: 11)
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, createdAtOffset: 15),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: nil, createdAtOffset: 14),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, createdAtOffset: 13),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: nil, createdAtOffset: 12),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, createdAtOffset: 11)
         ]
         let sortingKeys: [Sorting<ChannelListSortingKey>] = [
             Sorting(key: .lastMessageAt, isAscending: false),
-            Sorting(key: .updatedAt, isAscending: false)
+            Sorting(key: .createdAt, isAscending: false)
         ]
         let sortValues = sortingKeys.compactMap(\.sortValue)
         XCTAssertEqual(2, sortValues.count)
         let runtimeSortResult = channels
-            .sort(using: sortValues)
+            .sorted(using: sortValues)
             .map(\.cid.id)
         
-        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let nsArrayChannels = NSArray(array: channels.map { ChannelBoxed(channel: $0) })
         let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         XCTAssertEqual(2, sortDescriptors.count)
         
@@ -121,23 +121,23 @@ final class SortingValue_Tests: XCTestCase {
     
     func test_sortingValue_channelList_whenSomeEqualValues_thenEqualsToNSSortDesciptorSorting() {
         let channels = [
-            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 15),
-            makeChannel(cidIndex: 2, lastMessageAtOffset: 3, updatedAtOffset: 14),
-            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, updatedAtOffset: 13),
-            makeChannel(cidIndex: 4, lastMessageAtOffset: 3, updatedAtOffset: 12),
-            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, updatedAtOffset: 11)
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, createdAtOffset: 15),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: 3, createdAtOffset: 14),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, createdAtOffset: 13),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: 3, createdAtOffset: 12),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, createdAtOffset: 11)
         ]
         let sortingKeys: [Sorting<ChannelListSortingKey>] = [
             Sorting(key: .lastMessageAt, isAscending: false),
-            Sorting(key: .updatedAt, isAscending: false)
+            Sorting(key: .createdAt, isAscending: false)
         ]
         let sortValues = sortingKeys.compactMap(\.sortValue)
         XCTAssertEqual(2, sortValues.count)
         let runtimeSortResult = channels
-            .sort(using: sortValues)
+            .sorted(using: sortValues)
             .map(\.cid.id)
         
-        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let nsArrayChannels = NSArray(array: channels.map { ChannelBoxed(channel: $0) })
         let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         XCTAssertEqual(2, sortDescriptors.count)
         
@@ -149,28 +149,56 @@ final class SortingValue_Tests: XCTestCase {
     
     func test_sortingValue_channelList_whenAllEqualValues_thenEqualsToNSSortDesciptorSortingAndInitialOrderIsKept() {
         let channels = [
-            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 11),
-            makeChannel(cidIndex: 2, lastMessageAtOffset: 1, updatedAtOffset: 11),
-            makeChannel(cidIndex: 3, lastMessageAtOffset: 1, updatedAtOffset: 11),
-            makeChannel(cidIndex: 4, lastMessageAtOffset: 1, updatedAtOffset: 11),
-            makeChannel(cidIndex: 5, lastMessageAtOffset: 1, updatedAtOffset: 11)
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, createdAtOffset: 11),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: 1, createdAtOffset: 11),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 1, createdAtOffset: 11),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: 1, createdAtOffset: 11),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 1, createdAtOffset: 11)
         ]
         let sortingKeys: [Sorting<ChannelListSortingKey>] = [
             Sorting(key: .lastMessageAt, isAscending: false),
-            Sorting(key: .updatedAt, isAscending: false)
+            Sorting(key: .createdAt, isAscending: false)
         ]
         let sortValues = sortingKeys.compactMap(\.sortValue)
         XCTAssertEqual(2, sortValues.count)
         let runtimeSortResult = channels
-            .sort(using: sortValues)
+            .sorted(using: sortValues)
             .map(\.cid.id)
         
-        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let nsArrayChannels = NSArray(array: channels.map { ChannelBoxed(channel: $0) })
         let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         XCTAssertEqual(2, sortDescriptors.count)
         
         let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
         let expectedIds = ["1", "2", "3", "4", "5"]
+        XCTAssertEqual(expectedIds, sortDescriptorResult, "\(sortDescriptorResult)")
+        XCTAssertEqual(expectedIds, runtimeSortResult, "\(runtimeSortResult)")
+    }
+    
+    func test_sortingValue_channelList_whenSomeEqualValuesAndDescendingAndAscending_thenEqualsToNSSortDesciptorSorting() {
+        let channels = [
+            makeChannel(cidIndex: 1, createdAtOffset: 1, unreadMessages: 3),
+            makeChannel(cidIndex: 2, createdAtOffset: 2, unreadMessages: 0),
+            makeChannel(cidIndex: 3, createdAtOffset: 3, unreadMessages: 2),
+            makeChannel(cidIndex: 4, createdAtOffset: 4, unreadMessages: 0),
+            makeChannel(cidIndex: 5, createdAtOffset: 5, unreadMessages: 0)
+        ]
+        let sortingKeys: [Sorting<ChannelListSortingKey>] = [
+            Sorting(key: .unreadCount, isAscending: false),
+            Sorting(key: .createdAt, isAscending: true)
+        ]
+        let sortValues = sortingKeys.compactMap(\.sortValue)
+        XCTAssertEqual(2, sortValues.count)
+        let runtimeSortResult = channels
+            .sorted(using: sortValues)
+            .map(\.cid.id)
+        
+        let nsArrayChannels = NSArray(array: channels.map { ChannelBoxed(channel: $0) })
+        let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        XCTAssertEqual(2, sortDescriptors.count)
+        
+        let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
+        let expectedIds = ["1", "3", "2", "4", "5"]
         XCTAssertEqual(expectedIds, sortDescriptorResult, "\(sortDescriptorResult)")
         XCTAssertEqual(expectedIds, runtimeSortResult, "\(runtimeSortResult)")
     }
@@ -186,16 +214,18 @@ final class SortingValue_Tests: XCTestCase {
         
         @objc var id: String? { channel.cid.id }
         @objc var lastMessageAt: NSDate? { channel.lastMessageAt as? NSDate }
-        @objc var updatedAt: NSDate { channel.updatedAt as NSDate }
+        @objc var createdAt: NSDate { channel.createdAt as NSDate }
+        @objc var currentUserUnreadMessagesCount: Int { channel.unreadCount.messages }
     }
     
     static let referenceDate = Date().addingTimeInterval(-3600)
     
-    func makeChannel(cidIndex: Int, lastMessageAtOffset: Int?, updatedAtOffset: Int) -> ChatChannel {
+    func makeChannel(cidIndex: Int, lastMessageAtOffset: Int? = nil, createdAtOffset: Int, unreadMessages: Int = 0) -> ChatChannel {
         ChatChannel.mock(
             cid: ChannelId(type: .messaging, id: "\(cidIndex)"),
             lastMessageAt: lastMessageAtOffset != nil ? Self.referenceDate.addingTimeInterval(TimeInterval(lastMessageAtOffset!)) : nil,
-            updatedAt: Self.referenceDate.addingTimeInterval(TimeInterval(updatedAtOffset))
+            createdAt: Self.referenceDate.addingTimeInterval(TimeInterval(createdAtOffset)),
+            unreadCount: ChannelUnreadCount(messages: unreadMessages, mentions: 0)
         )
     }
 }

--- a/Tests/StreamChatTests/Query/Sorting/SortingValue_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/SortingValue_Tests.swift
@@ -65,4 +65,137 @@ final class SortingValue_Tests: XCTestCase {
 
         XCTAssertEqual(result.map(\.name), ["D", "B", "E", "A", "C"])
     }
+    
+    // MARK: - NSSortDescriptor Comparisons
+    
+    func test_sortingValue_channelList_whenNonNilValues_thenEqualsToNSSortDesciptorSorting() {
+        let channels = [
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 15),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: 2, updatedAtOffset: 14),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, updatedAtOffset: 13),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: 4, updatedAtOffset: 12),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, updatedAtOffset: 11)
+        ]
+        let sortingKeys: [Sorting<ChannelListSortingKey>] = [
+            Sorting(key: .lastMessageAt, isAscending: false),
+            Sorting(key: .updatedAt, isAscending: false)
+        ]
+        let runtimeSortResult = channels
+            .sort(using: sortingKeys.compactMap(\.sortValue))
+            .map(\.cid.id)
+        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
+        let expectedIds = ["5", "4", "3", "2", "1"]
+        XCTAssertEqual(expectedIds, sortDescriptorResult, "\(sortDescriptorResult)")
+        XCTAssertEqual(expectedIds, runtimeSortResult, "\(runtimeSortResult)")
+    }
+    
+    func test_sortingValue_channelList_whenSomeNilValues_thenEqualsToNSSortDesciptorSorting() {
+        let channels = [
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 15),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: nil, updatedAtOffset: 14),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, updatedAtOffset: 13),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: nil, updatedAtOffset: 12),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, updatedAtOffset: 11)
+        ]
+        let sortingKeys: [Sorting<ChannelListSortingKey>] = [
+            Sorting(key: .lastMessageAt, isAscending: false),
+            Sorting(key: .updatedAt, isAscending: false)
+        ]
+        let sortValues = sortingKeys.compactMap(\.sortValue)
+        XCTAssertEqual(2, sortValues.count)
+        let runtimeSortResult = channels
+            .sort(using: sortValues)
+            .map(\.cid.id)
+        
+        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        XCTAssertEqual(2, sortDescriptors.count)
+        
+        let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
+        let expectedIds = ["5", "3", "1", "2", "4"]
+        XCTAssertEqual(expectedIds, sortDescriptorResult, "\(sortDescriptorResult)")
+        XCTAssertEqual(expectedIds, runtimeSortResult, "\(runtimeSortResult)")
+    }
+    
+    func test_sortingValue_channelList_whenSomeEqualValues_thenEqualsToNSSortDesciptorSorting() {
+        let channels = [
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 15),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: 3, updatedAtOffset: 14),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 3, updatedAtOffset: 13),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: 3, updatedAtOffset: 12),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 5, updatedAtOffset: 11)
+        ]
+        let sortingKeys: [Sorting<ChannelListSortingKey>] = [
+            Sorting(key: .lastMessageAt, isAscending: false),
+            Sorting(key: .updatedAt, isAscending: false)
+        ]
+        let sortValues = sortingKeys.compactMap(\.sortValue)
+        XCTAssertEqual(2, sortValues.count)
+        let runtimeSortResult = channels
+            .sort(using: sortValues)
+            .map(\.cid.id)
+        
+        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        XCTAssertEqual(2, sortDescriptors.count)
+        
+        let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
+        let expectedIds = ["5", "2", "3", "4", "1"]
+        XCTAssertEqual(expectedIds, sortDescriptorResult, "\(sortDescriptorResult)")
+        XCTAssertEqual(expectedIds, runtimeSortResult, "\(runtimeSortResult)")
+    }
+    
+    func test_sortingValue_channelList_whenAllEqualValues_thenEqualsToNSSortDesciptorSortingAndInitialOrderIsKept() {
+        let channels = [
+            makeChannel(cidIndex: 1, lastMessageAtOffset: 1, updatedAtOffset: 11),
+            makeChannel(cidIndex: 2, lastMessageAtOffset: 1, updatedAtOffset: 11),
+            makeChannel(cidIndex: 3, lastMessageAtOffset: 1, updatedAtOffset: 11),
+            makeChannel(cidIndex: 4, lastMessageAtOffset: 1, updatedAtOffset: 11),
+            makeChannel(cidIndex: 5, lastMessageAtOffset: 1, updatedAtOffset: 11)
+        ]
+        let sortingKeys: [Sorting<ChannelListSortingKey>] = [
+            Sorting(key: .lastMessageAt, isAscending: false),
+            Sorting(key: .updatedAt, isAscending: false)
+        ]
+        let sortValues = sortingKeys.compactMap(\.sortValue)
+        XCTAssertEqual(2, sortValues.count)
+        let runtimeSortResult = channels
+            .sort(using: sortValues)
+            .map(\.cid.id)
+        
+        let nsArrayChannels = NSArray(array: channels.map({ ChannelBoxed(channel: $0) }))
+        let sortDescriptors = sortingKeys.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        XCTAssertEqual(2, sortDescriptors.count)
+        
+        let sortDescriptorResult = (nsArrayChannels.sortedArray(using: sortDescriptors) as! [ChannelBoxed]).compactMap(\.id)
+        let expectedIds = ["1", "2", "3", "4", "5"]
+        XCTAssertEqual(expectedIds, sortDescriptorResult, "\(sortDescriptorResult)")
+        XCTAssertEqual(expectedIds, runtimeSortResult, "\(runtimeSortResult)")
+    }
+    
+    // MARK: -
+    
+    class ChannelBoxed: NSObject {
+        let channel: ChatChannel
+        
+        init(channel: ChatChannel) {
+            self.channel = channel
+        }
+        
+        @objc var id: String? { channel.cid.id }
+        @objc var lastMessageAt: NSDate? { channel.lastMessageAt as? NSDate }
+        @objc var updatedAt: NSDate { channel.updatedAt as NSDate }
+    }
+    
+    static let referenceDate = Date().addingTimeInterval(-3600)
+    
+    func makeChannel(cidIndex: Int, lastMessageAtOffset: Int?, updatedAtOffset: Int) -> ChatChannel {
+        ChatChannel.mock(
+            cid: ChannelId(type: .messaging, id: "\(cidIndex)"),
+            lastMessageAt: lastMessageAtOffset != nil ? Self.referenceDate.addingTimeInterval(TimeInterval(lastMessageAtOffset!)) : nil,
+            updatedAt: Self.referenceDate.addingTimeInterval(TimeInterval(updatedAtOffset))
+        )
+    }
 }

--- a/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
@@ -161,6 +161,64 @@ final class ChannelList_Tests: XCTestCase {
         XCTAssertEqual(expectedChannels.map(\.channel.cid.rawValue), await channelList.state.channels.map(\.cid.rawValue))
     }
     
+    func test_loadChannels_whenSortingByEqualLastMessageAt_thenSortingOrderDoesNotChange() async throws {
+        await setUpChannelList(
+            usesMockedChannelUpdater: false,
+            sort: [.init(key: .lastMessageAt, isAscending: false)]
+        )
+        let equalLastMessageAt = Date()
+        
+        // Fetch 10 channels with the same lastMessageAt
+        let payload1 = makeMatchingChannelListPayload(
+            channelCount: 10,
+            createdAtOffset: 0,
+            messagesCreator: { cid in
+                [MessagePayload.dummy(createdAt: equalLastMessageAt, cid: cid)]
+            }
+        )
+        let payload1Cids = payload1.channels.map(\.channel.cid)
+        env.client.mockAPIClient.test_mockResponseResult(.success(payload1))
+        try await channelList.get()
+        let allCids1 = await channelList.state.channels.map(\.cid)
+        XCTAssertEqual(payload1Cids, allCids1)
+        
+        // Update some of the channels which makes FRC to refetch
+        try await env.client.mockDatabaseContainer.write { session in
+            for index in [3, 5, 7] {
+                let channel = payload1.channels[index].channel
+                try session.saveChannel(
+                    payload: .dummy(
+                        channel: .dummy(cid: channel.cid, lastMessageAt: equalLastMessageAt, createdAt: channel.createdAt),
+                        messages: [MessagePayload.dummy(createdAt: equalLastMessageAt, cid: channel.cid)]
+                    )
+                )
+            }
+        }
+        let allCids2 = await channelList.state.channels.map(\.cid)
+        XCTAssertEqual(payload1Cids, allCids2)
+        
+        // Fetch 10 more channels with the same lastMessageAt
+        let payload2 = makeMatchingChannelListPayload(
+            channelCount: 10,
+            createdAtOffset: 10,
+            messagesCreator: { cid in
+                [MessagePayload.dummy(createdAt: equalLastMessageAt, cid: cid)]
+            }
+        )
+        let payload2Cids = payload2.channels.map(\.channel.cid)
+        env.client.mockAPIClient.test_mockResponseResult(.success(payload2))
+        let loadMoreCids = try await channelList.loadMoreChannels(limit: 10).map(\.cid)
+        XCTAssertEqual(payload2Cids, loadMoreCids)
+        
+        let allCidsState3 = await channelList.state.channels.map(\.cid)
+        let allPayloadCids = payload1Cids + payload2Cids
+        XCTAssertEqual(
+            allPayloadCids,
+            allCidsState3,
+            "Exactly the same order as payload returned should be kept locally"
+        )
+    }
+    
     // MARK: - Observing the Core Data Store
     
     func test_observingLocalStore_whenStoreChanges_thenStateChanges() async throws {
@@ -287,9 +345,14 @@ final class ChannelList_Tests: XCTestCase {
     // MARK: - Test Data
     
     /// For tests which rely on the channel updater to update the local database.
-    @MainActor private func setUpChannelList(usesMockedChannelUpdater: Bool, loadState: Bool = true, dynamicFilter: ((ChatChannel) -> Bool)? = nil) {
+    @MainActor private func setUpChannelList(
+        usesMockedChannelUpdater: Bool,
+        loadState: Bool = true,
+        sort: [Sorting<ChannelListSortingKey>] = [.init(key: .createdAt, isAscending: true)],
+        dynamicFilter: ((ChatChannel) -> Bool)? = nil
+    ) {
         channelList = ChannelList(
-            query: ChannelListQuery(filter: .in(.members, values: [memberId]), sort: [.init(key: .createdAt, isAscending: true)]),
+            query: ChannelListQuery(filter: .in(.members, values: [memberId]), sort: sort),
             dynamicFilter: dynamicFilter,
             client: env.client,
             environment: env.channelListEnvironment(usesMockedUpdater: usesMockedChannelUpdater)
@@ -309,13 +372,20 @@ final class ChannelList_Tests: XCTestCase {
         makeMatchingChannelListPayload(channelCount: 1, createdAtOffset: createdAtOffset).channels[0]
     }
     
-    private func makeMatchingChannelListPayload(channelCount: Int, createdAtOffset: Int, namePrefix: String = "Name") -> ChannelListPayload {
+    private func makeMatchingChannelListPayload(
+        channelCount: Int,
+        createdAtOffset: Int,
+        namePrefix: String = "Name",
+        messagesCreator: ((ChannelId) -> [MessagePayload])? = nil
+    ) -> ChannelListPayload {
         let channelPayloads = (0..<channelCount)
             .map {
-                dummyPayload(
-                    with: ChannelId(type: .messaging, id: "cid\($0 + createdAtOffset)"),
+                let channelId = ChannelId(type: .messaging, id: "cid\($0 + createdAtOffset)")
+                return dummyPayload(
+                    with: channelId,
                     name: "\(namePrefix) \($0 + createdAtOffset)",
                     members: [.dummy(user: .dummy(userId: memberId))],
+                    messages: messagesCreator?(channelId),
                     createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval($0 + createdAtOffset))
                 )
             }

--- a/Tests/StreamChatTests/Utils/JSONDecoder_Tests.swift
+++ b/Tests/StreamChatTests/Utils/JSONDecoder_Tests.swift
@@ -169,7 +169,7 @@ final class JSONDecoder_Tests: XCTestCase {
         XCTAssertEqual(dateCache.getObjectCalledCounter, 5)
 
         // The actual decoded date must match the date JSONDecoder decoded and cached
-        let actualDecodedDate = Date(timeIntervalSince1970: 1_591_690_240.8)
+        let actualDecodedDate = Date(timeIntervalSince1970: 1_591_690_240.800_912)
         XCTAssertEqual(dateCache.object(forKey: repeatedDate as NSString)?.timeIntervalSince1970, actualDecodedDate.timeIntervalSince1970)
 
         // All dates must be decoded

--- a/Tests/StreamChatTests/Utils/StreamJSONDecoder_Tests.swift
+++ b/Tests/StreamChatTests/Utils/StreamJSONDecoder_Tests.swift
@@ -26,13 +26,13 @@ final class StreamJSONDecoderTests: XCTestCase {
     
     func test_parsingDate_whenMicrosecondsTruncated_thenReturnsDateWithMicroseconds() throws {
         // Last 0 is not there
-        let jsonData = jsonDataForItem(withDateString: "2024-06-14T16:24:37.63793Z")
+        let jsonData = jsonDataForItem(withDateString: "2024-06-14T16:24:37.63784Z")
         let item = try streamJSONDecoder.decode(Item.self, from: jsonData)
-        XCTAssertEqual(1_718_382_277.637_930, item.date.timeIntervalSince1970)
+        XCTAssertEqual(1_718_382_277.637_840, item.date.timeIntervalSince1970)
         
-        let jsonData2 = jsonDataForItem(withDateString: "2024-06-14T16:24:37.637930Z")
+        let jsonData2 = jsonDataForItem(withDateString: "2024-06-14T16:24:37.637840Z")
         let item2 = try streamJSONDecoder.decode(Item.self, from: jsonData2)
-        XCTAssertEqual(1_718_382_277.637_930, item2.date.timeIntervalSince1970)
+        XCTAssertEqual(1_718_382_277.637_840, item2.date.timeIntervalSince1970)
     }
     
     func test_parsingDate_whenNanoseconds_thenReturnsDateWithTruncatedNanoseconds() throws {

--- a/Tests/StreamChatTests/Utils/StreamJSONDecoder_Tests.swift
+++ b/Tests/StreamChatTests/Utils/StreamJSONDecoder_Tests.swift
@@ -1,0 +1,60 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class StreamJSONDecoderTests: XCTestCase {
+    private var streamJSONDecoder: StreamJSONDecoder!
+    
+    override func setUpWithError() throws {
+        streamJSONDecoder = StreamJSONDecoder()
+    }
+    
+    override func tearDownWithError() throws {
+        streamJSONDecoder = nil
+    }
+    
+    func test_parsingDate_whenMicroseconds_thenReturnsDateWithMicroseconds() throws {
+        let jsonData = jsonDataForItem(withDateString: "2024-06-24T21:00:33.167806Z")
+        let item = try streamJSONDecoder.decode(Item.self, from: jsonData)
+        XCTAssertEqual(1_719_262_833.167_806_1, item.date.timeIntervalSince1970)
+    }
+    
+    func test_parsingDate_whenMicrosecondsTruncated_thenReturnsDateWithMicroseconds() throws {
+        // Last 0 is not there
+        let jsonData = jsonDataForItem(withDateString: "2024-06-14T16:24:37.63793Z")
+        let item = try streamJSONDecoder.decode(Item.self, from: jsonData)
+        XCTAssertEqual(1_718_382_277.637_930, item.date.timeIntervalSince1970)
+        
+        let jsonData2 = jsonDataForItem(withDateString: "2024-06-14T16:24:37.637930Z")
+        let item2 = try streamJSONDecoder.decode(Item.self, from: jsonData2)
+        XCTAssertEqual(1_718_382_277.637_930, item2.date.timeIntervalSince1970)
+    }
+    
+    func test_parsingDate_whenNanoseconds_thenReturnsDateWithTruncatedNanoseconds() throws {
+        // Date interval is limited to 0.000_000_1 so the last 2 digits are dropped and it gets rounded
+        let jsonData = jsonDataForItem(withDateString: "2024-09-18T13:49:11.324282561Z")
+        let item = try streamJSONDecoder.decode(Item.self, from: jsonData)
+        print(item.date.timeIntervalSince1970)
+        XCTAssertEqual(1_726_667_351.324_282_5, item.date.timeIntervalSince1970, accuracy: 0.000_000_1)
+    }
+}
+
+private extension StreamJSONDecoderTests {
+    struct Item: Codable {
+        let date: Date
+    }
+    
+    func jsonDataForItem(withDateString dateString: String) -> Data {
+        let string = """
+        {
+          "date": "\(dateString)"
+        }
+        """
+        return Data(string.utf8)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5993](https://stream-io.atlassian.net/browse/PBE-5993)

### 🎯 Goal

When sorting by key(s) with equal values the sort order in SDK models is kept unchanged

### 📝 Summary

> Recommendation: Always try to add sorting criteria what contains one sorting key with unique values.

- Fix an issue where microseconds in timestamps were ignored causing channel list sorting to have many channels with the same `lastMessageAt` timestamp (triggers active reordering)
- Fix an issue where just sorting by `unreadCount` or other Int or Bool keys led to unexpected reordering in the channel list (many channels with equal sorting value). Break this by adding `updatedAt` sorting key internally.
- Fix an issue of runtime sorting (post FRC sorting used when FRC does not support sorting key) returning incorrect order
- Add `ChannelMemberListSortingKey.userId` for sorting channel members by id

### 🛠 Implementation

##### Microseconds parsing
DateFormatter supports milliseconds and ignores microseconds and nanoseconds. This led to date properties to lose precision and causing many equal values when sorting the list.

##### Equal values and sorting
Our SDK returns items sorted by Core Data sort descriptors (or by runtime sorting if custom sorting keys are used). When we sort over non-unique values and there are many items with the same value, the order returned by the SDK is inconsistent: `channel1`, `channel2`, `channel3` can change to `channel2`, `channel3`, `channel1` when DB changes happen. API responses, on the other hand, return consistent order even in cases like these. If we paginate, then we also do not want to see any reordering happening when the next page of channels is inserted into the DB. One way is to internally add a tie breaker.

##### The issue with runtime sorting
Runtime sorting is used when we can't sort on the Core Data model layer (DTO does not have a key for that field). I found that runtime sorting does not match with how NSSortDescriptor sorts items (nil values, multiple sort criteria). This PR fixes these issues.

### 🎨 Showcase

##### Channel list sorted by unread count

| Before | After |
| ------ | ----- |
|  ![img](https://github.com/user-attachments/assets/69875bd7-4024-4cb7-8887-28dde959a513)  | ![img](https://github.com/user-attachments/assets/0f3b0544-d674-439f-a55b-91df34a4b917)  |

### 🧪 Manual Testing Notes

#### Case: sort channel list by unread message count
##### Prerequisites
Open `DemoAppCoordinator+DemoApp.swift:L105` and change default sorting to sort by unread count (gives many equal values)
```swift
channelListQuery = .init(
  filter: .containMembers(userIds: [userCredentials.id]),
  sort: [.init(key: .unreadCount, isAscending: false)]
)
```
##### Steps
1. Open the demo app and log in with an user with many channels
2. Scroll down to load more channels
Result: Channels do not reorder

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_


[PBE-5993]: https://stream-io.atlassian.net/browse/PBE-5993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ