### PR TITLE
Convert to models after NSFetchedResultsController finishes reporting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix a rare infinite loop triggering a crash when handling database changes [#3508](https://github.com/GetStream/stream-chat-swift/pull/3508)
 
 # [4.67.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.67.0)
 _November 25, 2024_


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-569](https://linear.app/stream/issue/IOS-569)

### 🎯 Goal

Fix a crash caused by infinite loop in Core Data when converting models

### 📝 Summary

- Delay converting models to the point of time when `NSFetchedRequestController` has finished reporting changes

### 🛠 Implementation

We had an internal crash report which showed that Core Data change came in, triggered `NSFetchedRequestController` delegate, then we converted the DTO to a model type, but since the model type did another fetch request, this triggered the whole cycle again. Therefore, let's avoid it by delaying the model conversion to the point of time where `NSFetchedRequestController` has finished reporting changes.

### 🧪 Manual Testing Notes

Retrying the flow in IOS-569 which triggered it.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)