### PR TITLE
Unread messages divider did not appear in the message list when marking unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Unread messages divider did not appear in the message list when marking messages as unread [#3444](https://github.com/GetStream/stream-chat-swift/pull/3444)
 
 # [4.64.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.64.0)
 _October 02, 2024_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -538,7 +538,7 @@ class MessageDTO: NSManagedObject {
             .init(format: "id != %@", id),
             .init(format: "createdAt <= %@", message.createdAt)
         ])
-        request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageDTO.createdAt, ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageDTO.createdAt, ascending: false)]
         request.fetchLimit = 1
         return try context.fetch(request).first
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-5549](https://stream-io.atlassian.net/browse/PBE-5549)

### 🎯 Goal

Fix an issue where unread messages divider did not appear on mark as unread

### 📝 Summary

- Invalid unread message id was returned because of incorrect get message before implementation

### 🛠 Implementation

We need to find a previous message from the message we are marking as unread. API requires the last read message, not the first unread message id. The sorting logic and limiting the fetch to 1 ended up returning the oldest loaded message instead (filter matches, let's say 25 messages before limiting to 1, but we picked the id from the wrong end of results). Due to that reason, MessageListVC tried to reload cell for an older message instead (reloading is needed for making the cell to show the unread messages divider).

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  ![img](https://github.com/user-attachments/assets/590241d8-b280-4b98-8e30-57de6ac6973b)   |  ![img](https://github.com/user-attachments/assets/795b1176-55c2-47d3-ac7b-d09d4e95e2b1)  |

### 🧪 Manual Testing Notes

1. Open a channel
2. Mark the last message as unread
Result: Unread message divider appears.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-5549]: https://stream-io.atlassian.net/browse/PBE-5549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ