### PR TITLE
Replace shared current user observer used for reading privacy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix connection not resuming after guest user goes to background [#3483](https://github.com/GetStream/stream-chat-swift/pull/3483)
 - Fix empty channel list if the channel list filter contains OR statement with only custom filtering keys [#3482](https://github.com/GetStream/stream-chat-swift/pull/3482)
+### ⚡ Performance
+- Avoid creating `CurrentChatUserController` for reading user privacy settings which is more expensive than just reading the data from the local database [#3502](https://github.com/GetStream/stream-chat-swift/pull/3502)
 
 # [4.66.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.66.0)
 _November 05, 2024_
@@ -187,7 +189,7 @@ _July 10, 2024_
 - Add support for user blocking [#3223](https://github.com/GetStream/stream-chat-swift/pull/3223)
 - [Threads v2] Add support for Threads v2 [#3229](https://github.com/GetStream/stream-chat-swift/pull/3229)
    - Add `ChatThreadListController` to fetch current user threads
-   - Add `ChatMessageController.markThreadRead()` 
+   - Add `ChatMessageController.markThreadRead()`
    - Add `ChatMessageController.markThreadUnread()`
    - Add `ChatMessageController.updateThread()`
    - Add `ChatMessageController.loadThread()`

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -53,9 +53,6 @@ public class ChatClient {
 
     /// The notification center used to send and receive notifications about incoming events.
     private(set) var eventNotificationCenter: EventNotificationCenter
-    
-    private var _sharedCurrentUserController: CurrentChatUserController?
-    private let queue = DispatchQueue(label: "io.getstream.chat-client")
 
     /// The registry that contains all the attachment payloads associated with their attachment types.
     /// For the meantime this is a static property to avoid breaking changes. On v5, this can be changed.
@@ -483,7 +480,6 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers and removes all the local data related.
     public func logout(completion: @escaping () -> Void) {
         authenticationRepository.logOutUser()
-        resetSharedCurrentUserController()
 
         // Stop tracking active components
         syncRepository.removeAllTracked()
@@ -619,24 +615,6 @@ public class ChatClient {
     private func refreshToken(completion: ((Error?) -> Void)?) {
         authenticationRepository.refreshToken {
             completion?($0)
-        }
-    }
-    
-    /// A shared user controller for an easy access to the current user.
-    var sharedCurrentUserController: CurrentChatUserController {
-        queue.sync {
-            if let controller = _sharedCurrentUserController {
-                return controller
-            }
-            let controller = currentUserController()
-            _sharedCurrentUserController = controller
-            return controller
-        }
-    }
-    
-    func resetSharedCurrentUserController() {
-        queue.async {
-            self._sharedCurrentUserController = nil
         }
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -151,7 +151,11 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             completion(false)
             return
         }
-        eventSender.currentUserTypingEventsState(completion: completion)
+        eventSender.database.read { session in
+            session.currentUser?.isTypingIndicatorsEnabled ?? true
+        } completion: { result in
+            completion(result.value ?? false)
+        }
     }
 
     /// Set the delegate of `ChannelController` to observe the changes in the system.

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -146,12 +146,12 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
 
     /// A boolean value indicating if it should send typing events.
     /// It is `true` if the channel typing events are enabled as well as the user privacy settings.
-    internal var shouldSendTypingEvents: Bool {
-        /// Ignore if user typing indicators privacy settings are disabled. By default, they are enabled.
-        let currentUserPrivacySettings = client.sharedCurrentUserController.currentUser?.privacySettings
-        let isTypingIndicatorsForCurrentUserEnabled = currentUserPrivacySettings?.typingIndicators?.enabled ?? true
-        let isChannelTypingEventsEnabled = channel?.canSendTypingEvents ?? true
-        return isTypingIndicatorsForCurrentUserEnabled && isChannelTypingEventsEnabled
+    func shouldSendTypingEvents(completion: @escaping (Bool) -> Void) {
+        guard channel?.canSendTypingEvents ?? true else {
+            completion(false)
+            return
+        }
+        eventSender.currentUserTypingEventsState(completion: completion)
     }
 
     /// Set the delegate of `ChannelController` to observe the changes in the system.
@@ -611,23 +611,19 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
     public func sendKeystrokeEvent(parentMessageId: MessageId? = nil, completion: ((Error?) -> Void)? = nil) {
-        /// Ignore if app-level typing events or user-level typing events are not enabled.
-        guard shouldSendTypingEvents else {
-            callback {
-                completion?(nil)
-            }
-            return
-        }
-
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed { completion?($0) }
             return
         }
-
-        eventSender.keystroke(in: cid, parentMessageId: parentMessageId) { error in
-            self.callback {
-                completion?(error)
+        /// Ignore if app-level typing events or user-level typing events are not enabled.
+        shouldSendTypingEvents { isEnabled in
+            guard isEnabled else {
+                self.callback { completion?(nil) }
+                return
+            }
+            self.eventSender.keystroke(in: cid, parentMessageId: parentMessageId) { error in
+                self.callback { completion?(error) }
             }
         }
     }
@@ -641,21 +637,19 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
     public func sendStartTypingEvent(parentMessageId: MessageId? = nil, completion: ((Error?) -> Void)? = nil) {
-        /// Ignore if app-level typing events or user-level typing events are not enabled.
-        guard shouldSendTypingEvents else {
-            channelFeatureDisabled(feature: "typing events", completion: completion)
-            return
-        }
-
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed { completion?($0) }
             return
         }
-
-        eventSender.startTyping(in: cid, parentMessageId: parentMessageId) { error in
-            self.callback {
-                completion?(error)
+        
+        shouldSendTypingEvents { isEnabled in
+            guard isEnabled else {
+                self.channelFeatureDisabled(feature: "typing events", completion: completion)
+                return
+            }
+            self.eventSender.startTyping(in: cid, parentMessageId: parentMessageId) { error in
+                self.callback { completion?(error) }
             }
         }
     }
@@ -669,21 +663,18 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
     public func sendStopTypingEvent(parentMessageId: MessageId? = nil, completion: ((Error?) -> Void)? = nil) {
-        /// Ignore if app-level typing events or user-level typing events are not enabled.
-        guard shouldSendTypingEvents else {
-            channelFeatureDisabled(feature: "typing events", completion: completion)
-            return
-        }
-
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed { completion?($0) }
             return
         }
-
-        eventSender.stopTyping(in: cid, parentMessageId: parentMessageId) { error in
-            self.callback {
-                completion?(error)
+        shouldSendTypingEvents { isEnabled in
+            guard isEnabled else {
+                self.channelFeatureDisabled(feature: "typing events", completion: completion)
+                return
+            }
+            self.eventSender.stopTyping(in: cid, parentMessageId: parentMessageId) { error in
+                self.callback { completion?(error) }
             }
         }
     }

--- a/Sources/StreamChat/Workers/TypingEventsSender.swift
+++ b/Sources/StreamChat/Workers/TypingEventsSender.swift
@@ -39,19 +39,6 @@ class TypingEventsSender: Worker {
         guard currentUserLastTypingDate != nil else { return }
         self.stopTyping(in: typingInfo.channelId, parentMessageId: typingInfo.parentMessageId)
     }
-    
-    func currentUserTypingEventsState(completion: @escaping (Bool) -> Void) {
-        database.read { session in
-            session.currentUser?.isTypingIndicatorsEnabled ?? true
-        } completion: { result in
-            switch result {
-            case .success(let isEnabled):
-                completion(isEnabled)
-            case .failure:
-                completion(false)
-            }
-        }
-    }
 
     // MARK: Typing events
 

--- a/Sources/StreamChat/Workers/TypingEventsSender.swift
+++ b/Sources/StreamChat/Workers/TypingEventsSender.swift
@@ -39,6 +39,19 @@ class TypingEventsSender: Worker {
         guard currentUserLastTypingDate != nil else { return }
         self.stopTyping(in: typingInfo.channelId, parentMessageId: typingInfo.parentMessageId)
     }
+    
+    func currentUserTypingEventsState(completion: @escaping (Bool) -> Void) {
+        database.read { session in
+            session.currentUser?.isTypingIndicatorsEnabled ?? true
+        } completion: { result in
+            switch result {
+            case .success(let isEnabled):
+                completion(isEnabled)
+            case .failure:
+                completion(false)
+            }
+        }
+    }
 
     // MARK: Typing events
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -99,8 +99,6 @@ final class ChatClient_Mock: ChatClient {
     // MARK: - Clean Up
 
     func cleanUp() {
-        resetSharedCurrentUserController()
-        
         (apiClient as? APIClient_Spy)?.cleanUp()
 
         fetchCurrentUserIdFromDatabase_called = false

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/TypingEventsSender_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/TypingEventsSender_Mock.swift
@@ -4,38 +4,38 @@
 
 import Foundation
 @testable import StreamChat
+import XCTest
 
 /// Mock implementation of ChannelUpdater
 final class TypingEventsSender_Mock: TypingEventsSender {
     @Atomic var keystroke_cid: ChannelId?
     @Atomic var keystroke_parentMessageId: MessageId?
     @Atomic var keystroke_completion: ((Error?) -> Void)?
+    @Atomic var keystroke_completion_expectation = XCTestExpectation()
 
     @Atomic var startTyping_cid: ChannelId?
     @Atomic var startTyping_parentMessageId: MessageId?
     @Atomic var startTyping_completion: ((Error?) -> Void)?
+    @Atomic var startTyping_completion_expectation = XCTestExpectation()
 
     @Atomic var stopTyping_cid: ChannelId?
     @Atomic var stopTyping_parentMessageId: MessageId?
     @Atomic var stopTyping_completion: ((Error?) -> Void)?
     @Atomic var stopTyping_completion_result: Result<Void, Error>?
-    
-    @Atomic var currentUserTypingEventsState_completion: ((Bool) -> Void)?
-
-    override func currentUserTypingEventsState(completion: @escaping (Bool) -> Void) {
-        currentUserTypingEventsState_completion = completion
-    }
-    
+    @Atomic var stopTyping_completion_expectation = XCTestExpectation()
+        
     override func keystroke(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
         keystroke_cid = cid
         keystroke_parentMessageId = parentMessageId
         keystroke_completion = completion
+        keystroke_completion_expectation.fulfill()
     }
 
     override func startTyping(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
         startTyping_cid = cid
         startTyping_parentMessageId = parentMessageId
         startTyping_completion = completion
+        startTyping_completion_expectation.fulfill()
     }
 
     override func stopTyping(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
@@ -43,20 +43,24 @@ final class TypingEventsSender_Mock: TypingEventsSender {
         stopTyping_parentMessageId = parentMessageId
         stopTyping_completion = completion
         stopTyping_completion_result?.invoke(with: completion)
+        stopTyping_completion_expectation.fulfill()
     }
 
     func cleanUp() {
         keystroke_cid = nil
         keystroke_parentMessageId = nil
         keystroke_completion = nil
+        keystroke_completion_expectation = XCTestExpectation()
 
         startTyping_cid = nil
         startTyping_parentMessageId = nil
         startTyping_completion = nil
+        startTyping_completion_expectation = XCTestExpectation()
 
         stopTyping_cid = nil
         stopTyping_parentMessageId = nil
         stopTyping_completion = nil
         stopTyping_completion_result = nil
+        stopTyping_completion_expectation = XCTestExpectation()
     }
 }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/TypingEventsSender_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/TypingEventsSender_Mock.swift
@@ -19,7 +19,13 @@ final class TypingEventsSender_Mock: TypingEventsSender {
     @Atomic var stopTyping_parentMessageId: MessageId?
     @Atomic var stopTyping_completion: ((Error?) -> Void)?
     @Atomic var stopTyping_completion_result: Result<Void, Error>?
+    
+    @Atomic var currentUserTypingEventsState_completion: ((Bool) -> Void)?
 
+    override func currentUserTypingEventsState(completion: @escaping (Bool) -> Void) {
+        currentUserTypingEventsState_completion = completion
+    }
+    
     override func keystroke(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
         keystroke_cid = cid
         keystroke_parentMessageId = parentMessageId

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -835,43 +835,6 @@ final class ChatClient_Tests: XCTestCase {
 
         XCTAssertEqual(streamHeader, SystemEnvironment.xStreamClientHeader)
     }
-    
-    // MARK: - User Session
-    
-    func test_sharedCurrentUserController() {
-        let client = ChatClient_Mock.mock()
-        let controller1 = client.sharedCurrentUserController
-        let controller2 = client.sharedCurrentUserController
-        XCTAssertTrue(controller1 === controller2, "Shared instance should be returned")
-    }
-    
-    func test_sharedCurrentUserController_whenConnectAndLogout_thenNewInstance() throws {
-        let client = ChatClient_Mock(config: inMemoryStorageConfig, environment: testEnv.environment)
-        let userInfo = UserInfo(id: "id1")
-        // Connect
-        let expectation = XCTestExpectation(description: "Connect")
-        client.mockAuthenticationRepository.connectUserResult = .success(())
-        try client.mockDatabaseContainer.createCurrentUser(id: userInfo.id)
-        client.connectUser(userInfo: userInfo, token: .unique()) { error in
-            guard error == nil else { return }
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: defaultTimeout)
-        let controller1 = client.sharedCurrentUserController
-        let controller2 = client.sharedCurrentUserController
-        XCTAssertTrue(controller1 === controller2, "Shared instance should be returned")
-        
-        // Logout
-        let expectation2 = XCTestExpectation(description: "Logout")
-        let connectionRepositoryMock = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
-        connectionRepositoryMock.disconnectResult = .success(())
-        client.logout {
-            expectation2.fulfill()
-        }
-        wait(for: [expectation2], timeout: defaultTimeout)
-        let controller3 = client.sharedCurrentUserController
-        XCTAssertFalse(controller1 === controller3, "New instance should be returned")
-    }
 }
 
 final class TestWorker: Worker {

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -3032,6 +3032,9 @@ final class ChannelController_Tests: XCTestCase {
         // (Try to) deallocate the controller
         // by not keeping any references to it
         controller = nil
+        
+        // Continue the request
+        env.eventSender!.currentUserTypingEventsState_completion?(true)
 
         // Check keystroke cid and parentMessageId.
         XCTAssertEqual(env.eventSender!.keystroke_cid, channelId)
@@ -3041,6 +3044,7 @@ final class ChannelController_Tests: XCTestCase {
         let testError = TestError()
         env.eventSender!.keystroke_completion!(testError)
         // Release reference of completion so we can deallocate stuff
+        env.eventSender!.currentUserTypingEventsState_completion = nil
         env.eventSender!.keystroke_completion = nil
 
         // Completion should be called with the error
@@ -3104,6 +3108,9 @@ final class ChannelController_Tests: XCTestCase {
         // by not keeping any references to it
         controller = nil
 
+        // Continue the request
+        env.eventSender!.currentUserTypingEventsState_completion?(true)
+        
         // Check `startTyping` cid and parentMessageId.
         XCTAssertEqual(env.eventSender!.startTyping_cid, channelId)
         XCTAssertEqual(env.eventSender!.startTyping_parentMessageId, parentMessageId)
@@ -3112,6 +3119,7 @@ final class ChannelController_Tests: XCTestCase {
         let testError = TestError()
         env.eventSender!.startTyping_completion!(testError)
         // Release reference of completion so we can deallocate stuff
+        env.eventSender!.currentUserTypingEventsState_completion = nil
         env.eventSender!.startTyping_completion = nil
 
         // Completion should be called with the error
@@ -3174,6 +3182,9 @@ final class ChannelController_Tests: XCTestCase {
         // (Try to) deallocate the controller
         // by not keeping any references to it
         controller = nil
+        
+        // Continue the request
+        env.eventSender!.currentUserTypingEventsState_completion?(true)
 
         // Check `stopTyping` cid and parentMessageId.
         XCTAssertEqual(env.eventSender!.stopTyping_cid, channelId)
@@ -3183,6 +3194,7 @@ final class ChannelController_Tests: XCTestCase {
         let testError = TestError()
         env.eventSender!.stopTyping_completion!(testError)
         // Release reference of completion so we can deallocate stuff
+        env.eventSender!.currentUserTypingEventsState_completion = nil
         env.eventSender!.stopTyping_completion = nil
 
         // Completion should be called with the error
@@ -5180,7 +5192,8 @@ final class ChannelController_Tests: XCTestCase {
             try $0.saveCurrentUser(payload: .dummy(userId: userId, privacySettings: nil))
         }
 
-        XCTAssertEqual(controller.shouldSendTypingEvents, true)
+        let isEnabled = try waitFor { controller.shouldSendTypingEvents(completion: $0) }
+        XCTAssertEqual(isEnabled, true)
     }
 
     func test_shouldSendTypingEvents_whenChannelEnabled_whenUserEnabled() throws {
@@ -5200,7 +5213,8 @@ final class ChannelController_Tests: XCTestCase {
             )))
         }
 
-        XCTAssertEqual(controller.shouldSendTypingEvents, true)
+        let isEnabled = try waitFor { controller.shouldSendTypingEvents(completion: $0) }
+        XCTAssertEqual(isEnabled, true)
     }
 
     func test_shouldSendTypingEvents_whenChannelDisabled_whenUserEnabled() throws {
@@ -5219,7 +5233,9 @@ final class ChannelController_Tests: XCTestCase {
                 cid: self.channelId, ownCapabilities: []
             )))
         }
-        XCTAssertEqual(controller.shouldSendTypingEvents, false)
+        
+        let isEnabled = try waitFor { controller.shouldSendTypingEvents(completion: $0) }
+        XCTAssertEqual(isEnabled, false)
     }
 
     func test_shouldSendTypingEvents_whenChannelEnabled_whenUserDisabled() throws {
@@ -5239,7 +5255,8 @@ final class ChannelController_Tests: XCTestCase {
             )))
         }
 
-        XCTAssertEqual(controller.shouldSendTypingEvents, false)
+        let isEnabled = try waitFor { controller.shouldSendTypingEvents(completion: $0) }
+        XCTAssertEqual(isEnabled, false)
     }
 
     func test_shouldSendTypingEvents_whenChannelDisabled_whenUserDisabled() throws {
@@ -5259,7 +5276,8 @@ final class ChannelController_Tests: XCTestCase {
             )))
         }
 
-        XCTAssertEqual(controller.shouldSendTypingEvents, false)
+        let isEnabled = try waitFor { controller.shouldSendTypingEvents(completion: $0) }
+        XCTAssertEqual(isEnabled, false)
     }
 
     // MARK: deinit

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -3034,7 +3034,7 @@ final class ChannelController_Tests: XCTestCase {
         controller = nil
 
         // Check keystroke cid and parentMessageId.
-        wait(for: [env.eventSender!.keystroke_completion_expectation])
+        wait(for: [env.eventSender!.keystroke_completion_expectation], timeout: defaultTimeout)
         XCTAssertEqual(env.eventSender!.keystroke_cid, channelId)
         XCTAssertEqual(env.eventSender!.keystroke_parentMessageId, parentMessageId)
 
@@ -3106,7 +3106,7 @@ final class ChannelController_Tests: XCTestCase {
         controller = nil
         
         // Check `startTyping` cid and parentMessageId.
-        wait(for: [env.eventSender!.startTyping_completion_expectation])
+        wait(for: [env.eventSender!.startTyping_completion_expectation], timeout: defaultTimeout)
         XCTAssertEqual(env.eventSender!.startTyping_cid, channelId)
         XCTAssertEqual(env.eventSender!.startTyping_parentMessageId, parentMessageId)
 
@@ -3178,7 +3178,7 @@ final class ChannelController_Tests: XCTestCase {
         controller = nil
 
         // Check `stopTyping` cid and parentMessageId.
-        wait(for: [env.eventSender!.stopTyping_completion_expectation])
+        wait(for: [env.eventSender!.stopTyping_completion_expectation], timeout: defaultTimeout)
         XCTAssertEqual(env.eventSender!.stopTyping_cid, channelId)
         XCTAssertEqual(env.eventSender!.stopTyping_parentMessageId, parentMessageId)
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -3032,11 +3032,9 @@ final class ChannelController_Tests: XCTestCase {
         // (Try to) deallocate the controller
         // by not keeping any references to it
         controller = nil
-        
-        // Continue the request
-        env.eventSender!.currentUserTypingEventsState_completion?(true)
 
         // Check keystroke cid and parentMessageId.
+        wait(for: [env.eventSender!.keystroke_completion_expectation])
         XCTAssertEqual(env.eventSender!.keystroke_cid, channelId)
         XCTAssertEqual(env.eventSender!.keystroke_parentMessageId, parentMessageId)
 
@@ -3044,7 +3042,6 @@ final class ChannelController_Tests: XCTestCase {
         let testError = TestError()
         env.eventSender!.keystroke_completion!(testError)
         // Release reference of completion so we can deallocate stuff
-        env.eventSender!.currentUserTypingEventsState_completion = nil
         env.eventSender!.keystroke_completion = nil
 
         // Completion should be called with the error
@@ -3107,11 +3104,9 @@ final class ChannelController_Tests: XCTestCase {
         // (Try to) deallocate the controller
         // by not keeping any references to it
         controller = nil
-
-        // Continue the request
-        env.eventSender!.currentUserTypingEventsState_completion?(true)
         
         // Check `startTyping` cid and parentMessageId.
+        wait(for: [env.eventSender!.startTyping_completion_expectation])
         XCTAssertEqual(env.eventSender!.startTyping_cid, channelId)
         XCTAssertEqual(env.eventSender!.startTyping_parentMessageId, parentMessageId)
 
@@ -3119,7 +3114,6 @@ final class ChannelController_Tests: XCTestCase {
         let testError = TestError()
         env.eventSender!.startTyping_completion!(testError)
         // Release reference of completion so we can deallocate stuff
-        env.eventSender!.currentUserTypingEventsState_completion = nil
         env.eventSender!.startTyping_completion = nil
 
         // Completion should be called with the error
@@ -3182,11 +3176,9 @@ final class ChannelController_Tests: XCTestCase {
         // (Try to) deallocate the controller
         // by not keeping any references to it
         controller = nil
-        
-        // Continue the request
-        env.eventSender!.currentUserTypingEventsState_completion?(true)
 
         // Check `stopTyping` cid and parentMessageId.
+        wait(for: [env.eventSender!.stopTyping_completion_expectation])
         XCTAssertEqual(env.eventSender!.stopTyping_cid, channelId)
         XCTAssertEqual(env.eventSender!.stopTyping_parentMessageId, parentMessageId)
 
@@ -3194,7 +3186,6 @@ final class ChannelController_Tests: XCTestCase {
         let testError = TestError()
         env.eventSender!.stopTyping_completion!(testError)
         // Release reference of completion so we can deallocate stuff
-        env.eventSender!.currentUserTypingEventsState_completion = nil
         env.eventSender!.stopTyping_completion = nil
 
         // Completion should be called with the error


### PR DESCRIPTION
### 🔗 Issue Links

Part of [IOS-558](https://linear.app/stream/issue/IOS-558)

### 🎯 Goal

Remove current user controller since it takes unnecessary CPU time when reacting to DB changes

### 📝 Summary

- Replace internal current user controller with just reading the data directly

### 🛠 Implementation

We had a perf issue some time ago where we used to create the `ChatCurrentUserController` every single time when checking for typing state (on each key press). Then we started to use a shared instance for that. Solved the issue, but there is one downside, reacting to current user changes can get expensive (e.g. current user has many muted channels which triggers recreating channel objects when updating the immutable `CurrentChatUser` type). Instead all of this, we should just read the data we need and skip controllers.

### 🧪 Manual Testing Notes

Try typing events, if disabled, should not appear, otherwise appear.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)