### PR TITLE
Fix UI glitch in thread parent message when sending a message and scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Fix UI glitch in thread parent message when sending a message and scrolling [#3446](https://github.com/GetStream/stream-chat-swift/pull/3446)
 
 # [4.64.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.64.0)
 _October 02, 2024_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCell.swift
@@ -12,7 +12,7 @@ public class ChatMessageCell: _TableViewCell, ThemeProvider {
     public static var reuseId: String { "\(self)" }
 
     /// The container that holds the header, footer and the message content view.
-    internal lazy var containerStackView = UIStackView()
+    internal lazy var containerStackView = ContainerStackView()
         .withoutAutoresizingMaskConstraints
         .withAccessibilityIdentifier(identifier: "containerStackView")
 
@@ -51,6 +51,7 @@ public class ChatMessageCell: _TableViewCell, ThemeProvider {
 
         containerStackView.axis = .vertical
         containerStackView.alignment = .center
+        containerStackView.spacing = 0
 
         containerStackView.addArrangedSubview(headerContainerView)
         messageContentView.map { containerStackView.addArrangedSubview($0) }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://stream-io.atlassian.net/browse/PBE-5999

### 🎯 Goal

Fix an issue where the thread parent message would shrink after sending a thread reply and quickly scroll to the parent message.

### 📝 Summary

#### Problem
The reason for the issue is that the decorator's views rely on showing and hiding the top and bottom stack views in `ChatMessageCell`, but when quickly scrolling, the message cell, since it has the same identifier as the regular reply, is reused and the decorators are not shown instantly and it requires a cell reload to re-calculate its size. 

### 🛠 Implementation

#### Solution
Using our custom `ContainerStackView` fixes the problem since it relies on manually disabling and enabling constraints, which will re-calculate the cell's size.

### 🧪 Manual Testing Notes

Follow to the steps in https://stream-io.atlassian.net/browse/PBE-5999

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)