### PR TITLE
Fix channel list state views not updating when the view is not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChatUI
 ### ✅ Added
 - Open `shouldMarkThreadRead` and `shouldMarkChannelRead` [#3468](https://github.com/GetStream/stream-chat-swift/pull/3468)
+### 🐞 Fixed
+- Fix channel list state views not updating when the view is not visible [#3479](https://github.com/GetStream/stream-chat-swift/pull/3479)
 
 # [4.65.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.65.0)
 _October 18, 2024_

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -410,12 +410,14 @@ open class ChatChannelListVC: _ViewController,
         _ controller: ChatChannelListController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
+        handleStateChanges(controller.state)
+
         if skipChannelUpdates {
             skippedRendering = true
             return
         }
+
         reloadChannels()
-        handleStateChanges(controller.state)
     }
 
     // MARK: - DataControllerStateDelegate

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -267,6 +267,22 @@ final class ChatChannelListVC_Tests: XCTestCase {
         XCTAssertEqual(channelListVC.skippedRendering, true)
     }
 
+    func test_didChangeChannels_whenIsNotVisible_shouldStillUpdateStateViews() {
+        mockedChannelListController.channels_mock = [.mock(cid: .unique)]
+        mockedChannelListController.state_mock = .remoteDataFetched
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.components.isChatChannelListStatesEnabled = true
+        channelListVC.controller = mockedChannelListController
+        channelListVC.shouldMockViewIfLoaded = false
+        channelListVC.emptyView.isHidden = false
+
+        channelListVC.controller(mockedChannelListController, didChangeChannels: [])
+
+        XCTAssertEqual(channelListVC.emptyView.isHidden, true)
+        XCTAssertEqual(channelListVC.mockedCollectionView.performBatchUpdatesCallCount, 0)
+        XCTAssertEqual(channelListVC.mockedCollectionView.reloadDataCallCount, 0)
+    }
+
     func test_didChangeChannels_whenEmptyViewVisible_whenNewChannelsNotEmpty_shouldHideEmptyView() {
         let channelListVC = FakeChatChannelListVC()
         channelListVC.components.isChatChannelListStatesEnabled = true


### PR DESCRIPTION
### 🔗 Issue Links

None. Found the issue when investigating https://stream-io.atlassian.net/browse/PBE-6291 for SwiftUI.

### 🎯 Goal
Fixes a rare case where the channel list won't update the state views if the view is not on the screen. (Example, creating a channel)

### 🛠 Implementation
The issue was that when skipping the channel list rendering while the view is off-screen, we were not calling the update on the channel list state views, which caused the empty view to not disappear.

### 🧪 Manual Testing Notes

1- Open the Demo App
2- Login with Guest User
3- Create a DM Channel
4- Go back to the Channel List
5- The channel list should have the new channel and not the empty view.


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
