### PR TITLE
Fix reconnection timeout handler not working in the token provider phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix a rare infinite loop triggering a crash when handling database changes [#3508](https://github.com/GetStream/stream-chat-swift/pull/3508)
+- Fix reconnection timeout handler not working in the token provider phase [#3513](https://github.com/GetStream/stream-chat-swift/pull/3513)
 
 # [4.67.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.67.0)
 _November 25, 2024_

--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -47,6 +47,11 @@ extension ChatClient {
             )
         }
 
+        var reconnectionHandlerBuilder: (_ chatClientConfig: ChatClientConfig) -> StreamTimer? = {
+            guard let reconnectionTimeout = $0.reconnectionTimeout else { return nil }
+            return ScheduledStreamTimer(interval: reconnectionTimeout, fireOnStart: false, repeats: false)
+        }
+
         var extensionLifecycleBuilder = NotificationExtensionLifecycle.init
 
         var requestEncoderBuilder: (_ baseURL: URL, _ apiKey: APIKey) -> RequestEncoder = DefaultRequestEncoder.init
@@ -97,8 +102,7 @@ extension ChatClient {
             _ extensionLifecycle: NotificationExtensionLifecycle,
             _ backgroundTaskScheduler: BackgroundTaskScheduler?,
             _ internetConnection: InternetConnection,
-            _ keepConnectionAliveInBackground: Bool,
-            _ reconnectionTimeoutHandler: StreamTimer?
+            _ keepConnectionAliveInBackground: Bool
         ) -> ConnectionRecoveryHandler = {
             DefaultConnectionRecoveryHandler(
                 webSocketClient: $0,
@@ -109,8 +113,7 @@ extension ChatClient {
                 internetConnection: $5,
                 reconnectionStrategy: DefaultRetryStrategy(),
                 reconnectionTimerType: DefaultTimer.self,
-                keepConnectionAliveInBackground: $6,
-                reconnectionTimeoutHandler: $7
+                keepConnectionAliveInBackground: $6
             )
         }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -637,7 +637,6 @@ public class ChatClient {
         authenticationRepository.completeTokenCompletions(error: ClientError.ReconnectionTimeout())
         completeTokenWaiters(token: nil)
         authenticationRepository.reset()
-        connectionRecoveryHandler?.stop()
         let webSocketConnectionState = webSocketClient?.connectionState ?? .initialized
         connectionRepository.disconnect(source: .timeout(from: webSocketConnectionState)) {}
     }

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -196,9 +196,12 @@ class AuthenticationRepository {
         isGettingToken = false
     }
 
-    func cancelTimers() {
+    func reset() {
         connectionProviderTimer?.cancel()
         tokenProviderTimer?.cancel()
+        tokenQueue.async(flags: .barrier) {
+            self._tokenExpirationRetryStrategy.resetConsecutiveFailures()
+        }
     }
 
     func logOutUser() {
@@ -280,6 +283,19 @@ class AuthenticationRepository {
         updateToken(token: token, notifyTokenWaiters: true)
     }
 
+    func completeTokenCompletions(error: Error?) {
+        let completionBlocks: [(Error?) -> Void]? = tokenQueue.sync(flags: .barrier) {
+            self._isGettingToken = false
+            let completions = self._tokenRequestCompletions
+            return completions
+        }
+        completionBlocks?.forEach { $0(error) }
+        tokenQueue.async(flags: .barrier) {
+            self._tokenRequestCompletions = []
+            self._consecutiveRefreshFailures = 0
+        }
+    }
+
     private func updateToken(token: Token?, notifyTokenWaiters: Bool) {
         let waiters: [String: (Result<Token, Error>) -> Void] = tokenQueue.sync(flags: .barrier) {
             _currentToken = token
@@ -338,14 +354,7 @@ class AuthenticationRepository {
                 log.debug("Successfully retrieved token", subsystems: .authentication)
             }
 
-            let completionBlocks: [(Error?) -> Void]? = self.tokenQueue.sync(flags: .barrier) {
-                self._isGettingToken = false
-                let completions = self._tokenRequestCompletions
-                self._tokenRequestCompletions = []
-                self._consecutiveRefreshFailures = 0
-                return completions
-            }
-            completionBlocks?.forEach { $0(error) }
+            completeTokenCompletions(error: error)
         }
 
         guard consecutiveRefreshFailures < Constants.maximumTokenRefreshAttempts else {

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -347,14 +347,12 @@ class AuthenticationRepository {
         isGettingToken = true
 
         let onCompletion: (Error?) -> Void = { [weak self] error in
-            guard let self = self else { return }
             if let error = error {
                 log.error("Error when getting token: \(error)", subsystems: .authentication)
             } else {
                 log.debug("Successfully retrieved token", subsystems: .authentication)
             }
-
-            completeTokenCompletions(error: error)
+            self?.completeTokenCompletions(error: error)
         }
 
         guard consecutiveRefreshFailures < Constants.maximumTokenRefreshAttempts else {

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -42,6 +42,10 @@ class ConnectionRepository {
         self.timerType = timerType
     }
 
+    func initialize() {
+        webSocketClient?.initialize()
+    }
+
     /// Connects the chat client the controller represents to the chat servers.
     ///
     /// When the connection is established, `ChatClient` starts receiving chat updates, and `currentUser` variable is available.

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -99,14 +99,6 @@ class ConnectionRepository {
             return
         }
 
-        if connectionId == nil {
-            if source == .userInitiated {
-                log.warning("The client is already disconnected. Skipping the `disconnect` call.")
-            }
-            completion()
-            return
-        }
-
         // Disconnect the web socket
         webSocketClient?.disconnect(source: source) { [weak self] in
             // Reset `connectionId`. This would happen asynchronously by the callback from WebSocketClient anyway, but it's

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -77,7 +77,7 @@ enum WebSocketConnectionState: Equatable {
         }
     }
 
-    /// The initial state meaning that  there was no atempt to connect yet.
+    /// The initial state meaning that the web socket engine is not yet connected or connecting.
     case initialized
 
     /// The web socket is not connected. Contains the source/reason why the disconnection has happened.

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -100,6 +100,10 @@ class WebSocketClient {
         self.eventNotificationCenter = eventNotificationCenter
     }
 
+    func initialize() {
+        connectionState = .initialized
+    }
+
     /// Connects the web connect.
     ///
     /// Calling this method has no effect is the web socket is already connected, or is in the connecting phase.
@@ -137,23 +141,18 @@ class WebSocketClient {
         source: WebSocketConnectionState.DisconnectionSource = .userInitiated,
         completion: @escaping () -> Void
     ) {
-        connectionState = .disconnecting(source: source)
+        switch connectionState {
+        case .initialized, .disconnected, .disconnecting:
+            connectionState = .disconnected(source: source)
+        case .connecting, .waitingForConnectionId, .connected:
+            connectionState = .disconnecting(source: source)
+        }
+        
         engineQueue.async { [engine, eventsBatcher] in
             engine?.disconnect()
 
             eventsBatcher.processImmediately(completion: completion)
         }
-    }
-
-    func timeout() {
-        let previousState = connectionState
-        connectionState = .disconnected(source: .timeout(from: previousState))
-        engineQueue.async { [engine, eventsBatcher] in
-            engine?.disconnect()
-
-            eventsBatcher.processImmediately {}
-        }
-        log.error("Connection timed out. `\(connectionState)", subsystems: .webSocket)
     }
 }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
@@ -8,6 +8,7 @@ import Foundation
 /// Mock implementation of `ChatClientUpdater`
 final class ConnectionRepository_Mock: ConnectionRepository, Spy {
     enum Signature {
+        static let initialize = "initialize()"
         static let connect = "connect(completion:)"
         static let disconnect = "disconnect(source:completion:)"
         static let forceConnectionInactiveMode = "forceConnectionStatusForInactiveModeIfNeeded()"
@@ -57,6 +58,10 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
     }
 
     // MARK: - Overrides
+
+    override func initialize() {
+        record()
+    }
 
     override func connect(completion: ((Error?) -> Void)? = nil) {
         record()

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
@@ -14,6 +14,7 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
         static let clearTokenProvider = "clearTokenProvider()"
         static let logOut = "logOutUser()"
         static let completeTokenWaiters = "completeTokenWaiters(token:)"
+        static let completeTokenCompletions = "completeTokenCompletions(error:)"
         static let setToken = "setToken(token:completeTokenWaiters:)"
         static let provideToken = "provideToken(timeout:completion:)"
     }
@@ -102,6 +103,10 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
     override func completeTokenWaiters(token: Token?) {
         record()
         completeWaitersToken = token
+    }
+
+    override func completeTokenCompletions(error: (any Error)?) {
+        record()
     }
 
     override func provideToken(timeout: TimeInterval = 10, completion: @escaping (Result<Token, Error>) -> Void) {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
@@ -94,9 +94,9 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
         record()
     }
 
-    var cancelTimersCallCount: Int = 0
-    override func cancelTimers() {
-        cancelTimersCallCount += 1
+    var resetCallCount: Int = 0
+    override func reset() {
+        resetCallCount += 1
     }
 
     override func completeTokenWaiters(token: Token?) {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
@@ -21,8 +21,6 @@ final class WebSocketClient_Mock: WebSocketClient {
     var disconnect_called: Bool { disconnect_calledCounter > 0 }
     var disconnect_completion: (() -> Void)?
 
-    var timeout_callCount = 0
-
 
     var mockedConnectionState: WebSocketConnectionState?
 
@@ -76,10 +74,6 @@ final class WebSocketClient_Mock: WebSocketClient {
         disconnect_calledCounter += 1
         disconnect_source = source
         disconnect_completion = completion
-    }
-
-    override func timeout() {
-        timeout_callCount += 1
     }
 
     var mockEventsBatcher: EventBatcher_Mock {

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -665,7 +665,7 @@ final class ChatClient_Tests: XCTestCase {
 
         XCTAssertCall(ConnectionRepository_Mock.Signature.disconnect, on: connectionRepository)
         XCTAssertCall(AuthenticationRepository_Mock.Signature.clearTokenProvider, on: authenticationRepository)
-        XCTAssertEqual(client.mockAuthenticationRepository.cancelTimersCallCount, 1)
+        XCTAssertEqual(client.mockAuthenticationRepository.resetCallCount, 1)
     }
 
     func test_logout_shouldDisconnect_logOut_andRemoveAllData() throws {

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -462,6 +462,9 @@ final class ChatClient_Tests: XCTestCase {
         let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
         let userInfo = UserInfo(id: "id")
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
+        let reconnectionTimeoutHandler = try XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        let connectionRecoveryHandler = try XCTUnwrap(client.connectionRecoveryHandler as? ConnectionRecoveryHandler_Mock)
+        let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
         let expectation = self.expectation(description: "Connect completes")
 
         authenticationRepository.connectUserResult = .success(())
@@ -472,8 +475,11 @@ final class ChatClient_Tests: XCTestCase {
         }
         waitForExpectations(timeout: defaultTimeout)
 
-        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectTokenProvider, on: authenticationRepository)
         XCTAssertNil(receivedError)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectTokenProvider, on: authenticationRepository)
+        XCTAssertCall(ConnectionRepository_Mock.Signature.initialize, on: connectionRepository)
+        XCTAssertEqual(reconnectionTimeoutHandler.startCallCount, 1)
+        XCTAssertEqual(connectionRecoveryHandler.startCallCount, 1)
     }
 
     // MARK: - Connect Static Token
@@ -598,6 +604,9 @@ final class ChatClient_Tests: XCTestCase {
         let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
         let userInfo = UserInfo(id: "id")
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
+        let reconnectionTimeoutHandler = try XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        let connectionRecoveryHandler = try XCTUnwrap(client.connectionRecoveryHandler as? ConnectionRecoveryHandler_Mock)
+        let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
         let expectation = self.expectation(description: "Connect completes")
 
         authenticationRepository.connectGuestResult = .success(())
@@ -608,8 +617,11 @@ final class ChatClient_Tests: XCTestCase {
         }
         waitForExpectations(timeout: defaultTimeout)
 
-        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectGuest, on: authenticationRepository)
         XCTAssertNil(receivedError)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectGuest, on: authenticationRepository)
+        XCTAssertCall(ConnectionRepository_Mock.Signature.initialize, on: connectionRepository)
+        XCTAssertEqual(reconnectionTimeoutHandler.startCallCount, 1)
+        XCTAssertEqual(connectionRecoveryHandler.startCallCount, 1)
     }
 
     // MARK: - Connect Anonymous
@@ -635,6 +647,9 @@ final class ChatClient_Tests: XCTestCase {
     func test_connectAnonymous_tokenProvider_callsAuthenticationRepository_success() throws {
         let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
+        let reconnectionTimeoutHandler = try XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        let connectionRecoveryHandler = try XCTUnwrap(client.connectionRecoveryHandler as? ConnectionRecoveryHandler_Mock)
+        let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
         let expectation = self.expectation(description: "Connect completes")
 
         authenticationRepository.connectAnonResult = .success(())
@@ -645,8 +660,11 @@ final class ChatClient_Tests: XCTestCase {
         }
         waitForExpectations(timeout: defaultTimeout)
 
-        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectAnon, on: authenticationRepository)
         XCTAssertNil(receivedError)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectAnon, on: authenticationRepository)
+        XCTAssertCall(ConnectionRepository_Mock.Signature.initialize, on: connectionRepository)
+        XCTAssertEqual(reconnectionTimeoutHandler.startCallCount, 1)
+        XCTAssertEqual(connectionRecoveryHandler.startCallCount, 1)
     }
 
     // MARK: - Disconnect
@@ -835,6 +853,97 @@ final class ChatClient_Tests: XCTestCase {
 
         XCTAssertEqual(streamHeader, SystemEnvironment.xStreamClientHeader)
     }
+
+    // MARK: - Reconnection Timeout Tests
+
+    func test_reconnectionTimeoutHandler_isInitializedWithConfig() {
+        // Given
+        var config = inMemoryStorageConfig
+        config.reconnectionTimeout = 20
+        let client = ChatClient(config: config)
+
+        // Then
+        XCTAssertNotNil(client.reconnectionTimeoutHandler)
+    }
+
+    func test_reconnectionTimeoutHandler_notInitialisedIfTimeoutNotProvided() {
+        // Given
+        var config = inMemoryStorageConfig
+        config.reconnectionTimeout = nil
+        let client = ChatClient(config: config)
+
+        // Then
+        XCTAssertNil(client.reconnectionTimeoutHandler)
+    }
+
+    func test_reconnectionTimeoutHandler_startsOnConnect() {
+        // Given
+        let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
+        let timerMock = try! XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        
+        // When
+        client.connectAnonymousUser()
+        
+        // Then
+        XCTAssertEqual(timerMock.startCallCount, 1)
+    }
+
+    func test_reconnectionTimeoutHandler_stopsOnConnected() {
+        // Given
+        let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
+        let timerMock = try! XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        
+        // When
+        client.webSocketClient(client.webSocketClient!, didUpdateConnectionState: .connected(connectionId: .unique))
+
+        // Then
+        XCTAssertEqual(timerMock.stopCallCount, 1)
+    }
+
+    func test_reconnectionTimeoutHandler_startsOnConnecting() {
+        // Given
+        let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
+        let timerMock = try! XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        timerMock.isRunning = false
+        
+        // When
+        client.webSocketClient(client.webSocketClient!, didUpdateConnectionState: .connecting)
+        
+        // Then
+        XCTAssertEqual(timerMock.startCallCount, 1)
+    }
+
+    func test_reconnectionTimeoutHandler_whenRunning_doesNotStart() {
+        let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
+        let timerMock = try! XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        timerMock.isRunning = true
+        
+        // When
+        client.webSocketClient(client.webSocketClient!, didUpdateConnectionState: .connecting)
+
+        // Then
+        XCTAssertEqual(timerMock.startCallCount, 0)
+    }
+
+    func test_reconnectionTimeout_onChange() throws {
+        // Given
+        let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
+        let timerMock = try XCTUnwrap(client.reconnectionTimeoutHandler as? ScheduledStreamTimer_Mock)
+        let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
+        let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
+        connectionRepository.disconnectResult = .success(())
+        
+        // When
+        timerMock.onChange?()
+        
+        // Then
+        XCTAssertCall(ConnectionRepository_Mock.Signature.disconnect, on: connectionRepository)
+        XCTAssertCall(ConnectionRepository_Mock.Signature.completeConnectionIdWaiters, on: connectionRepository)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.completeTokenWaiters, on: authenticationRepository)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.completeTokenCompletions, on: authenticationRepository)
+        XCTAssertEqual(connectionRepository.disconnectSource, .timeout(from: .initialized))
+        XCTAssertEqual(authenticationRepository.resetCallCount, 1)
+    }
 }
 
 final class TestWorker: Worker {
@@ -904,6 +1013,9 @@ private class TestEnvironment {
                 )
                 return self.databaseContainer!
             },
+            reconnectionHandlerBuilder: { _ in
+                ScheduledStreamTimer_Mock()
+            },
             requestEncoderBuilder: {
                 if let encoder = self.requestEncoder {
                     return encoder
@@ -940,6 +1052,9 @@ private class TestEnvironment {
                 return self.backgroundTaskScheduler!
             },
             timerType: VirtualTimeTimer.self,
+            connectionRecoveryHandlerBuilder: { _, _, _, _, _, _, _ in
+                ConnectionRecoveryHandler_Mock()
+            },
             authenticationRepositoryBuilder: {
                 self.authenticationRepository = AuthenticationRepository_Mock(
                     apiClient: $0,

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -1039,11 +1039,12 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(state, .newToken)
     }
 
-    // MARK: Cancel Timers
+    // MARK: Reset
 
-    func test_cancelTimers() {
+    func test_reset() {
         let mockTimer = MockTimer()
         FakeTimer.mockTimer = mockTimer
+        retryStrategy.consecutiveFailuresCount = 5
         let repository = AuthenticationRepository(
             apiClient: apiClient,
             databaseContainer: database,
@@ -1059,10 +1060,11 @@ final class AuthenticationRepository_Tests: XCTestCase {
             completion: { _ in }
         )
 
-        repository.cancelTimers()
+        repository.reset()
         // should cancel the connection provider timer and the
         // the token provider timer
         XCTAssertEqual(mockTimer.cancelCallCount, 2)
+        XCTAssertEqual(retryStrategy.consecutiveFailuresCount, 0)
     }
 
     // MARK: Helpers

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -1064,7 +1064,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         // should cancel the connection provider timer and the
         // the token provider timer
         XCTAssertEqual(mockTimer.cancelCallCount, 2)
-        XCTAssertEqual(retryStrategy.consecutiveFailuresCount, 0)
+        XCTAssertEqual(retryStrategy.mock_resetConsecutiveFailures.count, 1)
     }
 
     // MARK: Helpers

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -150,19 +150,6 @@ final class ConnectionRepository_Tests: XCTestCase {
 
     // MARK: Disconnect
 
-    func test_disconnect_noConnectionId_shouldReturnWithoutTryingToConnect() {
-        XCTAssertNil(repository.connectionId)
-
-        let expectation = self.expectation(description: "connect completes")
-        repository.disconnect(source: .userInitiated) { expectation.fulfill() }
-
-        waitForExpectations(timeout: defaultTimeout)
-
-        XCTAssertFalse(webSocketClient.disconnect_called)
-        XCTAssertCall(APIClient_Spy.Signature.flushRequestsQueue, on: apiClient)
-        XCTAssertCall(SyncRepository_Mock.Signature.cancelRecoveryFlow, on: syncRepository)
-    }
-
     func test_disconnect_withConnectionId_notInActiveMode_shouldReturnError() {
         repository.completeConnectionIdWaiters(connectionId: "123")
         XCTAssertNotNil(repository.connectionId)

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
@@ -238,7 +238,9 @@ final class WebSocketClient_Tests: XCTestCase {
         ]
 
         for source in testCases {
+            // reset state
             engine?.disconnect_calledCount = 0
+            webSocketClient.connect()
 
             // Call `disconnect` with the given source
             webSocketClient.disconnect(source: source) {}

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
@@ -259,6 +259,17 @@ final class WebSocketClient_Tests: XCTestCase {
         }
     }
 
+    func test_disconnect_whenInitialized_shouldDisconnect() {
+        // When in initialized state
+        XCTAssertEqual(webSocketClient.connectionState, .initialized)
+
+        // Call disconnect when not connected
+        webSocketClient.disconnect {}
+
+        // Assert connection state is updated
+        XCTAssertEqual(webSocketClient.connectionState, .disconnected(source: .userInitiated))
+    }
+
     func test_connectionState_afterDecodingError() {
         // Simulate connection
         test_connectionFlow()


### PR DESCRIPTION
### 🔗 Issue Links
Fixes https://linear.app/stream/issue/IOS-78

### 🎯 Goal

Fixes the reconnection timeout handler not working in the token provider phase.

### 🛠 Implementation

The main change is that the `reconnectionTimeoutHandler` was moved from the `ConnectionRecoveryHandler` to the `ChatClient` so that it can handle the token provider phase. For this to work, a couple of things required some changes. There are comments in the PR explaining each change.

Flow diagram to explain why we need to set the state to `.initialize` again whenever we call connect in `ChatClient`:

### Before
```mermaid
stateDiagram-v2
    [*] --> ChatClient.init
    ChatClient.init--> ChatClient.Connect
    ChatClient.Connect --> TokenProvider
    
    TokenProvider --> ReconnectionTimeout: Fails
    TokenProvider --> WebSocket.Connect: Success
    
     ReconnectionTimeout --> disconnected
     disconnected --> ChatClient.Connect
    
    note right of WebSocket.Connect
        State reported: .connecting
    end note
    
    note right of ChatClient.init
        State reported: .initialize
    end note
    
    note right of disconnected
        State reported: .disconnected
    end note
    
    note left of disconnected
        On the second cycle, the state is not reported
        Because it did not change from .disconnected
    end note
```

### After
```mermaid
stateDiagram-v2
    [*] --> ChatClient.init
    ChatClient.init--> ChatClient.Connect
    ChatClient.Connect --> TokenProvider
    
    TokenProvider --> ReconnectionTimeout: Fails
    TokenProvider --> WebSocket.Connect: Success
    
     ReconnectionTimeout --> disconnected
     disconnected --> ChatClient.Connect
    
    note right of WebSocket.Connect
        State reported: .connecting
    end note
    
    note right of ChatClient.Connect
        State reported: .initialize
    end note
    
    note right of disconnected
        State reported: .disconnected
    end note
```

### 🧪 Manual Testing Notes
1. Open the Demo App Configuration
2. Setup token refresh details and make it fail, for example, 20 times
3. Set a reconnection timeout of 15 seconds
4. Connect a user
5. Wait 15 seconds
6. Should automatically disconnect
7. Should not report anymore "Token refresh failed" in the console


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
