### PR TITLE
Fix unstable AuthenticationRepository_Tests.test_reset()

### DIFF
--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -1063,6 +1063,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         repository.reset()
         // should cancel the connection provider timer and the
         // the token provider timer
+        XCTAssertEqual(repository.isGettingToken, false)
         XCTAssertEqual(mockTimer.cancelCallCount, 2)
         XCTAssertEqual(retryStrategy.mock_resetConsecutiveFailures.count, 1)
     }


### PR DESCRIPTION
### 🎯 Goal

Fix unstable `AuthenticationRepository_Tests.test_reset()` where the reset internally uses `tokenQueue.async` call to set the `resetConsecutiveFailures` state, checking for `isGettingToken` just schedules `tokenQueue.sync` internally and therefore fixes the timing issue

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)