### PR TITLE
Fix a crash with thematic breaks in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Keep consistent order in channel and member lists when sorting by key with many equal values [#3423](https://github.com/GetStream/stream-chat-swift/pull/3423)
   - Recommendation: Always add at least one unique key to the query's sort
+- Fix a crash with thematic breaks in markdown [#3437](https://github.com/GetStream/stream-chat-swift/pull/3437)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.63.0)
 _September 12, 2024_

--- a/Sources/StreamChatUI/StreamSwiftyMarkdown/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/StreamChatUI/StreamSwiftyMarkdown/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -193,7 +193,7 @@ class SwiftyLineProcessor {
 		// Remove the first line, which is the front matter opening tag
 		let _ = outputString.removeFirst()
 		var closeFound = false
-		while !closeFound {
+		while !closeFound && !outputString.isEmpty {
 			let nextString = outputString.removeFirst()
 			if nextString == existentRules.closeTag {
 				closeFound = true
@@ -207,6 +207,9 @@ class SwiftyLineProcessor {
 			let value = keyValue.joined()
 			self.frontMatterAttributes[key] = value
 		}
+        if !closeFound {
+            return strings
+        }
 		while outputString.first?.isEmpty ?? false {
 			outputString.removeFirst()
 		}

--- a/Tests/StreamChatUITests/Utils/DefaultMarkdownFormatter_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/DefaultMarkdownFormatter_Tests.swift
@@ -255,4 +255,20 @@ final class DefaultMarkdownFormatter_Tests: XCTestCase {
         let result = sut.format(string)
         XCTAssertEqual(result.string, "**~~*~**~~ h e a r d ***~~~**~")
     }
+    
+    func test_thematicBreak_isHandled() {
+        // Note: --- is removed by SwiftyMarkdown although it should be kept
+        let string = """
+        ---
+        hi!
+        """
+        let result = sut.format(string)
+        XCTAssertEqual(
+            result.string,
+            """
+            
+            hi!
+            """
+        )
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [PBE-6131](https://stream-io.atlassian.net/browse/PBE-6131)

### 🎯 Goal

Crash when `---` is used in markdown

### 📝 Summary

SwiftyMarkdown does not handle `---` correctly and caused a crash.

### 🧪 Manual Testing Notes

Send a message like
```
---
hi!
```
Result: no crash, `hi!` is rendered (not fully correct because SwiftyMarkdown removes `---`)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-6131]: https://stream-io.atlassian.net/browse/PBE-6131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ