### PR TITLE
[CI] Fix release script

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -66,7 +66,7 @@ lane :release do |options|
     File.write(artifacts_path, JSON.dump(artifacts))
 
     # Set the framework version in SystemEnvironment+Version.swift
-    new_content = File.read(swift_environment_path).gsub!(previous_version_number, release_version).gsub!('-SNAPSHOT', '')
+    new_content = File.read(swift_environment_path).gsub!(previous_version_number, release_version).gsub('-SNAPSHOT', '')
     File.open(swift_environment_path, 'w') { |f| f.puts(new_content) }
 
     # Update sdk sizes


### PR DESCRIPTION
Removing `!` ensures that if there is no `-SNAPSHOT` postfix it won’t clean up the file.