### PR TITLE
[POC] Reuse ViewModels across SwiftUI and UIKit

### DIFF
--- a/DemoApp/StreamChat/DemoAppCoordinator+DemoApp.swift
+++ b/DemoApp/StreamChat/DemoAppCoordinator+DemoApp.swift
@@ -33,16 +33,14 @@ extension DemoAppCoordinator {
 
         let client = StreamChatWrapper.shared.client!
         let threadListQuery = ThreadListQuery(watch: true)
-        let threadListVC = DemoChatThreadListVC(
-            threadListController: client.threadListController(query: threadListQuery),
+        let viewModel = ChatThreadListViewModel(
+            threadListController: client.threadListController(query: .init(watch: true)),
             eventsController: client.eventsController()
         )
-        threadListVC.onLogout = { [weak self] in
-            self?.logOut()
-        }
-        threadListVC.onDisconnect = { [weak self] in
-            self?.disconnect()
-        }
+        viewModel.chatClient = client
+        let threadListVC = ChatThreadListStatefulVC(
+            viewModel: viewModel
+        )
         let tabBarViewController = DemoAppTabBarController(
             channelListVC: chatVC,
             threadListVC: UINavigationController(rootViewController: threadListVC),

--- a/Sources/StreamChatUI/ChatThreadList/ChatThreadListStatefulVC.swift
+++ b/Sources/StreamChatUI/ChatThreadList/ChatThreadListStatefulVC.swift
@@ -1,0 +1,293 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import StreamChat
+import UIKit
+
+/// The view controller used to display the list of threads the current user is participating.
+@available(iOSApplicationExtension, unavailable)
+open class ChatThreadListStatefulVC:
+    _ViewController,
+    ThemeProvider,
+    UITableViewDelegate,
+    UITableViewDataSource
+{
+    var viewModel: ChatThreadListViewModel
+
+    public init(
+        viewModel: ChatThreadListViewModel
+    ) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// The current thread list data.
+    public private(set) var threads: [ChatThread] = []
+
+    /// A component responsible to handle when to load new channels.
+    private lazy var viewPaginationHandler: ViewPaginationHandling = {
+        ScrollViewPaginationHandler(scrollView: tableView)
+    }()
+
+    /// The `UITableView` instance that displays the thread list.
+    open private(set) lazy var tableView: UITableView = UITableView()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "tableView")
+
+    /// The loading indicator shown at the top when fetching new threads.
+    open private(set) lazy var loadingBannerIndicator: UIActivityIndicatorView = {
+        UIActivityIndicatorView(style: .medium)
+    }()
+
+    /// The banner view shown by default as a table view header to fetch unread threads.
+    open private(set) lazy var headerBannerView: ChatThreadListHeaderBannerView = components
+        .threadListHeaderBannerView.init()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "headerBannerView")
+
+    /// The thread list error view that is shown when loading threads fails.
+    open private(set) lazy var errorView: ChatThreadListErrorView = components
+        .threadListErrorView.init()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "errorView")
+
+    /// The thread list loading view.
+    open private(set) lazy var loadingView: ChatThreadListLoadingView = components
+        .threadListLoadingView.init()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "loadingView")
+
+    /// The empty view when there are no threads.
+    open private(set) lazy var emptyView: ChatThreadListEmptyView = components
+        .threadListEmptyView.init()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "emptyView")
+
+    /// A router object responsible for handling navigation actions of this view controller.
+    open lazy var router: ChatThreadListStatefulRouter = ChatThreadListStatefulRouter(rootViewController: self)
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override open func setUp() {
+        super.setUp()
+
+        tableView.register(ChatThreadListItemCell.self)
+        tableView.delegate = self
+        tableView.dataSource = self
+
+        viewModel.$threads
+            .sink { [weak self] threads in
+                guard let self = self else { return }
+                let previousThreads = self.threads
+                let newThreads = Array(threads)
+                let stagedChangeset = StagedChangeset(source: previousThreads, target: newThreads)
+                tableView.reload(
+                    using: stagedChangeset,
+                    with: .fade,
+                    reconfigure: { _ in true }
+                ) { [weak self] newThreads in
+                    self?.threads = newThreads
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$isLoading
+            .sink { [weak self] isLoading in
+                if isLoading {
+                    self?.showLoadingView()
+                } else {
+                    self?.hideLoadingView()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$isEmpty
+            .sink { [weak self] isEmpty in
+                if isEmpty {
+                    self?.showEmptyView()
+                } else {
+                    self?.hideEmptyView()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$failedToLoadThreads
+            .sink { [weak self] failed in
+                if failed {
+                    self?.showErrorView()
+                } else {
+                    self?.hideErrorView()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$hasNewThreads
+            .sink { [weak self] hasNewThreads in
+                if hasNewThreads {
+                    self?.showHeaderBannerView()
+                } else {
+                    self?.hideHeaderBannerView()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$isReloading
+            .sink { [weak self] isReloading in
+                if isReloading {
+                    self?.showLoadingBannerView()
+                } else {
+                    self?.hideLoadingBannerView()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$newThreadsCount
+            .sink { [weak self] newThreadsCount in
+                self?.headerBannerView.content = .init(newThreadsCount: newThreadsCount)
+            }
+            .store(in: &cancellables)
+
+        headerBannerView.onAction = { [weak self] in
+            self?.viewModel.loadThreads()
+        }
+        errorView.onAction = { [weak self] in
+            self?.viewModel.retryLoadThreads()
+        }
+        viewPaginationHandler.bottomThreshold = 800
+        viewPaginationHandler.onNewBottomPage = { [weak self] in
+            self?.viewModel.loadMoreThreads()
+        }
+    }
+
+    override open func setUpAppearance() {
+        super.setUpAppearance()
+
+        tableView.backgroundColor = appearance.colorPalette.background
+        tableView.separatorStyle = .singleLine
+    }
+
+    override open func setUpLayout() {
+        super.setUpLayout()
+
+        view.embed(tableView)
+        view.embed(loadingView)
+        view.embed(emptyView)
+
+        view.addSubview(errorView)
+        errorView.pin(anchors: [.leading, .trailing], to: view)
+        errorView.bottomAnchor.pin(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+
+        hideLoadingView()
+        hideEmptyView()
+        hideErrorView()
+    }
+
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel.viewDidAppear()
+    }
+
+    // MARK: - Show/Hide state views
+
+    /// Displays the header banner view when there are thread updates to be fetched.
+    open func showHeaderBannerView() {
+        tableView.tableHeaderView = headerBannerView
+        headerBannerView.widthAnchor.pin(equalTo: tableView.widthAnchor).isActive = true
+        headerBannerView.layoutIfNeeded()
+    }
+
+    /// Hides the header banner view.
+    open func hideHeaderBannerView() {
+        Animate {
+            self.tableView.tableHeaderView = nil
+            self.tableView.layoutIfNeeded()
+        }
+    }
+
+    /// Shows the loading banner view when fetching unread threads.
+    open func showLoadingBannerView() {
+        loadingBannerIndicator.startAnimating()
+        tableView.tableHeaderView = loadingBannerIndicator
+    }
+
+    /// Hides the loading banner view.
+    open func hideLoadingBannerView() {
+        Animate {
+            self.tableView.tableHeaderView = nil
+            self.tableView.layoutIfNeeded()
+        }
+    }
+
+    /// Shows the loading view.
+    open func showLoadingView() {
+        loadingView.isHidden = false
+    }
+
+    /// Hides the loading view.
+    open func hideLoadingView() {
+        loadingView.isHidden = true
+    }
+
+    /// Shows the empty view.
+    open func showEmptyView() {
+        emptyView.isHidden = false
+    }
+
+    /// Hides the empty view.
+    open func hideEmptyView() {
+        emptyView.isHidden = true
+    }
+
+    /// Shows the error view.
+    open func showErrorView() {
+        errorView.isHidden = false
+    }
+
+    /// Hides the error view.
+    open func hideErrorView() {
+        errorView.isHidden = true
+    }
+
+    // MARK: - UITableViewDataSource & UITableViewDelegate
+
+    open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        threads.count
+    }
+
+    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let thread = threads[indexPath.row]
+        let cell = tableView.dequeueReusableCell(with: ChatThreadListItemCell.self, for: indexPath)
+        cell.components = components
+        cell.itemView.content = .init(
+            thread: thread,
+            currentUserId: viewModel.chatClient.currentUserId
+        )
+        return cell
+    }
+
+    open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let thread = threads[indexPath.row]
+        router.showThread(thread)
+    }
+}
+
+extension Publisher where Failure == Never {
+    /// Assigns each element from a publisher to a property on an object without retaining the object.
+    func assignWeakly<Root: AnyObject>(
+        to keyPath: ReferenceWritableKeyPath<Root, Output>,
+        on root: Root
+    ) -> AnyCancellable {
+        sink { [weak root] in
+            root?[keyPath: keyPath] = $0
+        }
+    }
+}

--- a/Sources/StreamChatUI/ChatThreadList/ChatThreadListStatefulVC.swift
+++ b/Sources/StreamChatUI/ChatThreadList/ChatThreadListStatefulVC.swift
@@ -82,6 +82,17 @@ open class ChatThreadListStatefulVC:
         tableView.delegate = self
         tableView.dataSource = self
 
+        headerBannerView.onAction = { [weak self] in
+            self?.viewModel.loadThreads()
+        }
+        errorView.onAction = { [weak self] in
+            self?.viewModel.retryLoadThreads()
+        }
+        viewPaginationHandler.bottomThreshold = 800
+        viewPaginationHandler.onNewBottomPage = { [weak self] in
+            self?.viewModel.loadMoreThreads()
+        }
+
         viewModel.$threads
             .sink { [weak self] threads in
                 guard let self = self else { return }
@@ -153,17 +164,6 @@ open class ChatThreadListStatefulVC:
                 self?.headerBannerView.content = .init(newThreadsCount: newThreadsCount)
             }
             .store(in: &cancellables)
-
-        headerBannerView.onAction = { [weak self] in
-            self?.viewModel.loadThreads()
-        }
-        errorView.onAction = { [weak self] in
-            self?.viewModel.retryLoadThreads()
-        }
-        viewPaginationHandler.bottomThreshold = 800
-        viewPaginationHandler.onNewBottomPage = { [weak self] in
-            self?.viewModel.loadMoreThreads()
-        }
     }
 
     override open func setUpAppearance() {

--- a/Sources/StreamChatUI/ChatThreadList/ChatThreadListViewModel.swift
+++ b/Sources/StreamChatUI/ChatThreadList/ChatThreadListViewModel.swift
@@ -1,0 +1,221 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import StreamChat
+import UIKit
+
+/// The ViewModel for the `ChatThreadListView`.
+open class ChatThreadListViewModel: ObservableObject, ChatThreadListControllerDelegate, EventsControllerDelegate {
+    /// Context provided dependencies.
+    public var chatClient: ChatClient!
+
+    /// The controller that manages the thread list data.
+    private var threadListController: ChatThreadListController!
+
+    /// The controller that manages thread list events.
+    private var eventsController: EventsController!
+
+    /// A boolean value indicating if the initial threads have been loaded.
+    public private(set) var hasLoadedThreads = false
+
+    /// The current selected thread.
+    @Published public var selectedThread: ThreadSelectionInfo?
+
+    /// The list of threads.
+    @Published public var threads = LazyCachedMapCollection<ChatThread>()
+
+    /// A boolean indicating if it is loading data from the server and no local cache is available.
+    @Published public var isLoading = false
+
+    /// A boolean indicating if it is reloading data from the server.
+    @Published public var isReloading = false
+
+    /// A boolean indicating that there is no data from server.
+    @Published public var isEmpty = false
+
+    /// A boolean indicating if it failed loading the initial data from the server.
+    @Published public var failedToLoadThreads = false
+
+    /// A boolean indicating if it failed loading threads while paginating.
+    @Published public var failedToLoadMoreThreads = false
+
+    /// A boolean value indicating if the view is currently loading more threads.
+    @Published public var isLoadingMoreThreads: Bool = false
+
+    /// A boolean value indicating if all the older threads are loaded.
+    @Published public var hasLoadedAllThreads: Bool = false
+
+    /// The number of new threads available to be fetched.
+    @Published public var newThreadsCount: Int = 0
+
+    /// A boolean value indicating if there are new threads available to be fetched.
+    @Published public var hasNewThreads: Bool = false
+
+    /// The ids of the new threads available to be fetched.
+    private var newAvailableThreadIds: Set<MessageId> = [] {
+        didSet {
+            newThreadsCount = newAvailableThreadIds.count
+            hasNewThreads = newThreadsCount > 0
+        }
+    }
+
+    /// Creates a view model for the `ChatThreadListView`.
+    ///
+    /// - Parameters:
+    ///   - threadListController: A controller providing the list of threads. If nil, a controller with default `ThreadListQuery` is created.
+    ///   - eventsController: The controller that manages thread list events. If nil, the default events controller will be provided.
+    public init(
+        threadListController: ChatThreadListController? = nil,
+        eventsController: EventsController? = nil
+    ) {
+        if let threadListController = threadListController {
+            self.threadListController = threadListController
+        } else {
+            makeDefaultThreadListController()
+        }
+
+        if let eventsController = eventsController {
+            self.eventsController = eventsController
+        } else {
+            makeDefaultEventsController()
+        }
+    }
+
+    /// Re-fetches the threads. If the initial query failed, it will load the initial page.
+    /// If on the other hand it was a new page that failed, it will re-fetch that page.
+    public func retryLoadThreads() {
+        if failedToLoadMoreThreads {
+            loadMoreThreads()
+            return
+        }
+
+        loadThreads()
+    }
+
+    /// Called when the view appears on screen.
+    ///
+    /// By default it will load the initial threads and start observing new data.
+    public func viewDidAppear() {
+        if !hasLoadedThreads {
+            startObserving()
+            loadThreads()
+        }
+    }
+
+    /// Starts observing new data.
+    public func startObserving() {
+        threadListController.delegate = self
+        eventsController?.delegate = self
+    }
+
+    /// Loads the initial page of threads.
+    public func loadThreads() {
+        let isEmpty = threadListController.threads.isEmpty
+        isLoading = isEmpty
+        failedToLoadThreads = false
+        isReloading = !isEmpty
+        preselectThreadIfNeeded()
+        threadListController.synchronize { [weak self] error in
+            self?.isLoading = false
+            self?.isReloading = false
+            self?.hasLoadedThreads = error == nil
+            self?.failedToLoadThreads = error != nil
+            self?.isEmpty = self?.threadListController.threads.isEmpty == true
+            self?.preselectThreadIfNeeded()
+            self?.hasLoadedAllThreads = self?.threadListController.hasLoadedAllThreads ?? false
+            if error == nil {
+                self?.newAvailableThreadIds = []
+            }
+        }
+    }
+
+    /// Called when a thread in the list is shown on screen.
+    public func didAppearThread(at index: Int) {
+        guard index >= threads.count - 5 else {
+            return
+        }
+
+        loadMoreThreads()
+    }
+
+    /// Loads the next page of threads.
+    public func loadMoreThreads() {
+        if isLoadingMoreThreads || threadListController.hasLoadedAllThreads == true {
+            return
+        }
+
+        isLoadingMoreThreads = true
+        threadListController.loadMoreThreads { [weak self] result in
+            self?.isLoadingMoreThreads = false
+            self?.hasLoadedAllThreads = self?.threadListController.hasLoadedAllThreads ?? false
+            let threads = try? result.get()
+            self?.failedToLoadMoreThreads = threads == nil
+        }
+    }
+
+    public func controller(
+        _ controller: ChatThreadListController,
+        didChangeThreads changes: [ListChange<ChatThread>]
+    ) {
+        threads = controller.threads
+    }
+
+    public func eventsController(_ controller: EventsController, didReceiveEvent event: any Event) {
+        switch event {
+        case let event as ThreadMessageNewEvent:
+            guard let parentId = event.message.parentMessageId else { break }
+            let isNewThread = threadListController.dataStore.thread(parentMessageId: parentId) == nil
+            if isNewThread {
+                newAvailableThreadIds.insert(parentId)
+            }
+        default:
+            break
+        }
+    }
+
+    private func makeDefaultThreadListController() {
+        threadListController = chatClient.threadListController(
+            query: .init(watch: true)
+        )
+        chatClient = threadListController.client
+    }
+
+    private func makeDefaultEventsController() {
+        eventsController = chatClient.eventsController()
+    }
+
+    private func preselectThreadIfNeeded() {
+        guard let firstThread = threads.first else { return }
+        guard selectedThread == nil else { return }
+
+        selectedThread = .init(thread: firstThread)
+    }
+}
+
+public struct ThreadSelectionInfo: Identifiable {
+    public let id: String
+    public let thread: ChatThread
+
+    public init(thread: ChatThread) {
+        self.thread = thread
+        id = thread.id
+    }
+}
+
+extension ThreadSelectionInfo: Hashable, Equatable {
+    public static func == (lhs: ThreadSelectionInfo, rhs: ThreadSelectionInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+extension ChatThread: Identifiable {
+    public var id: String {
+        parentMessageId
+    }
+}

--- a/Sources/StreamChatUI/Navigation/ChatThreadListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatThreadListRouter.swift
@@ -33,3 +33,32 @@ open class ChatThreadListRouter: NavigationRouter<ChatThreadListVC>, ComponentsP
         }
     }
 }
+
+/// A `NavigationRouter` subclass that handles navigation actions of `ChatChannelListVC`.
+@available(iOSApplicationExtension, unavailable)
+open class ChatThreadListStatefulRouter: NavigationRouter<ChatThreadListStatefulVC>, ComponentsProvider {
+    let modalTransitioningDelegate = StreamModalTransitioningDelegate()
+
+    /// Shows the thread from the thread list.
+    /// By default it opens the `ChatThreadVC` that displays the replies.
+    open func showThread(_ thread: ChatThread) {
+        guard let client = rootViewController.viewModel.chatClient else { return }
+        let threadVC = components.threadVC.init()
+        threadVC.channelController = client.channelController(for: thread.channel.cid)
+        threadVC.messageController = client.messageController(
+            cid: thread.channel.cid,
+            messageId: thread.parentMessageId
+        )
+
+        if let splitVC = rootViewController.splitViewController {
+            splitVC.showDetailViewController(UINavigationController(rootViewController: threadVC), sender: self)
+        } else if let navigationVC = rootViewController.navigationController {
+            navigationVC.show(threadVC, sender: self)
+        } else {
+            let navigationVC = UINavigationController(rootViewController: threadVC)
+            navigationVC.transitioningDelegate = modalTransitioningDelegate
+            navigationVC.modalPresentationStyle = .custom
+            rootViewController.show(navigationVC, sender: self)
+        }
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1764,6 +1764,10 @@
 		ADE2093D29FC022D007D0FF3 /* MessagesPaginationStateHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE2093C29FC022D007D0FF3 /* MessagesPaginationStateHandling.swift */; };
 		ADE40043291B1A510000C98B /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE40042291B1A510000C98B /* AttachmentUploader.swift */; };
 		ADE40044291B1A510000C98B /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE40042291B1A510000C98B /* AttachmentUploader.swift */; };
+		ADE442F42CBECD560066CDF7 /* ChatThreadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE442F32CBECD560066CDF7 /* ChatThreadListViewModel.swift */; };
+		ADE442F52CBECD560066CDF7 /* ChatThreadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE442F32CBECD560066CDF7 /* ChatThreadListViewModel.swift */; };
+		ADE442F72CBECE030066CDF7 /* ChatThreadListStatefulVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE442F62CBECE030066CDF7 /* ChatThreadListStatefulVC.swift */; };
+		ADE442F82CBECE030066CDF7 /* ChatThreadListStatefulVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE442F62CBECE030066CDF7 /* ChatThreadListStatefulVC.swift */; };
 		ADE57B792C36DB2000DD6B88 /* ChatThreadListErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE57B782C36DB2000DD6B88 /* ChatThreadListErrorView.swift */; };
 		ADE57B7A2C36DB2000DD6B88 /* ChatThreadListErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE57B782C36DB2000DD6B88 /* ChatThreadListErrorView.swift */; };
 		ADE57B7C2C36E71200DD6B88 /* ChatThreadListHeaderBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE57B7B2C36E71200DD6B88 /* ChatThreadListHeaderBannerView.swift */; };
@@ -4422,6 +4426,8 @@
 		ADDC08132C82A81F00EA0E5F /* TextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldView.swift; sourceTree = "<group>"; };
 		ADE2093C29FC022D007D0FF3 /* MessagesPaginationStateHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesPaginationStateHandling.swift; sourceTree = "<group>"; };
 		ADE40042291B1A510000C98B /* AttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploader.swift; sourceTree = "<group>"; };
+		ADE442F32CBECD560066CDF7 /* ChatThreadListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListViewModel.swift; sourceTree = "<group>"; };
+		ADE442F62CBECE030066CDF7 /* ChatThreadListStatefulVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListStatefulVC.swift; sourceTree = "<group>"; };
 		ADE57B782C36DB2000DD6B88 /* ChatThreadListErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListErrorView.swift; sourceTree = "<group>"; };
 		ADE57B7B2C36E71200DD6B88 /* ChatThreadListHeaderBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListHeaderBannerView.swift; sourceTree = "<group>"; };
 		ADE57B832C3C5C8700DD6B88 /* ThreadMessageNew.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ThreadMessageNew.json; sourceTree = "<group>"; };
@@ -8820,6 +8826,8 @@
 				AD7BE16F2C234798000A5756 /* ChatThreadListLoadingView.swift */,
 				AD7BE1722C2347A3000A5756 /* ChatThreadListEmptyView.swift */,
 				ADE57B782C36DB2000DD6B88 /* ChatThreadListErrorView.swift */,
+				ADE442F62CBECE030066CDF7 /* ChatThreadListStatefulVC.swift */,
+				ADE442F32CBECD560066CDF7 /* ChatThreadListViewModel.swift */,
 			);
 			path = ChatThreadList;
 			sourceTree = "<group>";
@@ -10555,6 +10563,7 @@
 				ACCA772E26C568D8007AE2ED /* NukeImageProcessor.swift in Sources */,
 				4067764F2A14CB550079B05C /* MediaButton.swift in Sources */,
 				C1FC2F6B27416E150062530F /* ImagePublisher.swift in Sources */,
+				ADE442F42CBECD560066CDF7 /* ChatThreadListViewModel.swift in Sources */,
 				88A8CF16256E7BDA004EA4C7 /* ChatMessageContentView.swift in Sources */,
 				BDEB9417268211EC00928AF1 /* ChatMessageListUnreadCountView.swift in Sources */,
 				226C438D25802AAD008B3648 /* InputTextView.swift in Sources */,
@@ -10755,6 +10764,7 @@
 				ADCB577F28A42D7700B81AE8 /* ContentIdentifiable.swift in Sources */,
 				E7073A6325DD67B3003896B9 /* UILabel+Extensions.swift in Sources */,
 				C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */,
+				ADE442F72CBECE030066CDF7 /* ChatThreadListStatefulVC.swift in Sources */,
 				ADD3285E2C05447200BAD0E9 /* ChatThreadListVC.swift in Sources */,
 				843F0BC526775D2D00B342CB /* VideoLoading.swift in Sources */,
 				88CABC4625933EE70061BB67 /* ChatReactionPickerBubbleView.swift in Sources */,
@@ -12646,6 +12656,7 @@
 				C121EB7F2746A1E700023E4C /* SystemEnvironment.swift in Sources */,
 				C121EB802746A1E700023E4C /* CACornerMask+Extensions.swift in Sources */,
 				C121EB812746A1E700023E4C /* CGRect+Extensions.swift in Sources */,
+				ADE442F52CBECD560066CDF7 /* ChatThreadListViewModel.swift in Sources */,
 				AD4C8C232C5D479B00E1C414 /* StackedUserAvatarsView.swift in Sources */,
 				C121EB822746A1E700023E4C /* CGPoint+Extensions.swift in Sources */,
 				40FA4DEB2A12A46D00DA21D2 /* VoiceRecordingAttachmentComposerPreview_Tests.swift in Sources */,
@@ -12699,6 +12710,7 @@
 				C121EBA12746A1E800023E4C /* ShrinkInputButton.swift in Sources */,
 				C121EBA22746A1E800023E4C /* CheckboxControl.swift in Sources */,
 				AD50C31E2A607A88002FDD06 /* ChannelListSearchStrategy.swift in Sources */,
+				ADE442F82CBECE030066CDF7 /* ChatThreadListStatefulVC.swift in Sources */,
 				C121EBA32746A1E800023E4C /* QuotedChatMessageView.swift in Sources */,
 				C121EBA42746A1E800023E4C /* QuotedChatMessageView+SwiftUI.swift in Sources */,
 				C121EBA52746A1E800023E4C /* OnlineIndicatorView.swift in Sources */,


### PR DESCRIPTION
### Summary
This is just a proof of concept to see how feasible it would be to reuse view models across the SwiftUI and UIKit SDK. 

Spoiler Alert: It looks pretty promising 👌 

### Further work
- We would need to make sure we do not import UIKit or SwiftUI in the ViewModels to make sure they do not depend on any UI framework
- We would need to expose a constructor to replace the "@Injected" dependencies from SwiftUI
- We would need to make the View Models, Formatters and all presentation logic part of LLC or create an additional framework
- Maybe even move SwiftUI to this repo?

###  Demo

| Loading Threads | New Threads |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/911e3316-200c-45f1-b834-55e15e58fd8b"/> | <video src="https://github.com/user-attachments/assets/ccba9b0b-dc4b-42a0-8551-13c3b56340c5"/> | 



