### PR TITLE
Improve performance of presenting ChatChannelVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Unread messages divider did not appear in the message list when marking messages as unread [#3444](https://github.com/GetStream/stream-chat-swift/pull/3444)
 - Fix UI glitch in thread parent message when sending a message and scrolling [#3446](https://github.com/GetStream/stream-chat-swift/pull/3446)
+### ⚡ Performance
+- Improve performance of presenting `ChatChannelVC` [#3448](https://github.com/GetStream/stream-chat-swift/pull/3448)
 
 # [4.64.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.64.0)
 _October 02, 2024_

--- a/Scripts/updateDependency.sh
+++ b/Scripts/updateDependency.sh
@@ -73,6 +73,7 @@ fi
 
 if [[ $dependency_directory == *"SwiftyMarkdown"* ]]; then
     # We currently use customized version of SwiftyMarkdown
+	git restore $output_directory/SwiftyMarkdown/PerformanceLog.swift || true
     git restore $output_directory/SwiftyMarkdown/SwiftyLineProcessor.swift || true
     git restore $output_directory/SwiftyMarkdown/SwiftyTokeniser.swift || true
 fi

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -157,6 +157,10 @@ open class ChatMessageContentView: _View, ThemeProvider, UITextViewDelegate {
     open var editedLabelSeparator: String {
         " • "
     }
+    
+    /// Skip content update when tintColorDidChange is called but content was already updated for that color
+    /// Unnecessary updates can get expensive due to text updates.
+    private var previousContentUpdateTintColor: UIColor?
 
     // MARK: - Content views
 
@@ -590,6 +594,7 @@ open class ChatMessageContentView: _View, ThemeProvider, UITextViewDelegate {
         super.updateContent()
         defer {
             attachmentViewInjector?.contentViewDidUpdateContent()
+            previousContentUpdateTintColor = tintColor
             setNeedsLayout()
         }
 
@@ -747,7 +752,7 @@ open class ChatMessageContentView: _View, ThemeProvider, UITextViewDelegate {
 
     override open func tintColorDidChange() {
         super.tintColorDidChange()
-
+        guard previousContentUpdateTintColor != tintColor else { return }
         guard UIApplication.shared.applicationState == .active else { return }
         // We need to update the content and manually apply the updated `tintColor`
         // to the subviews which don't listen for `tintColor` updates.

--- a/Sources/StreamChatUI/StreamSwiftyMarkdown/SwiftyMarkdown/PerfomanceLog.swift
+++ b/Sources/StreamChatUI/StreamSwiftyMarkdown/SwiftyMarkdown/PerfomanceLog.swift
@@ -16,7 +16,7 @@ class PerformanceLog {
 	
 	init( with environmentVariableName : String, identifier : String, log : OSLog  ) {
 		self.log = log
-		self.enablePerfomanceLog = (ProcessInfo.processInfo.environment[environmentVariableName] != nil)
+		self.enablePerfomanceLog = false
 		self.identifier = identifier
 	}
 	

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -652,6 +652,10 @@ final class ChatChannelVC_Tests: XCTestCase {
 
         vc.components.isMessageEditedLabelEnabled = true
 
+        // Also update the default because in snapshot tests, message cells are created before they are in the responder chain
+        defer { Components.default.isMessageEditedLabelEnabled = false }
+        Components.default.isMessageEditedLabelEnabled = true
+        
         AssertSnapshot(vc, variants: [.defaultLight])
     }
 

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -506,7 +506,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         ])
         mockedListView.updateMessagesCompletion?()
 
-        XCTAssertEqual(mockedListView.reloadRowsCallCount, 2)
+        XCTAssertEqual(mockedListView.reloadRowsCallCount, 1)
         XCTAssertEqual(mockedListView.reloadRowsCalledWith, [.init(item: 0, section: 0), .init(item: 1, section: 0)])
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-6192](https://stream-io.atlassian.net/browse/PBE-6192)

### 🎯 Goal

Present `ChatChannelVC` quicker

### 📝 Summary

- Reduce cell reloads after applying message list changes
- Skip duplicate `updateContent` call when creating the `ChatMessageContentCell`

### 🛠 Implementation

`ChatMessageContentView` parses markdown and links which can get expensive. Reloading a cell repeats the parsing. This PR aims to reduce cell reloads. 

### 🎨 Showcase

Measured with iPhone 12 Pro Max and 3 different channels using a separate sample app what just presents the `ChatChannelVC` in a sheet. Time spent by the main thread.

Channel with 25 simple messages with text. Negligible change here. **5-10%** faster.
| Criteria | Before | After |
| ----- | ------ | ----- |
| Main thread |  269 ms  |  251 ms  |
| Hang time | 297 ms  | 291 ms  |

Channel with complex markdown and some other simple messages with links. **~50%** faster
| Criteria | Before | After |
| ----- | ------ | ----- |
| Main thread |  969 ms  |  420 ms  |
| Hang time | 811 ms  | 480 ms |

All of this really depends on how much processing the message cell requires. If more, the impact is higher because it is less time recalculated.

### 🧪 Manual Testing Notes

##### Verify sending giphys
1. Open giphy preview
2. Send/cancel a giphy

##### Verify deleting messages and displaying user avatars.

1. Log in from 2 devices/simulators
2. Open the same channel with 2 different users
3. Send 2 messages: "A" and "B"
4. Hard delete the "B"
Result: Avatar is shown for message "A"

##### Verify sending messages and displaying user avatars.
1. Send message "A" > avatar is shown for it
2. Send message "B" > avatar is shown for "B" and not for "A" since messages are grouped

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)


[PBE-6192]: https://stream-io.atlassian.net/browse/PBE-6192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ