### PR TITLE
[POC] Creating live ephemeral messages

### DIFF
--- a/DemoApp/StreamChat/Components/DemoChatMessageContentView.swift
+++ b/DemoApp/StreamChat/Components/DemoChatMessageContentView.swift
@@ -53,5 +53,15 @@ final class DemoChatMessageContentView: ChatMessageContentView {
            let birthLand = content?.author.birthLand {
             authorNameLabel.text?.append(" \(birthLand)")
         }
+
+        if content?.extraData["is_live"]?.boolValue == true && content?.localState != nil {
+            bubbleView?.layer.borderWidth = 2
+            bubbleView?.layer.borderColor = appearance.colorPalette.accentPrimary.cgColor
+            footnoteContainer?.isHidden = true
+        } else {
+            bubbleView?.layer.borderWidth = 1
+            bubbleView?.layer.borderColor = appearance.colorPalette.border3.cgColor
+            footnoteContainer?.isHidden = false
+        }
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1315,7 +1315,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         skipPush: Bool = false,
         skipEnrichUrl: Bool = false,
         extraData: [String: RawJSON] = [:],
-        completion: ((Result<EphemeralMessageUpdater, Error>) -> Void)? = nil
+        completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
@@ -1341,19 +1341,17 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             extraData: extraData
         ) { result in
             self.callback {
-                switch result {
-                case .success(let message):
-                    let updater = EphemeralMessageUpdater(messageId: message.id) { [weak self] newText in
-                        self?.updater.updateEphemeralMessage(id: message.id, text: newText)
-                    } publish: { [weak self] in
-                        self?.updater.publishEphemeralMessage(id: message.id)
-                    }
-                    completion?(.success(updater))
-                case .failure(let error):
-                    completion?(.failure(error))
-                }
+                completion?(result.map(\.id))
             }
         }
+    }
+
+    public func updateEphemeralMessage(id: MessageId, text: String) {
+        updater.updateEphemeralMessage(id: id, text: text)
+    }
+    
+    public func publishEphemeralMessage(id: MessageId) {
+        updater.publishEphemeralMessage(id: id)
     }
 
     deinit {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1348,8 +1348,8 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         }
     }
 
-    internal func updateEphemeralMessage(id: MessageId, text: String) {
-        updater.updateEphemeralMessage(id: id, text: text)
+    internal func updateEphemeralMessage(id: MessageId, text: String, extraData: [String: RawJSON]) {
+        updater.updateEphemeralMessage(id: id, text: text, extraData: extraData)
     }
     
     internal func publishEphemeralMessage(id: MessageId) {
@@ -1373,15 +1373,15 @@ public class EphemeralMessageEditor {
         self.channelController = channelController
     }
 
-    public func updateMessage(text: String) {
+    public func updateMessage(text: String, extraData: [String: RawJSON] = [:]) {
         if let messageId {
-            channelController.updateEphemeralMessage(id: messageId, text: text)
+            channelController.updateEphemeralMessage(id: messageId, text: text, extraData: extraData)
             return
         }
         
         let group = DispatchGroup()
         group.enter()
-        channelController.createEphemeralMessage(text: text) {
+        channelController.createEphemeralMessage(text: text, extraData: extraData) {
             self.messageId = try? $0.get()
             group.leave()
         }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -519,7 +519,10 @@ class MessageDTO: NSManagedObject {
     static func loadSendingMessages(context: NSManagedObjectContext) -> [MessageDTO] {
         let request = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageDTO.locallyCreatedAt, ascending: false)]
-        request.predicate = NSPredicate(format: "localMessageStateRaw == %@", LocalMessageState.sending.rawValue)
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            .init(format: "localMessageStateRaw == %@", LocalMessageState.sending.rawValue),
+            .init(format: "type != %@", MessageType.ephemeral.rawValue)
+        ])
         return load(by: request, context: context)
     }
     

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -361,7 +361,6 @@ class ChannelUpdater: Worker {
         extraData: [String: RawJSON],
         completion: ((Result<ChatMessage, Error>) -> Void)? = nil
     ) {
-        var newMessage: ChatMessage?
         database.write({ (session) in
             let newMessageDTO = try session.createNewMessage(
                 in: cid,
@@ -387,12 +386,11 @@ class ChannelUpdater: Worker {
             }
             newMessageDTO.type = MessageType.ephemeral.rawValue
             newMessageDTO.localMessageState = .sending
-            newMessage = try newMessageDTO.asModel()
+            let newMessage = try newMessageDTO.asModel()
+            completion?(.success(newMessage))
         }) { error in
-            if let message = newMessage, error == nil {
-                completion?(.success(message))
-            } else {
-                completion?(.failure(error ?? ClientError.Unknown()))
+            if let error {
+                completion?(.failure(error))
             }
         }
     }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -397,11 +397,14 @@ class ChannelUpdater: Worker {
         }
     }
 
-    func updateEphemeralMessage(id: MessageId, text: String) {
+    func updateEphemeralMessage(id: MessageId, text: String, extraData: [String: RawJSON]?) {
         database.write { (session) in
             let dto = session.message(id: id)
             dto?.text = text
             dto?.localMessageState = .sending
+            if let extraData {
+                dto?.extraData = try JSONEncoder.default.encode(extraData)
+            }
         }
     }
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -385,7 +385,7 @@ class ChannelUpdater: Worker {
             if quotedMessageId != nil {
                 newMessageDTO.showInsideThread = true
             }
-            newMessageDTO.type = MessageType.regular.rawValue
+            newMessageDTO.type = MessageType.ephemeral.rawValue
             newMessageDTO.localMessageState = .sending
             newMessage = try newMessageDTO.asModel()
         }) { error in

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1442,7 +1442,7 @@ open class ComposerVC: _ViewController,
 
         channelController?
             .ephemeralMessageEditor
-            .updateMessage(text: content.text)
+            .updateMessage(text: content.text, extraData: ["is_live": true])
     }
 
     open func textView(

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -903,8 +903,6 @@ open class ComposerVC: _ViewController,
         content.clear()
     }
 
-    var ephemeralMessageId: MessageId?
-
     /// Creates a new message and notifies the delegate that a new message was created.
     /// - Parameter text: The text content of the message.
     open func createNewMessage(text: String) {
@@ -938,10 +936,9 @@ open class ComposerVC: _ViewController,
             return
         }
 
-        if let ephemeralMessageId {
-            channelController?.publishEphemeralMessage(id: ephemeralMessageId)
-            self.ephemeralMessageId = nil
-        }
+        channelController?
+            .ephemeralMessageEditor
+            .publish()
     }
 
     /// Updates an existing message.
@@ -1443,14 +1440,9 @@ open class ComposerVC: _ViewController,
 
         content.text = textView.text
 
-        guard let ephemeralMessageId = self.ephemeralMessageId else {
-            channelController?.createEphemeralMessage(text: content.text) { [weak self] result in
-                self?.ephemeralMessageId = try? result.get()
-            }
-            return
-        }
-
-        channelController?.updateEphemeralMessage(id: ephemeralMessageId, text: content.text)
+        channelController?
+            .ephemeralMessageEditor
+            .updateMessage(text: content.text)
     }
 
     open func textView(

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1438,11 +1438,17 @@ open class ComposerVC: _ViewController,
         // it will update `UITextView.text` and vice-versa.
         guard textView.text != content.text else { return }
 
-        content.text = textView.text
+        if textView.text.isEmpty && !content.text.isEmpty {
+            channelController?
+                .ephemeralMessageEditor
+                .delete()
+        } else {
+            channelController?
+                .ephemeralMessageEditor
+                .updateMessage(text: textView.text, extraData: ["is_live": true])
+        }
 
-        channelController?
-            .ephemeralMessageEditor
-            .updateMessage(text: content.text, extraData: ["is_live": true])
+        content.text = textView.text
     }
 
     open func textView(

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -903,7 +903,7 @@ open class ComposerVC: _ViewController,
         content.clear()
     }
 
-    var ephemeralMessageUpdater: EphemeralMessageUpdater?
+    var ephemeralMessageId: MessageId?
 
     /// Creates a new message and notifies the delegate that a new message was created.
     /// - Parameter text: The text content of the message.
@@ -938,8 +938,10 @@ open class ComposerVC: _ViewController,
             return
         }
 
-        ephemeralMessageUpdater?.publish()
-        ephemeralMessageUpdater = nil
+        if let ephemeralMessageId {
+            channelController?.publishEphemeralMessage(id: ephemeralMessageId)
+            self.ephemeralMessageId = nil
+        }
     }
 
     /// Updates an existing message.
@@ -1441,14 +1443,14 @@ open class ComposerVC: _ViewController,
 
         content.text = textView.text
 
-        guard let ephemeralMessageUpdater = self.ephemeralMessageUpdater else {
+        guard let ephemeralMessageId = self.ephemeralMessageId else {
             channelController?.createEphemeralMessage(text: content.text) { [weak self] result in
-                self?.ephemeralMessageUpdater = try? result.get()
+                self?.ephemeralMessageId = try? result.get()
             }
             return
         }
 
-        ephemeralMessageUpdater.update(content.text)
+        channelController?.updateEphemeralMessage(id: ephemeralMessageId, text: content.text)
     }
 
     open func textView(

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -8,6 +8,10 @@ import StreamChat
 public extension ChatMessage {
     /// A boolean value that checks if actions are available on the message (e.g. `edit`, `delete`, `resend`, etc.).
     var isInteractionEnabled: Bool {
+        if extraData["is_live"]?.boolValue == true {
+            return true
+        }
+        
         if type == .ephemeral || isDeleted || shouldRenderAsSystemMessage {
             return false
         }
@@ -45,7 +49,7 @@ public extension ChatMessage {
 
     /// The text which should be shown in a text view inside the message bubble.
     var textContent: String? {
-        guard type != .ephemeral else {
+        if type == .ephemeral && extraData["is_live"]?.boolValue != true {
             return nil
         }
 

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -8,7 +8,7 @@ import StreamChat
 public extension ChatMessage {
     /// A boolean value that checks if actions are available on the message (e.g. `edit`, `delete`, `resend`, etc.).
     var isInteractionEnabled: Bool {
-        if extraData["is_live"]?.boolValue == true {
+        if type == .ephemeral && localState == .sending {
             return true
         }
         
@@ -49,7 +49,7 @@ public extension ChatMessage {
 
     /// The text which should be shown in a text view inside the message bubble.
     var textContent: String? {
-        if type == .ephemeral && extraData["is_live"]?.boolValue != true {
+        if type == .ephemeral && localState != .sending {
             return nil
         }
 


### PR DESCRIPTION
### 🔗 Issue Links

None

### 🎯 Goal

PoC to test how creating live ephemeral messages would work.

### How to use

The `ComposerVC` example should be simple to understand on how to use it. There 3 new `ChannelController` methods:
- `createEphemeralMessage()`: This one creates the ephemeral message ready to be updated. You need to store the messageId somewhere.
- `updateEphemeralMessage()`: This one should be used to live update the content of the message.
- `publishEphemeralMessage()`: This one should be used to publish the message to the server. 

There is also an alternative approach [here](https://github.com/GetStream/stream-chat-swift/pull/3473/commits/e59021f042fe044ec9b2f16ebf6772440512d31b) that uses an `EphemeralMessageUpdater` object, but I think for now this one is simple enough. In the future we should refine and decide the final API. We could even opt for creating a new controller or object, that handles the state of the ephemeral message, but will discuss this internally. 

## Update 
Tried a new, simpler version, which contains only 2 methods, and is easier to use:
- `channelController.ephemeralMessageEditor.updateMessage(text:)`
- `channelController.ephemeralMessageEditor.publish()`
