### PR TITLE
[Swift6] Fix converting value causes data races warnings in Xcode 16

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -581,7 +581,7 @@ public class ChatClient {
     /// - Returns: The latest state of app settings.
     public func loadAppSettings() async throws -> AppSettings {
         try await withCheckedThrowingContinuation { continuation in
-            loadAppSettings(completion: continuation.resume(with:))
+            loadAppSettings { continuation.resume(with: $0) }
         }
     }
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -920,7 +920,7 @@ extension ChannelUpdater {
                 isInRecoveryMode: false,
                 onChannelCreated: useCreateEndpoint,
                 actions: ChannelUpdateActions(memberListSorting: memberSorting),
-                completion: continuation.resume(with:)
+                completion: { continuation.resume(with: $0) }
             )
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Fix warnings:
```
ChatClient.swift:584:54: Converting a value of type '(__shared sending Result<AppSettings, any Error>) -> ()' to type '(Result<AppSettings, any Error>) -> Void' risks causing data races; this is an error in the Swift 6 language mode
```

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)