### PR TITLE
[CI] Unstable data container test

### DIFF
--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -143,11 +143,6 @@ final class DatabaseContainer_Tests: XCTestCase {
             expectation.fulfill()
         }
         
-        // Save just after triggering remove all
-        container.write { session in
-            try session.saveChannel(payload: self.dummyPayload(with: .unique), query: nil, cache: nil)
-        }
-        
         wait(for: [expectation], timeout: defaultTimeout)
         
         let counts = try container.readSynchronously { session in


### PR DESCRIPTION
### 🎯 Goal

Fix an unstable test what has race between another write call and reading the database state.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
