### PR TITLE
Cache NSManagedObjectID instead of the CurrentUserDTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix connection not resuming after guest user goes to background [#3483](https://github.com/GetStream/stream-chat-swift/pull/3483)
 - Fix empty channel list if the channel list filter contains OR statement with only custom filtering keys [#3482](https://github.com/GetStream/stream-chat-swift/pull/3482)
+- Fix rare crashes when accessing the current user object [#3500](https://github.com/GetStream/stream-chat-swift/pull/3500)
 
 # [4.66.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.66.0)
 _November 05, 2024_

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -173,7 +173,7 @@ extension NSManagedObjectContext: CurrentUserDatabaseSession {
         }
     }
 
-    private static let currentUserKey = "io.getStream.chat.core.context.current_user_key"
+    static let currentUserKey = "io.getStream.chat.core.context.current_user_key"
     var currentUser: CurrentUserDTO? {
         if let objectId = userInfo[Self.currentUserKey] as? NSManagedObjectID {
             if let dto = try? existingObject(with: objectId) as? CurrentUserDTO {

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -123,13 +123,8 @@ class AuthenticationRepository {
     func fetchCurrentUser() {
         var currentUserId: UserId?
 
-        let context = databaseContainer.viewContext
-        if Thread.isMainThread {
-            currentUserId = context.currentUser?.user.id
-        } else {
-            context.performAndWait {
-                currentUserId = context.currentUser?.user.id
-            }
+        databaseContainer.backgroundReadOnlyContext.performAndWait {
+            currentUserId = databaseContainer.backgroundReadOnlyContext.currentUser?.user.id
         }
         self.currentUserId = currentUserId
     }

--- a/Tests/StreamChatTests/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -246,9 +246,8 @@ final class CurrentUserModelDTO_Tests: XCTestCase {
 
         let originalUser = try XCTUnwrap(database.viewContext.currentUser)
 
-        database.writableContext.performAndWait {
-            database.writableContext.delete(database.writableContext.currentUser!)
-            try! database.writableContext.save()
+        database.viewContext.performAndWait {
+            XCTAssertNotNil(database.viewContext.userInfo[NSManagedObjectContext.currentUserKey])
         }
 
         XCTAssertEqual(database.viewContext.currentUser, originalUser)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-21](https://linear.app/stream/issue/IOS-21)

### 🎯 Goal

Cache `NSManagedObjectID` instead of the full `CurrentUserDTO` for increased reliability. 

### 📝 Summary

- Cache `NSManagedObjectID` which is less susceptible to possible threading issues (although I haven't found out that his is actually the case, but something seems to have corrupted the DTO in rare cases)

### 🛠 Implementation

We have seen a crash when NSManagedObjectContext's currentUser property is accessed which leads to a crash when the `user.id` is called. This PR tries to fix this issue by not keeping the DTO alive all the time and instead asking context to retrieve it instead of (which is not slow).
I measured the time taken for accessing the `currentUser` property and when all the call sites are combined, it was 1 ms.

### 🧪 Manual Testing Notes

Quick testing round of logging in and out

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)