### PR TITLE
Fix connection not resuming after guest user goes to background

### DIFF
--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -28,11 +28,10 @@ struct DemoAppConfig {
         /// The app secret from the dashboard.
         let appSecret: String
         /// The duration in seconds until the token is expired.
-        let duration: TimeInterval
+        let expirationDuration: TimeInterval
         /// In order to test token refresh fails, we can set a value of how
-        /// many token refresh will succeed before it starts failing.
-        /// By default it is 0. Which means it will always succeed.
-        let numberOfSuccessfulRefreshesBeforeFailing: Int
+        /// many token refresh will fail before a successful one.
+        let numberOfFailures: Int
     }
 }
 
@@ -317,8 +316,8 @@ class AppConfigViewController: UITableViewController {
                 self?.demoAppConfig.isLocationAttachmentsEnabled = newValue
             }
         case .tokenRefreshDetails:
-            if let tokenRefreshDuration = demoAppConfig.tokenRefreshDetails?.duration {
-                cell.detailTextLabel?.text = "Duration: \(tokenRefreshDuration)s"
+            if let tokenRefreshDuration = demoAppConfig.tokenRefreshDetails?.expirationDuration {
+                cell.detailTextLabel?.text = "Duration before expired: \(tokenRefreshDuration)s"
             } else {
                 cell.detailTextLabel?.text = "Disabled"
             }
@@ -626,16 +625,16 @@ class AppConfigViewController: UITableViewController {
             }
         }
         alert.addTextField { textField in
-            textField.placeholder = "Duration (Seconds)"
+            textField.placeholder = "Expiration duration (Seconds)"
             textField.keyboardType = .numberPad
-            if let duration = self.demoAppConfig.tokenRefreshDetails?.duration {
+            if let duration = self.demoAppConfig.tokenRefreshDetails?.expirationDuration {
                 textField.text = "\(duration)"
             }
         }
         alert.addTextField { textField in
-            textField.placeholder = "Number of Refreshes Before Failing"
+            textField.placeholder = "Number of refresh fails"
             textField.keyboardType = .numberPad
-            if let numberOfRefreshes = self.demoAppConfig.tokenRefreshDetails?.numberOfSuccessfulRefreshesBeforeFailing {
+            if let numberOfRefreshes = self.demoAppConfig.tokenRefreshDetails?.numberOfFailures {
                 textField.text = "\(numberOfRefreshes)"
             }
         }
@@ -646,8 +645,8 @@ class AppConfigViewController: UITableViewController {
             guard let successfulRetries = alert.textFields?[2].text else { return }
             self.demoAppConfig.tokenRefreshDetails = .init(
                 appSecret: appSecret,
-                duration: TimeInterval(duration) ?? 60,
-                numberOfSuccessfulRefreshesBeforeFailing: Int(successfulRetries) ?? 0
+                expirationDuration: TimeInterval(duration) ?? 60,
+                numberOfFailures: Int(successfulRetries) ?? 0
             )
         }))
 

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -17,16 +17,15 @@ extension StreamChatWrapper {
                 let generatedToken: Token? = _generateUserToken(
                     secret: refreshDetails.appSecret,
                     userID: initialToken.userId,
-                    expirationDate: Date().addingTimeInterval(refreshDetails.duration)
+                    expirationDate: Date().addingTimeInterval(refreshDetails.expirationDuration)
                 )
 
                 if generatedToken == nil {
                     log.error("Demo App Token Refreshing: Unable to generate token. Using initialToken instead.")
                 }
 
-                let numberOfSuccessfulRefreshes = refreshDetails.numberOfSuccessfulRefreshesBeforeFailing
-                let shouldNotFail = numberOfSuccessfulRefreshes == 0
-                if shouldNotFail || self.numberOfRefreshTokens >= numberOfSuccessfulRefreshes {
+                let shouldNotFail = refreshDetails.numberOfFailures == 0
+                if shouldNotFail || self.numberOfRefreshTokens >= refreshDetails.numberOfFailures {
                     print("Demo App Token Refreshing: New token generated successfully.")
                     let newToken = generatedToken ?? initialToken
                     completion(.success(newToken))

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -456,7 +456,6 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers. No further updates from the servers
     /// are received.
     public func disconnect(completion: @escaping () -> Void) {
-        connectionRecoveryHandler?.stop()
         connectionRepository.disconnect(source: .userInitiated) {
             log.info("The `ChatClient` has been disconnected.", subsystems: .webSocket)
             completion()


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/stream-chat-swift/issues/3338
https://linear.app/stream/issue/IOS-75/[reconnection]-[github]-websocket-disconnectes-when-guest-user-comes

### 🎯 Goal

Fixes connection not resuming after guest user goes to background

### 📝 Summary

- Fixes connection not resuming after guest user goes to background
- Improves Demo App Token Refreshing UX

### 🛠 Implementation

The problem was that in a previous PR, we introduced stopping the recovery handler whenever a user disconnects... But this is an issue because whenever the user comes from the background and connects again, it will try to "logout" the user, and so it will stop the recovery handle before the connection.

This is at the moment the simplest solution. The con, is that the recovery handler will keep running, even after disconnection, but it s not a big deal (and it was working like this since the begining) 

### 🧪 Manual Testing Notes

- Open Demo App Configuration
- Disable `staysConnectedInBackground`
- Login with Guest User
- Go to background, wait 5s to make sure everything is disconnected
- Go back to foreground
- Connection should resume

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
