### PR TITLE
Avoid rare optimistic locking failure by refreshing the object before saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix old channel updates not being added to the channel list automatically [#3430](https://github.com/GetStream/stream-chat-swift/pull/3430)
 - Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
   - Recommendation: Always add at least one unique key to the query's sort
+- Avoid rare optimistic locking failure by refreshing the object before saving to the persistent store [#3432](https://github.com/GetStream/stream-chat-swift/pull/3432)
 - Fix `PollOption.latestVotes` sorting [#3374](https://github.com/GetStream/stream-chat-swift/pull/3374)
 - Fix `Poll.latestAnswers` sorting [#3374](https://github.com/GetStream/stream-chat-swift/pull/3374)
 - Fix `Poll` updates not triggering message updates in `ChannelController` [#3374](https://github.com/GetStream/stream-chat-swift/pull/3374)

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -222,10 +222,9 @@ class DatabaseContainer: NSPersistentContainer {
                 try actions(self.writableContext)
                 FetchCache.clear()
 
+                // Refresh the state by merging persistent state and local state for avoiding optimistic locking failure
                 for object in self.writableContext.updatedObjects {
-                    if object.changedValues().isEmpty {
-                        self.writableContext.refresh(object, mergeChanges: true)
-                    }
+                    self.writableContext.refresh(object, mergeChanges: true)
                 }
 
                 if self.writableContext.hasChanges {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-6035](https://stream-io.atlassian.net/browse/PBE-6035)

### 🎯 Goal

Try fixing rare crash on managed object context save

### 🛠 Implementation

I learned that the rare crash we have seen on context save is related to Core Data failing to resolve constraint conflict (although I can't see how this could happen). NSManagedObjectContext has [refresh(_:mergeChanges:)](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506224-refresh) for forcing the context to fetch the persistent state and applying local changes. I would like to see if this resolves these rare cases.

> Merging the local values into object always succeeds, and never results in a merge conflict.

> You typically use this method to ensure data freshness if multiple managed object contexts share a single persistent store. You can use this method to resolve an optimistic locking failure when attempting to save.

### 🧪 Manual Testing Notes

- [ ] Extensive exploratory testing
- [x] Time profiler

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)


[PBE-6035]: https://stream-io.atlassian.net/browse/PBE-6035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ