### PR TITLE
Fix sometimes failing test_loadPreviousReplies_whenMessagesAreEmpty_callDelegateWithEmptyChanges

### DIFF
--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -404,7 +404,7 @@ final class MessageController_Tests: XCTestCase {
 
         // Set top-to-bottom ordering
         controller.listOrdering = .topToBottom
-        try waitForRepliesChange(count: 2, requireDelegateChange: true)
+        try waitForRepliesChange(count: 2)
         
         // Check the order of replies is correct
         let topToBottomIds = [reply1, reply2].sorted { $0.createdAt > $1.createdAt }.map(\.id)
@@ -412,7 +412,7 @@ final class MessageController_Tests: XCTestCase {
 
         // Set bottom-to-top ordering
         controller.listOrdering = .bottomToTop
-        try waitForRepliesChange(count: 2, requireDelegateChange: true)
+        try waitForRepliesChange(count: 2)
 
         // Check the order of replies is correct
         let bottomToTopIds = [reply1, reply2].sorted { $0.createdAt < $1.createdAt }.map(\.id)
@@ -2486,9 +2486,8 @@ final class MessageController_Tests: XCTestCase {
     
     // MARK: -
     
-    func waitForRepliesChange(count: Int, requireDelegateChange: Bool = false) throws {
+    func waitForRepliesChange(count: Int) throws {
         let delegate = try XCTUnwrap(controller.delegate as? TestDelegate)
-        guard requireDelegateChange || count != controller.replies.count else { return }
         let expectation = XCTestExpectation(description: "RepliesChange")
         delegate.didChangeRepliesExpectation = expectation
         delegate.didChangeRepliesExpectedCount = count


### PR DESCRIPTION
### 🎯 Goal

Fix unstable test: test_loadPreviousReplies_whenMessagesAreEmpty_callDelegateWithEmptyChanges

### 🛠 Implementation

Unstable because it is checking delegate call counts, but did not properly wait for the initial background observer callback. This caused a race between initial fetch and the second load replies call. Failure was reproducible when running the unit-test locally with the repeat option.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
