### PR TITLE
[Swift6] Fix unchecked sendable warnings in Xcode 16

### DIFF
--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -6,7 +6,7 @@ import CoreData
 import Foundation
 
 /// Convenience subclass of `NSPersistentContainer` allowing easier setup of the database stack.
-class DatabaseContainer: NSPersistentContainer {
+class DatabaseContainer: NSPersistentContainer, @unchecked Sendable {
     enum Kind: Equatable {
         /// The database lives only in memory. This option is used typically for anonymous users, when the local
         /// persistence is not enabled, or in tests.

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -19,7 +19,7 @@ final class SyncContext {
 
 private let syncOperationsMaximumRetries = 2
 
-final class ActiveChannelIdsOperation: AsyncOperation {
+final class ActiveChannelIdsOperation: AsyncOperation, @unchecked Sendable {
     init(
         syncRepository: SyncRepository,
         context: SyncContext
@@ -65,7 +65,7 @@ final class ActiveChannelIdsOperation: AsyncOperation {
     }
 }
 
-final class RefreshChannelListOperation: AsyncOperation {
+final class RefreshChannelListOperation: AsyncOperation, @unchecked Sendable {
     init(controller: ChatChannelListController, context: SyncContext) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak controller] _, done in
             guard let controller = controller, controller.canBeRecovered else {
@@ -107,7 +107,7 @@ final class RefreshChannelListOperation: AsyncOperation {
     }
 }
 
-final class GetChannelIdsOperation: AsyncOperation {
+final class GetChannelIdsOperation: AsyncOperation, @unchecked Sendable {
     init(database: DatabaseContainer, context: SyncContext, activeChannelIds: [ChannelId]) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak database] _, done in
             guard let database = database else {
@@ -126,7 +126,7 @@ final class GetChannelIdsOperation: AsyncOperation {
     }
 }
 
-final class SyncEventsOperation: AsyncOperation {
+final class SyncEventsOperation: AsyncOperation, @unchecked Sendable {
     init(syncRepository: SyncRepository, context: SyncContext, recovery: Bool) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak syncRepository] _, done in
             log.info(
@@ -152,7 +152,7 @@ final class SyncEventsOperation: AsyncOperation {
     }
 }
 
-final class WatchChannelOperation: AsyncOperation {
+final class WatchChannelOperation: AsyncOperation, @unchecked Sendable {
     init(controller: ChatChannelController, context: SyncContext, recovery: Bool) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak controller] _, done in
             guard let controller = controller, controller.canBeRecovered else {
@@ -203,7 +203,7 @@ final class WatchChannelOperation: AsyncOperation {
     }
 }
 
-final class RefetchChannelListQueryOperation: AsyncOperation {
+final class RefetchChannelListQueryOperation: AsyncOperation, @unchecked Sendable {
     init(controller: ChatChannelListController, context: SyncContext) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak controller] _, done in
             guard let controller = controller, controller.canBeRecovered else {
@@ -260,7 +260,7 @@ final class RefetchChannelListQueryOperation: AsyncOperation {
     }
 }
 
-final class DeleteUnwantedChannelsOperation: AsyncOperation {
+final class DeleteUnwantedChannelsOperation: AsyncOperation, @unchecked Sendable {
     init(database: DatabaseContainer, context: SyncContext) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak database] _, done in
             log.info("4. Clean up unwanted channels", subsystems: .offlineSupport)
@@ -293,7 +293,7 @@ final class DeleteUnwantedChannelsOperation: AsyncOperation {
     }
 }
 
-final class ExecutePendingOfflineActions: AsyncOperation {
+final class ExecutePendingOfflineActions: AsyncOperation, @unchecked Sendable {
     init(offlineRequestsRepository: OfflineRequestsRepository) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak offlineRequestsRepository] _, done in
             log.info("Running offline actions requests", subsystems: .offlineSupport)

--- a/Sources/StreamChat/Utils/Codable+Extensions.swift
+++ b/Sources/StreamChat/Utils/Codable+Extensions.swift
@@ -6,7 +6,7 @@ import Foundation
 
 // MARK: - JSONDecoder Stream
 
-final class StreamJSONDecoder: JSONDecoder {
+final class StreamJSONDecoder: JSONDecoder, @unchecked Sendable {
     let iso8601formatter: ISO8601DateFormatter
     let dateCache: NSCache<NSString, NSDate>
 

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-class AsyncOperation: BaseOperation {
+class AsyncOperation: BaseOperation, @unchecked Sendable {
     enum Output {
         case retry
         case `continue`
@@ -57,7 +57,7 @@ class AsyncOperation: BaseOperation {
     }
 }
 
-class BaseOperation: Operation {
+class BaseOperation: Operation, @unchecked Sendable {
     private var _finished = false
     private var _executing = false
     private let stateQueue = DispatchQueue(label: "io.getstream.base-operation", attributes: .concurrent)

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -6,7 +6,7 @@ import Combine
 import Foundation
 
 /// The type is designed to pre-process some incoming `Event` via middlewares before being published
-class EventNotificationCenter: NotificationCenter {
+class EventNotificationCenter: NotificationCenter, @unchecked Sendable {
     private(set) var middlewares: [EventMiddleware] = []
 
     /// The database used when evaluating middlewares.

--- a/Sources/StreamChatUI/StreamNuke/Internal/Operation.swift
+++ b/Sources/StreamChatUI/StreamNuke/Internal/Operation.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-final class Operation: Foundation.Operation {
+final class Operation: Foundation.Operation, @unchecked Sendable {
     private let _isExecuting: UnsafeMutablePointer<Int32>
     private let _isFinished: UnsafeMutablePointer<Int32>
     private let isFinishCalled: UnsafeMutablePointer<Int32>


### PR DESCRIPTION
### 🎯 Goal

Reduce warnings when building with Xcode 16:
- Class `XYZ` must restate inherited `@unchecked Sendable` conformance

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)