### PR TITLE
Fix Channel List search bar disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix a rare infinite loop triggering a crash when handling database changes [#3508](https://github.com/GetStream/stream-chat-swift/pull/3508)
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix Channel List search bar disappearing after it loses scrollability in rare scenarios [#3515](https://github.com/GetStream/stream-chat-swift/pull/3515)
+
 # [4.67.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.67.0)
 _November 25, 2024_
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -138,6 +138,7 @@ open class ChatChannelListVC: _ViewController,
             withReuseIdentifier: separatorReuseIdentifier
         )
 
+        collectionView.alwaysBounceVertical = true
         collectionView.dataSource = self
         collectionView.delegate = self
 


### PR DESCRIPTION
### 🔗 Issue Links

Fixes https://linear.app/stream/issue/IOS-582

### 🎯 Goal

Fix Channel List search bar disappearing in rare cases. If the number of items was about 10, the channel list would be scrollable initially with the Search Bar shown. After scrolling to the bottom, the search bar would disappear, losing the scrollability.

### 🛠 Implementation

The `alwaysBounceVertical` should be set to `true` so that the scrollability is never lost and the Search Bar reappears again. 

### 🧪 Manual Testing Notes

- Open the channel list with "General Grievous"
- It should have exactly 10 channels only in the Channel List
- Scroll to the bottom and up again
- Search bar should always be visible

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
