### PR TITLE
End previous background task as soon as begin task is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `ChannelListSortingKey.pinnedAt`
   - Add `ChatChannel.membership.pinnedAt`
   - Add `ChatChannel.isPinned`
+### 🐞 Fixed
+- Fix a rare issue of not ending background tasks [#3528](https://github.com/GetStream/stream-chat-swift/pull/3528)
 
 # [4.68.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.68.0)
 _December 03, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `ChatChannel.membership.pinnedAt`
   - Add `ChatChannel.isPinned`
 ### 🐞 Fixed
-- Fix a rare issue of not ending background tasks [#3528](https://github.com/GetStream/stream-chat-swift/pull/3528)
+- End background task before starting a new one [#3528](https://github.com/GetStream/stream-chat-swift/pull/3528)
 
 # [4.68.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.68.0)
 _December 03, 2024_

--- a/Sources/StreamChat/WebSocketClient/BackgroundTaskScheduler.swift
+++ b/Sources/StreamChat/WebSocketClient/BackgroundTaskScheduler.swift
@@ -51,6 +51,7 @@ class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
     }
 
     func beginTask(expirationHandler: (() -> Void)?) -> Bool {
+        endTask()
         activeBackgroundTask = app?.beginBackgroundTask { [weak self] in
             expirationHandler?()
             self?.endTask()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-43](https://linear.app/stream/issue/IOS-43/)

### 🎯 Goal

Make sure previous task is ended when begin task is called immediately.

### 🛠 Implementation

There have been cases where background tasks are not ended correctly. Although I haven't been able to reproduce this with the demo app, I did find one way to reproduce it. Involves calling begin task twice. Could it be that in some configurations this can happen, not sure.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)