### PR TITLE
Improve database model conversion performance by caching extra data and keeping row cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ⚡ Performance
+- Improve performance of accessing database model properties [#3534](https://github.com/GetStream/stream-chat-swift/pull/3534)
+- Improve performance of model conversions with large extra data [#3534](https://github.com/GetStream/stream-chat-swift/pull/3534)
 
 # [4.69.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.69.0)
 _December 18, 2024_

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -477,7 +477,7 @@ extension ChatChannel {
 
         let extraData: [String: RawJSON]
         do {
-            extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dto.extraData)
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: dto.extraData)
         } catch {
             log.error(
                 "Failed to decode extra data for Channel with cid: <\(dto.cid)>, using default value instead. "

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -224,16 +224,12 @@ extension CurrentChatUser {
         
         let user = dto.user
 
-        var extraData = [String: RawJSON]()
-        if !dto.user.extraData.isEmpty {
-            do {
-                extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dto.user.extraData)
-            } catch {
-                log.error(
-                    "Failed to decode extra data for user with id: <\(dto.user.id)>, using default value instead. "
-                        + "Error: \(error)"
-                )
-            }
+        let extraData: [String: RawJSON]
+        do {
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: dto.user.extraData)
+        } catch {
+            log.error("Failed to decode extra data for user with id: <\(dto.user.id)>, using default value instead. Error: \(error)")
+            extraData = [:]
         }
         
         let mutedUsers: [ChatUser] = try dto.mutedUsers.map { try $0.asModel() }

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -189,7 +189,7 @@ extension ChatChannelMember {
         
         let extraData: [String: RawJSON]
         do {
-            extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dto.user.extraData)
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: dto.user.extraData)
         } catch {
             log.error(
                 "Failed to decode extra data for user with id: <\(dto.user.id)>, using default value instead. "
@@ -198,13 +198,15 @@ extension ChatChannelMember {
             extraData = [:]
         }
 
-        var memberExtraData: [String: RawJSON] = [:]
-        if let dtoMemberExtraData = dto.extraData {
-            do {
-                memberExtraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dtoMemberExtraData)
-            } catch {
-                memberExtraData = [:]
-            }
+        let memberExtraData: [String: RawJSON]
+        do {
+            memberExtraData = try JSONDecoder.stream.decodeCachedRawJSON(from: dto.extraData)
+        } catch {
+            log.error(
+                "Failed to decode extra data for channel member with id: <\(dto.user.id)>, using default value instead. "
+                    + "Error: \(error)"
+            )
+            memberExtraData = [:]
         }
 
         let role = dto.channelRoleRaw.flatMap { MemberRole(rawValue: $0) } ?? .member

--- a/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -207,17 +207,12 @@ extension MessageReactionDTO {
     func asModel() throws -> ChatMessageReaction {
         try isNotDeleted()
         
-        let decodedExtraData: [String: RawJSON]
-
-        if let extraData = self.extraData, !extraData.isEmpty {
-            do {
-                decodedExtraData = try JSONDecoder.default.decode([String: RawJSON].self, from: extraData)
-            } catch {
-                log.error("Failed decoding saved extra data with error: \(error)")
-                decodedExtraData = [:]
-            }
-        } else {
-            decodedExtraData = [:]
+        let extraData: [String: RawJSON]
+        do {
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: self.extraData)
+        } catch {
+            log.error("Failed decoding saved extra data with error: \(error)")
+            extraData = [:]
         }
 
         return try .init(
@@ -227,7 +222,7 @@ extension MessageReactionDTO {
             createdAt: createdAt?.bridgeDate ?? .init(),
             updatedAt: updatedAt?.bridgeDate ?? .init(),
             author: user.asModel(),
-            extraData: decodedExtraData
+            extraData: extraData
         )
     }
 }

--- a/Sources/StreamChat/Database/DTOs/PollDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/PollDTO.swift
@@ -88,11 +88,14 @@ extension PollDTO {
     func asModel() throws -> Poll {
         try isNotDeleted()
         
-        var extraData: [String: RawJSON] = [:]
-        if let custom,
-           !custom.isEmpty,
-           let decoded = try? JSONDecoder.default.decode([String: RawJSON].self, from: custom) {
-            extraData = decoded
+        let extraData: [String: RawJSON]
+        do {
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: custom)
+        } catch {
+            log.error(
+                "Failed to decode extra data for poll with id: <\(id)>, using default value instead. Error: \(error)"
+            )
+            extraData = [:]
         }
         
         let optionsArray = (options.array as? [PollOptionDTO]) ?? []

--- a/Sources/StreamChat/Database/DTOs/PollOptionDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/PollOptionDTO.swift
@@ -60,11 +60,14 @@ extension PollOptionDTO {
     func asModel() throws -> PollOption {
         try isNotDeleted()
         
-        var extraData: [String: RawJSON] = [:]
-        if let custom,
-           !custom.isEmpty,
-           let decoded = try? JSONDecoder.default.decode([String: RawJSON].self, from: custom) {
-            extraData = decoded
+        let extraData: [String: RawJSON]
+        do {
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: custom)
+        } catch {
+            log.error(
+                "Failed to decode extra data for poll option with id: <\(id)>, using default value instead. Error: \(error)"
+            )
+            extraData = [:]
         }
         return PollOption(
             id: id,

--- a/Sources/StreamChat/Database/DTOs/ThreadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ThreadDTO.swift
@@ -147,8 +147,11 @@ extension ThreadDTO {
         
         let extraData: [String: RawJSON]
         do {
-            extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: self.extraData)
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: self.extraData)
         } catch {
+            log.error(
+                "Failed to decode extra data for thread with id: <\(parentMessageId)>, using default value instead. Error: \(error)"
+            )
             extraData = [:]
         }
 

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -191,7 +191,7 @@ extension UserDTO {
     func asRequestBody() -> UserRequestBody {
         let extraData: [String: RawJSON]
         do {
-            extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: self.extraData)
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: self.extraData)
         } catch {
             log.assertionFailure(
                 "Failed decoding saved extra data with error: \(error). This should never happen because"
@@ -235,7 +235,7 @@ extension ChatUser {
         
         let extraData: [String: RawJSON]
         do {
-            extraData = try JSONDecoder.default.decode([String: RawJSON].self, from: dto.extraData)
+            extraData = try JSONDecoder.stream.decodeCachedRawJSON(from: dto.extraData)
         } catch {
             log.error(
                 "Failed to decode extra data for user with id: <\(dto.id)>, using default value instead. "

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -222,11 +222,6 @@ class DatabaseContainer: NSPersistentContainer, @unchecked Sendable {
                 try actions(self.writableContext)
                 FetchCache.clear()
 
-                // Refresh the state by merging persistent state and local state for avoiding optimistic locking failure
-                for object in self.writableContext.updatedObjects {
-                    self.writableContext.refresh(object, mergeChanges: true)
-                }
-
                 if self.writableContext.hasChanges {
                     log.debug("Context has changes. Saving.", subsystems: .database)
                     try self.writableContext.save()

--- a/Tests/StreamChatTests/Utils/JSONDecoder_Tests.swift
+++ b/Tests/StreamChatTests/Utils/JSONDecoder_Tests.swift
@@ -148,7 +148,7 @@ final class JSONDecoder_Tests: XCTestCase {
         let dateFormatter = ISO8601DateFormatter_Spy()
         dateFormatter.formatOptions = [.withFractionalSeconds, .withInternetDateTime]
         let dateCache = NSCache_Spy()
-        let decoder = StreamJSONDecoder(dateFormatter: dateFormatter, dateCache: dateCache)
+        let decoder = StreamJSONDecoder(dateFormatter: dateFormatter, dateCache: dateCache, rawJSONCache: RawJSONCache_Spy())
 
         // When we decode a payload with repeated dates
         let repeatedDate = "2020-06-09T08:10:40.800912Z" // If you change this, make sure to change `actualDecodedDate` below
@@ -177,6 +177,33 @@ final class JSONDecoder_Tests: XCTestCase {
         for (_, value) in dateDict {
             XCTAssertEqual(value, actualDecodedDate)
         }
+    }
+    
+    func test_extraDataIsCached() throws {
+        let extraData1: [String: RawJSON] = [
+            "key": .string("value")
+        ]
+        let extraData2: [String: RawJSON] = [
+            "key2": .string("value2")
+        ]
+        let data1 = try JSONEncoder().encode(extraData1)
+        let data2 = try JSONEncoder().encode(extraData2)
+        
+        let cacheSpy = RawJSONCache_Spy()
+        let decoder = StreamJSONDecoder(
+            dateFormatter: ISO8601DateFormatter(),
+            dateCache: NSCache(),
+            rawJSONCache: cacheSpy
+        )
+        let decoded1 = try decoder.decodeCachedRawJSON(from: data1)
+        let decoded2 = try decoder.decodeCachedRawJSON(from: data2)
+        let decoded1Again = try decoder.decodeCachedRawJSON(from: data1)
+        
+        XCTAssertEqual(extraData1, decoded1)
+        XCTAssertEqual(extraData2, decoded2)
+        XCTAssertEqual(extraData1, decoded1Again)
+        XCTAssertEqual(3, cacheSpy.numberOfCalls(on: "rawJSON(forKey:)"), cacheSpy.recordedFunctions.joined(separator: " "))
+        XCTAssertEqual(2, cacheSpy.numberOfCalls(on: "setRawJSON(_:forKey:)"), cacheSpy.recordedFunctions.joined(separator: " "))
     }
 
     // MARK: Helpers
@@ -249,5 +276,23 @@ final class JSONDecoder_Tests: XCTestCase {
             // Then
             XCTAssertNotNil(error, file: file, line: line)
         }
+    }
+}
+
+private final class RawJSONCache_Spy: StreamJSONDecoder.RawJSONCache, Spy {
+    let spyState = SpyState()
+    
+    init() {
+        super.init(countLimit: 3)
+    }
+    
+    override func rawJSON(forKey key: Int) -> [String: RawJSON]? {
+        record()
+        return super.rawJSON(forKey: key)
+    }
+    
+    override func setRawJSON(_ value: [String: RawJSON], forKey key: Int) {
+        record()
+        super.setRawJSON(value, forKey: key)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-610](https://linear.app/stream/issue/IOS-610)

### 🎯 Goal

- Improve performance of model conversion with more extreme use-cases (e.g. extra data is used a lot)

### 📝 Summary

- Cache extra data because it can be large and makes JSONDecoder way too busy when DB changes occur
- Remove reading the model state from the persistent storage in DatabaseContainer.write because it degrades performance a lot (other managed object contexts need to refetch everything, affects row cache)

### 🛠 Implementation

#### Performance measurement setup

Demo user `Chewbacca` has 19 muted channels and has a channel named "Performance Testing" with 12 members where each of the member has extra data filled with 162 fields (nested data).
```swift
var myData = [String: RawJSON]()
for index in 0..<40 {
    myData["extra_data_key_\(index)"] = .dictionary([
        "timestamp": .number(Date().timeIntervalSinceReferenceDate),
        "value": .string("value_\((0..<100).randomElement()!)"),
        "number": .number(Double(index)),
        "flag": .bool(true)
    ])
}
let updates = MemberUpdatePayload(extraData: [
    "extra_data_testing": .dictionary(myData),
    "extra_data_testing_2": .string("just testing stuff")
])
```

I added a simple snippet to the demo app (locally) which sent 20 messages with 1 second delay. While the message sending was taking place, I used time profiler to measure how busy threads are.

Time spent for extra data decoding went down a lot as expected, but time profiler was also showing that Core Data is busy fetching data for DTOs when `asModel()` functions were called (for ChannelDTO.asModel it was around 40% of time). What triggered this behaviour is the snippet in the `DatabaseContainer.write` where updated objects are fully refetched from the persistent store. This seems to affect the Core Data's row cache and makes it to discard it which in turn means that `backgroundReadOnlyContext` needs to refetch everything (because each context has its own DTO objects). The current state is that all the writes go through the `writableContext`, therefore there is not any need to actually sync update objects in the write call because there is no-one else changing the persistent store.

### 🎨 Showcase

Baseline
Cache - only extra data caching
Cache & merge off - extra data caching and not force updating updated objects
Cache & merge off & data prefetching - extra data caching, not force updating updated objects, and relationship prefetching enabled (`StreamRuntimeCheck._isDatabasePrefetchingEnabled`)

| Measurement | Baseline | Cache | Cache & merge off | Cache & merge off & data prefetching |
| ------ | ------ | ----- | ----- | ----- |
|  Total time (all threads)  |  6.45   |  5.39  |  4.46  |  4.35  |
|  `ChannelDTO.asModel()` (from channel controller)  |  1.97   |  1.44  |  0.80  |  0.82  |
|  `ChannelDTO.asModel()` (total)  |  4.07   |  2.96  |  2.34  |  1.75  |
|  `CurrentUserDTO.asModel()` (total)  |  1.82   |  1.49  |  1.46  |  0.84  |
|  Extra data decode (total)  |  1.33   |  0.12  |  0.13  |  0.13  |

Caching extra data also reduces the memory footprint for RawJSON

| Baseline | Caching |
| ------ | ------ |
| <img width="1129" alt="NoCache" src="https://github.com/user-attachments/assets/05898cf6-b982-41a6-afe6-fbcce4532a31" /> | <img width="1052" alt="Cache" src="https://github.com/user-attachments/assets/135b160b-9abe-46ea-914a-02c236658370" /> |

#### Takeaways
- Extra data caching is needed when extra data is used a lot (here we had an extreme case)
- `refresh:mergeChanges:` affects a lot (**~45%** improvement in channel controller)
- In general, this use-case saw **~33%** of improvement in CPU usage
-`CurrentChatUser` should not reference full `ChatChannel` models (cids would be better)
- Channel updates trigger current user model changes because updating a UserDTO referenced by CurrentUserDTO leads to CurrentUserDTO to trigger an update  

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)