### PR TITLE
Linking and unlinking channels based on the loaded list of channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ _September 12, 2024_
 ### 🐞 Fixed
 - Fix Logger printing the incorrect thread name [#3382](https://github.com/GetStream/stream-chat-swift/pull/3382)
 - Channel watching did not resume on web-socket reconnection [#3409](https://github.com/GetStream/stream-chat-swift/pull/3409)
-- Channel was not linked to the channel list query when receiving the `ChannelUpdatedEvent` event [#3430](https://github.com/GetStream/stream-chat-swift/pull/3430)
 ### 🔄 Changed
 - Discard offline state changes when saving database changes fails [#3399](https://github.com/GetStream/stream-chat-swift/pull/3399)
 - Deprecate `Filter.notEqual` and `Filter.notIn` [#3414](https://github.com/GetStream/stream-chat-swift/pull/3414)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _September 12, 2024_
 ### 🐞 Fixed
 - Fix Logger printing the incorrect thread name [#3382](https://github.com/GetStream/stream-chat-swift/pull/3382)
 - Channel watching did not resume on web-socket reconnection [#3409](https://github.com/GetStream/stream-chat-swift/pull/3409)
+- Channel was not linked to the channel list query when receiving the `ChannelUpdatedEvent` event [#3430](https://github.com/GetStream/stream-chat-swift/pull/3430)
 ### 🔄 Changed
 - Discard offline state changes when saving database changes fails [#3399](https://github.com/GetStream/stream-chat-swift/pull/3399)
 - Deprecate `Filter.notEqual` and `Filter.notIn` [#3414](https://github.com/GetStream/stream-chat-swift/pull/3414)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
   - Recommendation: Always add at least one unique key to the query's sort
 - Fix a crash with thematic breaks in markdown [#3437](https://github.com/GetStream/stream-chat-swift/pull/3437)
+- In some cases channel was not added to the channel list automatically [#3430](https://github.com/GetStream/stream-chat-swift/pull/3430)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.63.0)
 _September 12, 2024_

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -121,7 +121,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     private let environment: Environment
     private lazy var channelListLinker: ChannelListLinker = self.environment
         .channelListLinkerBuilder(
-            query, filter, client.config, client.databaseContainer, worker
+            query, filter, { [weak self] in StreamCollection(self?.channels ?? []) }, client.config, client.databaseContainer, worker
         )
 
     /// Creates a new `ChannelListController`.
@@ -269,6 +269,7 @@ extension ChatChannelListController {
         var channelListLinkerBuilder: (
             _ query: ChannelListQuery,
             _ filter: ((ChatChannel) -> Bool)?,
+            _ loadedChannels: @escaping () -> StreamCollection<ChatChannel>,
             _ clientConfig: ChatClientConfig,
             _ databaseContainer: DatabaseContainer,
             _ worker: ChannelListUpdater

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -43,6 +43,7 @@ extension ChannelListState {
             channelListLinker = ChannelListLinker(
                 query: query,
                 filter: dynamicFilter,
+                loadedChannels: { [weak channelListObserver] in channelListObserver?.items ?? StreamCollection([]) },
                 clientConfig: clientConfig,
                 databaseContainer: database,
                 worker: channelListUpdater

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		4F4562F72C240FD200675C7F /* DatabaseItemConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4562F52C240FD200675C7F /* DatabaseItemConverter.swift */; };
 		4F45802E2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */; };
 		4F45802F2BEE0B4B0099F540 /* ChannelListLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */; };
+		4F4817C92CA553EE00BE4A3C /* ChannelListLinker_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4817C82CA553EE00BE4A3C /* ChannelListLinker_Tests.swift */; };
 		4F5151962BC3DEA1001B7152 /* UserSearch_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */; };
 		4F5151982BC407ED001B7152 /* UserList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151972BC407ED001B7152 /* UserList_Tests.swift */; };
 		4F51519A2BC57C40001B7152 /* MessageState_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5151992BC57C40001B7152 /* MessageState_Tests.swift */; };
@@ -3110,6 +3111,7 @@
 		4F427F6B2BA2F53200D92238 /* ConnectedUserState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectedUserState+Observer.swift"; sourceTree = "<group>"; };
 		4F4562F52C240FD200675C7F /* DatabaseItemConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseItemConverter.swift; sourceTree = "<group>"; };
 		4F45802D2BEE0B4B0099F540 /* ChannelListLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListLinker.swift; sourceTree = "<group>"; };
+		4F4817C82CA553EE00BE4A3C /* ChannelListLinker_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListLinker_Tests.swift; sourceTree = "<group>"; };
 		4F5151952BC3DEA1001B7152 /* UserSearch_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearch_Tests.swift; sourceTree = "<group>"; };
 		4F5151972BC407ED001B7152 /* UserList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList_Tests.swift; sourceTree = "<group>"; };
 		4F5151992BC57C40001B7152 /* MessageState_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState_Tests.swift; sourceTree = "<group>"; };
@@ -6985,7 +6987,9 @@
 		A364D09627D0C56C0029857A /* Workers */ = {
 			isa = PBXGroup;
 			children = (
-				AD9490582BF5701D00E69224 /* ThreadsRepository_Tests.swift */,
+				A364D09927D0C5D80029857A /* Background */,
+				A364D09827D0C5C20029857A /* EventObservers */,
+				4F4817C82CA553EE00BE4A3C /* ChannelListLinker_Tests.swift */,
 				792921C424C0479700116BBB /* ChannelListUpdater_Tests.swift */,
 				882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */,
 				88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */,
@@ -6993,13 +6997,12 @@
 				AD90D18425D56196001D03BB /* CurrentUserUpdater_Tests.swift */,
 				F69C4BC324F664A700A3D740 /* EventNotificationCenter_Tests.swift */,
 				84A1D2E926AAFB1D00014712 /* EventSender_Tests.swift */,
-				AD0CC0252BDBF9D1005E2C66 /* ReactionListUpdater_Tests.swift */,
 				F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */,
+				AD0CC0252BDBF9D1005E2C66 /* ReactionListUpdater_Tests.swift */,
+				AD9490582BF5701D00E69224 /* ThreadsRepository_Tests.swift */,
 				8A0175F325013B6400570345 /* TypingEventSender_Tests.swift */,
 				DA8407322526003D005A0F62 /* UserListUpdater_Tests.swift */,
 				8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */,
-				A364D09927D0C5D80029857A /* Background */,
-				A364D09827D0C5C20029857A /* EventObservers */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -11679,6 +11682,7 @@
 				7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */,
 				8A0CC9EB24C601F600705CF9 /* MemberEvents_Tests.swift in Sources */,
 				C1A25D6029E70DEB00DAE933 /* FetchCache_Tests.swift in Sources */,
+				4F4817C92CA553EE00BE4A3C /* ChannelListLinker_Tests.swift in Sources */,
 				A32D55142860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift in Sources */,
 				ADA9DB8B2BCF2B1F00C4AE3B /* ThreadParticipantDTO_Tests.swift in Sources */,
 				4F51519A2BC57C40001B7152 /* MessageState_Tests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
@@ -23,11 +23,14 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
     var startWatchingChannels_callCount = 0
     @Atomic var startWatchingChannels_cids: [ChannelId] = []
     @Atomic var startWatchingChannels_completion: ((Error?) -> Void)?
-
+    @Atomic var startWatchingChannels_completion_result: Result<Void, Error>?
+    
     var link_callCount = 0
     var link_completion: ((Error?) -> Void)?
-
+    @Atomic var link_completion_result: Result<Void, Error>?
+    
     var unlink_callCount = 0
+    @Atomic var unlink_completion_result: Result<Void, Error>?
 
     func cleanUp() {
         update_queries.removeAll()
@@ -37,10 +40,15 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
         fetch_queries.removeAll()
         fetch_completion = nil
 
+        link_completion_result = nil
+        
         markAllRead_completion = nil
 
         startWatchingChannels_cids.removeAll()
         startWatchingChannels_completion = nil
+        startWatchingChannels_completion_result = nil
+        
+        unlink_completion_result = nil
     }
 
     override func update(
@@ -82,6 +90,7 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
     ) {
         link_callCount += 1
         link_completion = completion
+        link_completion_result?.invoke(with: completion)
     }
 
     override func unlink(
@@ -90,11 +99,13 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
         completion: ((Error?) -> Void)? = nil
     ) {
         unlink_callCount += 1
+        unlink_completion_result?.invoke(with: completion)
     }
 
     override func startWatchingChannels(withIds ids: [ChannelId], completion: ((Error?) -> Void)?) {
         startWatchingChannels_callCount += 1
         startWatchingChannels_cids = ids
         startWatchingChannels_completion = completion
+        startWatchingChannels_completion_result?.invoke(with: completion)
     }
 }

--- a/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
@@ -259,7 +259,7 @@ final class ChannelList_Tests: XCTestCase {
             channel: .mock(cid: incomingCid),
             unreadCount: nil,
             member: .mock(id: .unique),
-            createdAt: .unique
+            createdAt: Date()
         )
         // Write the incoming channel to the database
         try await env.client.mockDatabaseContainer.write { session in

--- a/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/ChannelList_Tests.swift
@@ -283,7 +283,7 @@ final class ChannelList_Tests: XCTestCase {
         cancellable.cancel()
     }
     
-    func test_observingEvents_whenChannelUpdatedEventReceived_thenChannelIsUnlinkedAndStateUpdates() async throws {
+    func test_observingEvents_whenChannelUpdatedEventReceivedMatchingFilter_thenChannelIsUnlinkedAndStateUpdates() async throws {
         // Allow unlink a channel
         await setUpChannelList(usesMockedChannelUpdater: false, dynamicFilter: { _ in false })
         // Create channel list
@@ -306,6 +306,40 @@ final class ChannelList_Tests: XCTestCase {
         
         let event = ChannelUpdatedEvent(
             channel: .mock(cid: existingCid, memberCount: 4),
+            user: .unique,
+            message: .unique,
+            createdAt: .unique
+        )
+        let eventExpectation = XCTestExpectation(description: "Event processed")
+        env.client.eventNotificationCenter.process([event], completion: { eventExpectation.fulfill() })
+        await fulfillmentCompatibility(of: [eventExpectation], timeout: defaultTimeout, enforceOrder: true)
+        cancellable.cancel()
+    }
+    
+    func test_observingEvents_whenChannelUpdatedEventReceivedMatchingFilter_thenChannelIsLinkedAndStateUpdates() async throws {
+        // Allow link a channel
+        await setUpChannelList(usesMockedChannelUpdater: false, dynamicFilter: { _ in true })
+        // Create a channel list
+        let existingChannelListPayload = makeMatchingChannelListPayload(channelCount: 1, createdAtOffset: 0)
+        let existingCid = try XCTUnwrap(existingChannelListPayload.channels.first?.channel.cid)
+        try await env.client.mockDatabaseContainer.write { session in
+            session.saveChannelList(payload: existingChannelListPayload, query: self.channelList.query)
+        }
+        let newCid = ChannelId.unique
+        // Ensure that the channel is in the state
+        XCTAssertEqual(existingChannelListPayload.channels.map(\.channel.cid.rawValue), await channelList.state.channels.map(\.cid.rawValue))
+        
+        let stateExpectation = XCTestExpectation(description: "State changed")
+        let cancellable = await channelList.state.$channels
+            .dropFirst() // ignore initial
+            .sink { channels in
+                // Ensure linking added it to the state
+                XCTAssertEqual(Set([existingCid, newCid]), Set(channels.map(\.cid)))
+                stateExpectation.fulfill()
+            }
+        
+        let event = ChannelUpdatedEvent(
+            channel: .mock(cid: newCid, memberCount: 4),
             user: .unique,
             message: .unique,
             createdAt: .unique

--- a/Tests/StreamChatTests/Workers/ChannelListLinker_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelListLinker_Tests.swift
@@ -152,6 +152,12 @@ final class ChannelListLinker_Tests: XCTestCase {
                 message: nil,
                 createdAt: Date()
             ),
+            ChannelHiddenEvent(
+                cid: channel.cid,
+                user: .mock(id: memberId),
+                isHistoryCleared: false,
+                createdAt: Date()
+            ),
             ChannelVisibleEvent(
                 cid: channel.cid,
                 user: .mock(id: memberId),

--- a/Tests/StreamChatTests/Workers/ChannelListLinker_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelListLinker_Tests.swift
@@ -1,0 +1,169 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChannelListLinker_Tests: XCTestCase {
+    private var channelListLinker: ChannelListLinker!
+    private var database: DatabaseContainer_Spy!
+    private var eventNotificationCenter: EventNotificationCenter!
+    private var loadedChannels: [ChatChannel]!
+    private var memberId: UserId!
+    private var worker: ChannelListUpdater_Spy!
+    private let pageSize = 5
+    
+    override func setUpWithError() throws {
+        database = DatabaseContainer_Spy()
+        eventNotificationCenter = EventNotificationCenter(database: database)
+        loadedChannels = []
+        memberId = .unique
+        worker = ChannelListUpdater_Spy(database: database, apiClient: APIClient_Spy())
+        worker.startWatchingChannels_completion_result = .success(())
+        worker.link_completion_result = .success(())
+        worker.unlink_completion_result = .success(())
+        setUpChannelListLinker(filter: nil)
+    }
+
+    override func tearDownWithError() throws {
+        database = nil
+        eventNotificationCenter = nil
+        loadedChannels = nil
+        memberId = nil
+        worker = nil
+    }
+    
+    // MARK: -
+    
+    func test_skippingLinking_whenNoFilterAndAutomaticFilteringDisabled() throws {
+        let events = events(with: .mock(cid: .unique))
+        for event in events {
+            setUpChannelListLinker(filter: nil, automatic: false)
+            let result = processEventAndWait(event)
+            XCTAssertEqual(ChannelListLinker.LinkingAction.none, result, event.name)
+        }
+    }
+    
+    func test_linkingChannel_whenChannelOnTheLoadedPage_thenItIsLinked() throws {
+        loadedChannels = generateChannels(count: pageSize)
+        let events = events(with: generateChannel(index: -1))
+        for event in events {
+            setUpChannelListLinker(filter: nil)
+            let result = processEventAndWait(event)
+            XCTAssertEqual(ChannelListLinker.LinkingAction.link, result, event.name)
+        }
+    }
+    
+    func test_linkingChannel_whenChannelOnOlderPage_thenItIsNotLinked() throws {
+        loadedChannels = generateChannels(count: pageSize)
+        let events = events(with: generateChannel(index: 6))
+        for event in events {
+            setUpChannelListLinker(filter: nil)
+            let result = processEventAndWait(event)
+            XCTAssertEqual(ChannelListLinker.LinkingAction.none, result, event.name)
+        }
+    }
+    
+    func test_linkingChannel_notificationAddedToChannelEvent_whenLessThanRequestedIsLoaded_thenItIsLinked() throws {
+        loadedChannels = generateChannels(count: 0)
+        let events = events(with: generateChannel(index: 0))
+        for event in events {
+            setUpChannelListLinker(filter: nil)
+            let result = processEventAndWait(event)
+            XCTAssertEqual(ChannelListLinker.LinkingAction.link, result, event.name)
+        }
+    }
+    
+    func test_linkingChannel_channelUpdatedEvent_whenItMatchesTheFilter_thenItIsLinked() throws {
+        loadedChannels = generateChannels(count: pageSize)
+        let events = events(with: generateChannel(index: 0))
+        for event in events {
+            setUpChannelListLinker(filter: { _ in
+                // simulate channel matching the query, e.g. extraData property based filtering
+                true
+            })
+            let result = processEventAndWait(event)
+            XCTAssertEqual(ChannelListLinker.LinkingAction.link, result, event.name)
+        }
+    }
+    
+    func test_unlinkingChannel_channelUpdatedEvent_whenItDoesNotMatchTheFilterAnymore_thenItIsUnlinked() throws {
+        loadedChannels = generateChannels(count: pageSize)
+        let events = events(with: loadedChannels[0])
+        for event in events {
+            setUpChannelListLinker(filter: { _ in
+                // simulate channel not matching the query anymore, e.g. extraData property based filtering
+                false
+            })
+            let result = processEventAndWait(event)
+            XCTAssertEqual(ChannelListLinker.LinkingAction.unlink, result, event.name)
+        }
+    }
+
+    // MARK: - Test Data
+    
+    private func setUpChannelListLinker(filter: ((ChatChannel) -> Bool)?, automatic: Bool = true) {
+        let query = ChannelListQuery(
+            filter: .in(.members, values: [memberId]),
+            sort: [.init(key: .createdAt, isAscending: true)],
+            pageSize: pageSize
+        )
+        var config = ChatClientConfig(apiKeyString: "123")
+        config.isChannelAutomaticFilteringEnabled = automatic
+        channelListLinker = ChannelListLinker(
+            query: query,
+            filter: filter,
+            loadedChannels: { StreamCollection(self.loadedChannels) },
+            clientConfig: config,
+            databaseContainer: database,
+            worker: worker
+        )
+        channelListLinker.start(with: eventNotificationCenter)
+    }
+    
+    private func events(with channel: ChatChannel) -> [Event] {
+        [
+            NotificationAddedToChannelEvent(
+                channel: channel,
+                unreadCount: nil,
+                member: .mock(id: memberId),
+                createdAt: Date()
+            ),
+            ChannelUpdatedEvent(
+                channel: channel,
+                user: nil,
+                message: nil,
+                createdAt: Date()
+            )
+        ]
+    }
+    
+    private func generateChannel(index: Int) -> ChatChannel {
+        ChatChannel.mock(
+            cid: .unique,
+            name: "Name \(index)",
+            createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval(index))
+        )
+    }
+    
+    private func generateChannels(count: Int) -> [ChatChannel] {
+        (0..<count).map { generateChannel(index: $0) }
+    }
+}
+
+extension ChannelListLinker_Tests {
+    func processEventAndWait(_ event: Event) -> ChannelListLinker.LinkingAction {
+        let expectation = XCTestExpectation(description: "Handle Event")
+        var action = ChannelListLinker.LinkingAction.none
+        channelListLinker.didHandleChannel = { _, receivedAction in
+            action = receivedAction
+            expectation.fulfill()
+        }
+        eventNotificationCenter.process(event, postNotification: true)
+        wait(for: [expectation], timeout: defaultTimeout)
+        return action
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-6097](https://stream-io.atlassian.net/browse/PBE-6097)

### 🎯 Goal

- Fix issues with linking a channel when dynamic filter is used

### 📝 Summary

- Fix issues where web-socket event updates the channel and it was not linked to the current query (extra data changes in a way that it matches with the current query now, think about the custom pinning feature in the demo app)
- Revisit the whole web-socket event handling for linking and make sure we link only when after sorting, the changed channel would be part of the currently loaded channel list (makes sure we do not insert it when it is from unloaded pages and therefore would disturb pagination)

### 🧪 Manual Testing Notes

##### Case 1: Linking a channel after being added to it
1. Launch two clients A and B
2. On the client B, A's user is added to a channel
Result: The channel appears in the A's channel list

##### Case 2: Receiving a message in channel not loaded in the channel list
1. Launch two clients A and B
2. On the client B, send a message to an old channel which includes A's user
Result: The channel appears in the A's channel list

##### Case 3: Hiding/showing channels
1. Launch two clients A and B with the **same** user
2. On the client A, use the hidden channels filter
3. On the client B, hide a channel at the top of the channel list (Channel's debug menu)
Result: The channel appears in the A's channel list
4. On the client B, navigate to hidden channels and "show" the channel (Channel's debug menu > Show Channel)
Result: The channel disappears in the A's channel list

##### Case 4: Extra data based filtering 
1. Launch two clients A and B with the **same** user
2. Enable channel pinning for both (configuration when logged out) (this makes pinned channels to appear at the top of the list)
3. On the client B, pin a channel
Result: A sees the channel at the top of the channel list
4. On the client B, unpin the same channel
Result: A sees the channel moving to a different location

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-6097]: https://stream-io.atlassian.net/browse/PBE-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ