### PR TITLE
Reduce channel list updates when syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a rare crash caused by missing uniqueness constraints in polls [#3454](https://github.com/GetStream/stream-chat-swift/pull/3454)
 - Fix rare crash in `WebSocketPingController.connectionStateDidChange` [#3451](https://github.com/GetStream/stream-chat-swift/pull/3451)
 - Improve reliability and performance of resetting ephemeral values [#3439](https://github.com/GetStream/stream-chat-swift/pull/3439)
-- Reduce channel list updates when syncing by reording syncing sequence and skipping channel based events sync (if already in sync) [#3450](https://github.com/GetStream/stream-chat-swift/pull/3450)
 - Reduce channel list updates when updating the local state [#3450](https://github.com/GetStream/stream-chat-swift/pull/3450)
 
 ## StreamChatUI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a rare crash caused by missing uniqueness constraints in polls [#3454](https://github.com/GetStream/stream-chat-swift/pull/3454)
 - Fix rare crash in `WebSocketPingController.connectionStateDidChange` [#3451](https://github.com/GetStream/stream-chat-swift/pull/3451)
 - Improve reliability and performance of resetting ephemeral values [#3439](https://github.com/GetStream/stream-chat-swift/pull/3439)
+- Reduce channel list updates when syncing by reording syncing sequence and skipping channel based events sync (if already in sync) [#3450](https://github.com/GetStream/stream-chat-swift/pull/3450)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix rare crash in `WebSocketPingController.connectionStateDidChange` [#3451](https://github.com/GetStream/stream-chat-swift/pull/3451)
 - Improve reliability and performance of resetting ephemeral values [#3439](https://github.com/GetStream/stream-chat-swift/pull/3439)
 - Reduce channel list updates when syncing by reording syncing sequence and skipping channel based events sync (if already in sync) [#3450](https://github.com/GetStream/stream-chat-swift/pull/3450)
+- Reduce channel list updates when updating the local state [#3450](https://github.com/GetStream/stream-chat-swift/pull/3450)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -7,7 +7,7 @@ import Foundation
 /// A final class that holds the context for the ongoing operations during the sync process
 final class SyncContext {
     let lastSyncAt: Date
-    var localChannelIds: [ChannelId] = []
+    var localChannelIds: Set<ChannelId> = Set()
     var synchedChannelIds: Set<ChannelId> = Set()
     var watchedAndSynchedChannelIds: Set<ChannelId> = Set()
     var unwantedChannelIds: Set<ChannelId> = Set()
@@ -31,13 +31,13 @@ final class ActiveChannelIdsOperation: AsyncOperation {
             }
             
             let completion: () -> Void = {
-                context.localChannelIds = Array(Set(context.localChannelIds))
+                context.localChannelIds = Set(context.localChannelIds)
                 log.info("Found \(context.localChannelIds.count) active channels", subsystems: .offlineSupport)
                 done(.continue)
             }
             
-            context.localChannelIds.append(contentsOf: syncRepository.activeChannelControllers.allObjects.compactMap(\.cid))
-            context.localChannelIds.append(contentsOf:
+            context.localChannelIds.formUnion(syncRepository.activeChannelControllers.allObjects.compactMap(\.cid))
+            context.localChannelIds.formUnion(
                 syncRepository.activeChannelListControllers.allObjects
                     .map(\.channels)
                     .flatMap { $0 }
@@ -51,8 +51,8 @@ final class ActiveChannelIdsOperation: AsyncOperation {
             } else {
                 // Main actor requirement
                 DispatchQueue.main.async {
-                    context.localChannelIds.append(contentsOf: syncRepository.activeChats.allObjects.compactMap { try? $0.cid })
-                    context.localChannelIds.append(contentsOf:
+                    context.localChannelIds.formUnion(syncRepository.activeChats.allObjects.compactMap { try? $0.cid })
+                    context.localChannelIds.formUnion(
                         syncRepository.activeChannelLists.allObjects
                             .map(\.state.channels)
                             .flatMap { $0 }
@@ -119,7 +119,7 @@ final class GetChannelIdsOperation: AsyncOperation {
                     .flatMap(\.channels)
                     .compactMap { try? ChannelId(cid: $0.cid) }
                 log.info("0. Retrieved channels from existing queries from DB. Count \(cids.count)", subsystems: .offlineSupport)
-                context.localChannelIds = Array(Set(cids + activeChannelIds))
+                context.localChannelIds = Set(cids + activeChannelIds)
                 done(.continue)
             }
         }
@@ -147,10 +147,9 @@ final class SyncEventsOperation: AsyncOperation {
             ) { result in
                 switch result {
                 case let .success(channelIds):
-                    context.synchedChannelIds = Set(channelIds)
+                    context.synchedChannelIds.formUnion(channelIds)
                     done(.continue)
                 case let .failure(error):
-                    context.synchedChannelIds = Set([])
                     done(error.shouldRetry ? .retry : .continue)
                 }
             }
@@ -253,8 +252,8 @@ final class RefetchChannelListQueryOperation: AsyncOperation {
         case let .success((watchedChannels, unwantedCids)):
             log.info("Successfully refetched query for \(query.debugDescription)", subsystems: .offlineSupport)
             let queryChannelIds = watchedChannels.map(\.cid)
-            context.watchedAndSynchedChannelIds = context.watchedAndSynchedChannelIds.union(queryChannelIds)
-            context.unwantedChannelIds = context.unwantedChannelIds.union(unwantedCids)
+            context.watchedAndSynchedChannelIds.formUnion(queryChannelIds)
+            context.unwantedChannelIds.formUnion(unwantedCids)
             done(.continue)
         case let .failure(error):
             log.error(

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -134,8 +134,14 @@ final class SyncEventsOperation: AsyncOperation {
                 subsystems: .offlineSupport
             )
 
+            let channelIds = Set(context.localChannelIds).subtracting(context.synchedChannelIds)
+            guard !channelIds.isEmpty else {
+                done(.continue)
+                return
+            }
+            
             syncRepository?.syncChannelsEvents(
-                channelIds: context.localChannelIds,
+                channelIds: Array(channelIds),
                 lastSyncAt: context.lastSyncAt,
                 isRecovery: recovery
             ) { result in

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -157,7 +157,7 @@ class SyncRepository {
     /// Background mode (other regular API requests are allowed to run at the same time)
     /// 1. Collect all the **active** channel ids (from instances of `Chat`, `ChannelList`, `ChatChannelController`, `ChatChannelListController`)
     /// 2. Refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)
-    /// 3. Apply updates from the /sync endpoint for channels not in active channel lists (max 1000 events is supported)
+    /// 3. Apply updates from the /sync endpoint for channels not in active channel lists (max 2000 events is supported)
     ///      * channel controllers targeting other channels
     ///      * no channel lists active, but channel controllers are
     /// 4. Re-watch channels what we were watching before disconnect
@@ -409,7 +409,7 @@ class SyncRepository {
                     completion(.failure(.syncEndpointFailed(error)))
                     return
                 }
-                // Backend responds with 400 if there were more than 1000 events to return
+                // Backend responds with 400 if there were more than 2000 events to return
                 // Cleaning local channels data and refetching it from scratch
                 log.info("/sync returned too many events. Continuing...", subsystems: .offlineSupport)
 

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -157,7 +157,9 @@ class SyncRepository {
     /// Background mode (other regular API requests are allowed to run at the same time)
     /// 1. Collect all the **active** channel ids (from instances of `Chat`, `ChannelList`, `ChatChannelController`, `ChatChannelListController`)
     /// 2. Refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)
-    /// 3. Apply updates from the /sync endpoint for channels (which were not already refreshed, note max 1000 events is supported)
+    /// 3. Apply updates from the /sync endpoint for channels not in active channel lists (max 1000 events is supported)
+    ///      * channel controllers targeting other channels
+    ///      * no channel lists active, but channel controllers are
     /// 4. Re-watch channels what we were watching before disconnect
     private func syncLocalStateV2(lastSyncAt: Date, completion: @escaping () -> Void) {
         let context = SyncContext(lastSyncAt: lastSyncAt)

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -156,8 +156,8 @@ class SyncRepository {
     ///
     /// Background mode (other regular API requests are allowed to run at the same time)
     /// 1. Collect all the **active** channel ids (from instances of `Chat`, `ChannelList`, `ChatChannelController`, `ChatChannelListController`)
-    /// 2. Apply updates from the /sync endpoint for these channels
-    /// 3. Refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)
+    /// 2. Refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`)
+    /// 3. Apply updates from the /sync endpoint for channels (which were not already refreshed, note max 1000 events is supported)
     /// 4. Re-watch channels what we were watching before disconnect
     private func syncLocalStateV2(lastSyncAt: Date, completion: @escaping () -> Void) {
         let context = SyncContext(lastSyncAt: lastSyncAt)
@@ -183,12 +183,12 @@ class SyncRepository {
         /// 1. Collect all the **active** channel ids
         operations.append(ActiveChannelIdsOperation(syncRepository: self, context: context))
         
-        // 2. /sync
-        operations.append(SyncEventsOperation(syncRepository: self, context: context, recovery: false))
-        
-        // 3. Refresh channel lists (required even after applying events)
+        // 2. Refresh channel lists
         operations.append(contentsOf: activeChannelLists.allObjects.map { RefreshChannelListOperation(channelList: $0, context: context) })
         operations.append(contentsOf: activeChannelListControllers.allObjects.map { RefreshChannelListOperation(controller: $0, context: context) })
+
+        // 3. /sync (for channels what not part of active channel lists)
+        operations.append(SyncEventsOperation(syncRepository: self, context: context, recovery: false))
         
         // 4. Re-watch channels what we were watching before disconnect
         // Needs to be done explicitly after reconnection, otherwise SDK users need to handle connection changes

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -189,7 +189,7 @@ final class SyncOperations_Tests: XCTestCase {
     func test_RefetchChannelListQueryOperation_notAvailableOnRemote() {
         let context = SyncContext(lastSyncAt: .init())
         let controller = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
-        controller.state = .initialized
+        controller.state_mock = .initialized
         let operation = RefetchChannelListQueryOperation(
             controller: controller,
             context: context
@@ -207,7 +207,7 @@ final class SyncOperations_Tests: XCTestCase {
     func test_RefetchChannelListQueryOperation_availableOnRemote_resetFailure_shouldRetry() {
         let context = SyncContext(lastSyncAt: .init())
         let controller = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
-        controller.state = .remoteDataFetched
+        controller.state_mock = .remoteDataFetched
         let operation = RefetchChannelListQueryOperation(
             controller: controller,
             context: context
@@ -226,7 +226,7 @@ final class SyncOperations_Tests: XCTestCase {
     func test_RefetchChannelListQueryOperation_availableOnRemote_resetSuccess_shouldAddToContext() throws {
         let context = SyncContext(lastSyncAt: .init())
         let controller = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
-        controller.state = .remoteDataFetched
+        controller.state_mock = .remoteDataFetched
         let channelId = ChannelId.unique
         try database.writeSynchronously { session in
             try session.saveChannel(payload: self.dummyPayload(with: channelId))
@@ -258,7 +258,7 @@ final class SyncOperations_Tests: XCTestCase {
     func test_RefetchChannelListQueryOperation_availableOnRemote_resetSuccess_shouldNotAddToContextWhenAlreadyExisting() throws {
         let context = SyncContext(lastSyncAt: .init())
         let controller = ChatChannelListController_Mock(query: .init(filter: .exists(.cid)), client: client)
-        controller.state = .remoteDataFetched
+        controller.state_mock = .remoteDataFetched
         let channelId = ChannelId.unique
         try database.writeSynchronously { session in
             try session.saveChannel(payload: self.dummyPayload(with: channelId))

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -75,6 +75,7 @@ final class SyncOperations_Tests: XCTestCase {
 
     func test_SyncEventsOperation_pendingDate_syncFailure_shouldRetry() throws {
         let context = SyncContext(lastSyncAt: .init())
+        context.localChannelIds = [ChannelId.unique]
         try database.createCurrentUser()
         let originalDate = Date().addingTimeInterval(-3600)
         try database.writeSynchronously { session in
@@ -96,6 +97,7 @@ final class SyncOperations_Tests: XCTestCase {
 
     func test_SyncEventsOperation_pendingDate_syncSuccess_shouldUpdateLastPendingConnectionDate() throws {
         let context = SyncContext(lastSyncAt: .init())
+        context.localChannelIds = [ChannelId.unique]
         try database.createCurrentUser()
         try database.writeSynchronously { session in
             session.currentUser?.lastSynchedEventDate = DBDate().addingTimeInterval(-3600)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [PBE-6191](https://stream-io.atlassian.net/browse/PBE-6191)

### 🎯 Goal

Reduce channel list updates when opening a channel list while syncing is in progress

### 📝 Summary

- Run channel list refresh before syncing events (`/sync`)
- Do not (again) fetch events for channels in the channel list (because these were just refreshed)
- Replace `Array` with `Set` in the context

### 🛠 Implementation

Currently the sequence has been (historically), call the `/sync` endpoint first and then refresh channel lists. This can trigger an issue where events applied from the `/sync` endpoint trigger local database change (channels can reorder) and then a moment later the whole channel list is refreshed which might cause another reordering. This PR changes things around by first refreshing channel list and then calling /sync only for active channels not part of the channel list (aka channel controllers).
Result:
1. Less reordering
2. Less cases where /sync exceeds the max event count API error 
3. Less data is fetched when syncing (duplicate data is skipped)

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

[PBE-6191]: https://stream-io.atlassian.net/browse/PBE-6191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ