### PR TITLE
Fix unstable typing related tests in ChatChannelController_Tests

### DIFF
--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -2987,6 +2987,8 @@ final class ChannelController_Tests: XCTestCase {
         controller.sendKeystrokeEvent {
             XCTAssertNil($0)
         }
+        wait(for: [env.eventSender!.keystroke_completion_expectation], timeout: defaultTimeout)
+        env.eventSender!.keystroke_completion_expectation = XCTestExpectation()
 
         // Simulate `keystroke` call and catch the completion
         var completionCalledError: Error?
@@ -3000,6 +3002,7 @@ final class ChannelController_Tests: XCTestCase {
         controller = nil
 
         // Check keystroke cid.
+        wait(for: [env.eventSender!.keystroke_completion_expectation], timeout: defaultTimeout)
         XCTAssertEqual(env.eventSender!.keystroke_cid, channelId)
 
         // Simulate failed update
@@ -3059,6 +3062,8 @@ final class ChannelController_Tests: XCTestCase {
         controller.sendStartTypingEvent {
             XCTAssertNil($0)
         }
+        wait(for: [env.eventSender!.startTyping_completion_expectation], timeout: defaultTimeout)
+        env.eventSender!.startTyping_completion_expectation = XCTestExpectation()
 
         // Simulate `startTyping` call and catch the completion
         var completionCalledError: Error?
@@ -3072,6 +3077,7 @@ final class ChannelController_Tests: XCTestCase {
         controller = nil
 
         // Check `startTyping` cid.
+        wait(for: [env.eventSender!.startTyping_completion_expectation], timeout: defaultTimeout)
         XCTAssertEqual(env.eventSender!.startTyping_cid, channelId)
 
         // Simulate failed update
@@ -3131,7 +3137,9 @@ final class ChannelController_Tests: XCTestCase {
         controller.sendStopTypingEvent {
             XCTAssertNil($0)
         }
-
+        wait(for: [env.eventSender!.stopTyping_completion_expectation], timeout: defaultTimeout)
+        env.eventSender!.stopTyping_completion_expectation = XCTestExpectation()
+        
         // Simulate `stopTyping` call and catch the completion
         var completionCalledError: Error?
         controller.sendStopTypingEvent { completionCalledError = $0 }
@@ -3144,6 +3152,7 @@ final class ChannelController_Tests: XCTestCase {
         controller = nil
 
         // Check `stopTyping` cid.
+        wait(for: [env.eventSender!.stopTyping_completion_expectation], timeout: defaultTimeout)
         XCTAssertEqual(env.eventSender!.stopTyping_cid, channelId)
 
         // Simulate failed update


### PR DESCRIPTION
### 🎯 Goal

These tests were not updated to include the waiting part ([PR:3502](https://github.com/GetStream/stream-chat-swift/pull/3502) made typing check asynchronous which now started triggering test failures)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
