### PR TITLE
An error message about recovery request mode was incorrectly logged after web-socket connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
   - Recommendation: Always add at least one unique key to the query's sort
+- An error message about recovery request mode was incorrectly logged after web-socket connect [#3426](https://github.com/GetStream/stream-chat-swift/pull/3426)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.63.0)
 _September 12, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
   - Recommendation: Always add at least one unique key to the query's sort
-- An error message about recovery request mode was incorrectly logged after web-socket connect [#3426](https://github.com/GetStream/stream-chat-swift/pull/3426)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.63.0)
 _September 12, 2024_

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1246,11 +1246,11 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
 
     // MARK: - Internal
 
-    func recoverWatchedChannel(completion: @escaping (Error?) -> Void) {
+    func recoverWatchedChannel(recovery: Bool, completion: @escaping (Error?) -> Void) {
         if cid != nil, isChannelAlreadyCreated {
-            startWatching(isInRecoveryMode: true, completion: completion)
+            startWatching(isInRecoveryMode: recovery, completion: completion)
         } else {
-            synchronize(isInRecoveryMode: true, completion)
+            synchronize(isInRecoveryMode: recovery, completion)
         }
     }
     

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -153,7 +153,7 @@ final class SyncEventsOperation: AsyncOperation {
 }
 
 final class WatchChannelOperation: AsyncOperation {
-    init(controller: ChatChannelController, context: SyncContext) {
+    init(controller: ChatChannelController, context: SyncContext, recovery: Bool) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak controller] _, done in
             guard let controller = controller, controller.canBeRecovered else {
                 done(.continue)
@@ -162,7 +162,7 @@ final class WatchChannelOperation: AsyncOperation {
 
             let cidString = (controller.cid?.rawValue ?? "unknown")
             log.info("Watching active channel \(cidString)", subsystems: .offlineSupport)
-            controller.recoverWatchedChannel { error in
+            controller.recoverWatchedChannel(recovery: recovery) { error in
                 if let cid = controller.cid, error == nil {
                     log.info("Successfully watched active channel \(cidString)", subsystems: .offlineSupport)
                     context.watchedAndSynchedChannelIds.insert(cid)

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -192,7 +192,7 @@ class SyncRepository {
         
         // 4. Re-watch channels what we were watching before disconnect
         // Needs to be done explicitly after reconnection, otherwise SDK users need to handle connection changes
-        operations.append(contentsOf: activeChannelControllers.allObjects.map { WatchChannelOperation(controller: $0, context: context) })
+        operations.append(contentsOf: activeChannelControllers.allObjects.map { WatchChannelOperation(controller: $0, context: context, recovery: false) })
         operations.append(contentsOf: activeChats.allObjects.map { WatchChannelOperation(chat: $0, context: context) })
         
         operations.append(BlockOperation(block: {
@@ -247,7 +247,7 @@ class SyncRepository {
 
         // 2. Start watching open channels.
         let watchChannelOperations: [AsyncOperation] = activeChannelControllers.allObjects.map { controller in
-            WatchChannelOperation(controller: controller, context: context)
+            WatchChannelOperation(controller: controller, context: context, recovery: true)
         }
         operations.append(contentsOf: watchChannelOperations)
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ChatChannelController_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ChatChannelController_Spy.swift
@@ -13,7 +13,7 @@ final class ChatChannelController_Spy: ChatChannelController, Spy {
         super.init(channelQuery: .init(cid: .unique), channelListQuery: nil, client: client)
     }
 
-    override func recoverWatchedChannel(completion: @escaping (Error?) -> Void) {
+    override func recoverWatchedChannel(recovery: Bool, completion: @escaping (Error?) -> Void) {
         record()
         completion(watchActiveChannelError)
     }

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -4683,7 +4683,7 @@ final class ChannelController_Tests: XCTestCase {
 
         var receivedError: Error?
         let expectation = self.expectation(description: "watchActiveChannel completion")
-        controller.recoverWatchedChannel { error in
+        controller.recoverWatchedChannel(recovery: true) { error in
             receivedError = error
             expectation.fulfill()
         }

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -125,7 +125,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedAndSynchedChannelIds.count, 0)
-        XCTAssertNotCall("recoverWatchedChannel(completion:)", on: controller)
+        XCTAssertNotCall("recoverWatchedChannel(recovery:completion:)", on: controller)
     }
 
     func test_WatchChannelOperation_availableOnRemote_alreadySynched() {
@@ -139,7 +139,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedAndSynchedChannelIds.count, 1)
-        XCTAssertCall("recoverWatchedChannel(completion:)", on: controller)
+        XCTAssertCall("recoverWatchedChannel(recovery:completion:)", on: controller)
     }
 
     func test_WatchChannelOperation_availableOnRemote_notSynched() {
@@ -153,7 +153,7 @@ final class SyncOperations_Tests: XCTestCase {
 
         XCTAssertEqual(context.watchedAndSynchedChannelIds.count, 1)
         XCTAssertEqual(context.synchedChannelIds.count, 0)
-        XCTAssertCall("recoverWatchedChannel(completion:)", on: controller)
+        XCTAssertCall("recoverWatchedChannel(recovery:completion:)", on: controller)
     }
 
     func test_WatchChannelOperation_availableOnRemote_notSynched_watchFailure_shouldRetry() {
@@ -167,7 +167,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedAndSynchedChannelIds.count, 0)
-        XCTAssertCall("recoverWatchedChannel(completion:)", on: controller, times: 3)
+        XCTAssertCall("recoverWatchedChannel(recovery:completion:)", on: controller, times: 3)
     }
 
     func test_WatchChannelOperation_availableOnRemote_notSynched_watchSuccess() {
@@ -181,7 +181,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedAndSynchedChannelIds.count, 1)
-        XCTAssertCall("recoverWatchedChannel(completion:)", on: controller, times: 1)
+        XCTAssertCall("recoverWatchedChannel(recovery:completion:)", on: controller, times: 1)
     }
 
     // MARK: - RefetchChannelListQueryOperation

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -120,7 +120,7 @@ final class SyncOperations_Tests: XCTestCase {
         let context = SyncContext(lastSyncAt: .init())
         let controller = ChatChannelController_Spy(client: client)
         controller.state = .initialized
-        let operation = WatchChannelOperation(controller: controller, context: context)
+        let operation = WatchChannelOperation(controller: controller, context: context, recovery: true)
 
         operation.startAndWaitForCompletion()
 
@@ -134,7 +134,7 @@ final class SyncOperations_Tests: XCTestCase {
         controller.state = .remoteDataFetched
         context.synchedChannelIds.insert(controller.cid!)
 
-        let operation = WatchChannelOperation(controller: controller, context: context)
+        let operation = WatchChannelOperation(controller: controller, context: context, recovery: true)
 
         operation.startAndWaitForCompletion()
 
@@ -147,7 +147,7 @@ final class SyncOperations_Tests: XCTestCase {
         let controller = ChatChannelController_Spy(client: client)
         controller.state = .remoteDataFetched
 
-        let operation = WatchChannelOperation(controller: controller, context: context)
+        let operation = WatchChannelOperation(controller: controller, context: context, recovery: true)
 
         operation.startAndWaitForCompletion()
 
@@ -162,7 +162,7 @@ final class SyncOperations_Tests: XCTestCase {
         controller.state = .remoteDataFetched
         controller.watchActiveChannelError = ClientError("")
 
-        let operation = WatchChannelOperation(controller: controller, context: context)
+        let operation = WatchChannelOperation(controller: controller, context: context, recovery: true)
 
         operation.startAndWaitForCompletion()
 
@@ -176,7 +176,7 @@ final class SyncOperations_Tests: XCTestCase {
         controller.state = .remoteDataFetched
         controller.watchActiveChannelError = nil
 
-        let operation = WatchChannelOperation(controller: controller, context: context)
+        let operation = WatchChannelOperation(controller: controller, context: context, recovery: true)
 
         operation.startAndWaitForCompletion()
 

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -224,7 +224,7 @@ class SyncRepository_Tests: XCTestCase {
         if repository.usesV2Sync {
             XCTAssertCall("watch()", on: chat, times: 1)
         } else {
-            XCTAssertCall("recoverWatchedChannel(completion:)", on: chatController, times: 1)
+            XCTAssertCall("recoverWatchedChannel(recovery:completion:)", on: chatController, times: 1)
         }
         XCTAssertEqual(repository.activeChannelListControllers.count, 0)
         if repository.usesV2Sync {


### PR DESCRIPTION
### 🎯 Goal

Invalid error log message was logged because we are actually not in the recovery mode in sync v2

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

