### PR TITLE
Unit-tests were crashing on iOS 13 and 14 when toDate() was used

### DIFF
--- a/TestTools/StreamChatTestTools/Extensions/String+Date.swift
+++ b/TestTools/StreamChatTestTools/Extensions/String+Date.swift
@@ -6,9 +6,11 @@ import Foundation
 @testable import StreamChat
 
 public extension String {
-    /// Converst a string to `Date`. Only for testing!
+    /// Converts a string to `Date`. Only for testing!
     func toDate() -> Date {
-        if let date = JSONDecoder.stream.iso8601formatter.dateWithMicroseconds(from: self) {
+        let iso8601Formatter = ISO8601DateFormatter()
+        iso8601Formatter.formatOptions = [.withFractionalSeconds, .withInternetDateTime]
+        if let date = iso8601Formatter.dateWithMicroseconds(from: self) {
             return date
         }
         return DateFormatter.Stream.rfc3339Date(from: self)!


### PR DESCRIPTION
### 🎯 Goal

Change `toDate()` not to use the shared ISO8601DateFormatter because it makes unit-tests to crash on iOS 13 and 14.

### 📝 Summary

ISO8601DateFormatter is not marked as Sendable, therefore it does not seem to be thread-safe (at least on iOS 13 and 14). Maybe on iOS 15 and later it is because it did not crash there, not sure. But this change fixes crashes.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
