### PR TITLE
Add additional sorting filter keys for member list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `ChannelListSortingKey.pinnedAt`
   - Add `ChatChannel.membership.pinnedAt`
   - Add `ChatChannel.isPinned`
+- Add member list filtering keys: `FilterKey.role` (`channel_role`) and `FilterKey.email` (`user.email`) [#3535](https://github.com/GetStream/stream-chat-swift/pull/3535)
+- Add member list sorting key: `ChannelMemberListSortingKey.role` (`channel_role`) [#3535](https://github.com/GetStream/stream-chat-swift/pull/3535)
 ### 🐞 Fixed
 - End background task before starting a new one [#3528](https://github.com/GetStream/stream-chat-swift/pull/3528)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `ChannelListSortingKey.pinnedAt`
   - Add `ChatChannel.membership.pinnedAt`
   - Add `ChatChannel.isPinned`
-- Add member list filtering keys: `FilterKey.role` (`channel_role`) and `FilterKey.email` (`user.email`) [#3535](https://github.com/GetStream/stream-chat-swift/pull/3535)
-- Add member list sorting key: `ChannelMemberListSortingKey.role` (`channel_role`) [#3535](https://github.com/GetStream/stream-chat-swift/pull/3535)
+- Add member list filtering keys: `FilterKey.channelRole` and `FilterKey.email` [#3535](https://github.com/GetStream/stream-chat-swift/pull/3535)
+- Add member list sorting key: `ChannelMemberListSortingKey.channelRole` [#3535](https://github.com/GetStream/stream-chat-swift/pull/3535)
 ### 🐞 Fixed
 - End background task before starting a new one [#3528](https://github.com/GetStream/stream-chat-swift/pull/3528)
 

--- a/Sources/StreamChat/Models/Member.swift
+++ b/Sources/StreamChat/Models/Member.swift
@@ -159,6 +159,18 @@ public extension MemberRole {
             self = MemberRole(rawValue: value)
         }
     }
+    
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .member:
+            try container.encode("channel_member")
+        case .moderator:
+            try container.encode("channel_moderator")
+        default:
+            try container.encode(rawValue)
+        }
+    }
 }
 
 /// The member information when adding a member to a channel.

--- a/Sources/StreamChat/Query/ChannelMemberListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelMemberListQuery.swift
@@ -24,6 +24,14 @@ public extension FilterKey where Scope: AnyMemberListFilterScope {
     /// Filter key matching the name of the user
     /// Supported operators: `equal`, `notEqual`, `in`, `notIn`, `autocomplete`, `query`
     static var name: FilterKey<Scope, String> { "name" }
+    
+    /// Filter key matching the email of the user
+    /// Supported operators: `equal`, `in`, `autocomplete`
+    static var email: FilterKey<Scope, String> { "user.email" }
+    
+    /// Filter key matching the role of the user
+    /// Supported operators: `equal`
+    static var role: FilterKey<Scope, MemberRole> { "channel_role" }
 
     /// Filter key matching the banned status
     /// Supported operators: `equal`

--- a/Sources/StreamChat/Query/ChannelMemberListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelMemberListQuery.swift
@@ -29,9 +29,9 @@ public extension FilterKey where Scope: AnyMemberListFilterScope {
     /// Supported operators: `equal`, `in`, `autocomplete`
     static var email: FilterKey<Scope, String> { "user.email" }
     
-    /// Filter key matching the role of the user
+    /// Filter key matching the channel role of the user
     /// Supported operators: `equal`
-    static var role: FilterKey<Scope, MemberRole> { "channel_role" }
+    static var channelRole: FilterKey<Scope, MemberRole> { "channel_role" }
 
     /// Filter key matching the banned status
     /// Supported operators: `equal`

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -80,6 +80,7 @@ extension Filter: FilterValue {}
 
 extension ChannelId: FilterValue {}
 extension ChannelType: FilterValue {}
+extension MemberRole: FilterValue {}
 extension UserRole: FilterValue {}
 extension AttachmentType: FilterValue {}
 extension Optional: FilterValue where Wrapped == TeamId {}

--- a/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
@@ -17,17 +17,17 @@ public enum ChannelMemberListSortingKey: String, SortingKey {
     /// - Warning: This option is heavy for the backend and can slow down API requests' response time. If there's no explicit requirement for this sorting option consider using a different one.
     case name = "user.name"
     
-    /// Sort channel members by their role (`channel_role`).
-    case role = "channelRoleRaw"
+    /// Sort channel members by their channel role.
+    case channelRole = "channelRoleRaw"
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         let value: String
 
         switch self {
+        case .channelRole: value = "channel_role"
         case .createdAt: value = "created_at"
         case .name: value = "name"
-        case .role: value = "channel_role"
         case .userId: value = "user_id"
         }
 

--- a/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
@@ -16,15 +16,18 @@ public enum ChannelMemberListSortingKey: String, SortingKey {
     ///
     /// - Warning: This option is heavy for the backend and can slow down API requests' response time. If there's no explicit requirement for this sorting option consider using a different one.
     case name = "user.name"
+    
+    /// Sort channel members by their role (`channel_role`).
+    case role = "channelRoleRaw"
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         let value: String
 
         switch self {
-        /// Sort channel members by date they were created.
         case .createdAt: value = "created_at"
         case .name: value = "name"
+        case .role: value = "channel_role"
         case .userId: value = "user_id"
         }
 

--- a/Tests/StreamChatTests/Query/MemberListFilterScope_Tests.swift
+++ b/Tests/StreamChatTests/Query/MemberListFilterScope_Tests.swift
@@ -12,6 +12,8 @@ final class MemberListFilterScope_Tests: XCTestCase {
     func test_filterKeys_matchChannelCodingKeys() {
         // Member specific coding keys
         XCTAssertEqual(Key<Bool>.isModerator.rawValue, "is_moderator")
+        XCTAssertEqual(Key<String>.email.rawValue, "user.email")
+        XCTAssertEqual(Key<MemberRole>.channelRole.rawValue, "channel_role")
 
         // User-related coding keys
         XCTAssertEqual(Key<UserId>.id.rawValue, UserPayloadsCodingKeys.id.rawValue)

--- a/Tests/StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
@@ -11,7 +11,7 @@ final class ChannelMemberListSortingKey_Tests: XCTestCase {
     func test_sortDescriptor_keyPaths_areValid() throws {
         // Put all `ChannelMemberListSortingKey`s in an array
         // We don't use `CaseIterable` since we only need this for tests
-        let sortingKeys: [ChannelMemberListSortingKey] = [.createdAt, .name, .userId]
+        let sortingKeys: [ChannelMemberListSortingKey] = [.createdAt, .name, .role, .userId]
 
         // Iterate over keys...
         for key in sortingKeys {
@@ -24,6 +24,8 @@ final class ChannelMemberListSortingKey_Tests: XCTestCase {
                     ChannelMemberListSortingKey.name.rawValue,
                     NSExpression(forKeyPath: \MemberDTO.user.name).keyPath
                 )
+            case .role:
+                XCTAssertEqual(key.rawValue, KeyPath.string(\MemberDTO.channelRoleRaw))
             case .userId:
                 XCTAssertEqual(key.rawValue, NSExpression(forKeyPath: \MemberDTO.user.id).keyPath)
             }

--- a/Tests/StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
@@ -11,7 +11,7 @@ final class ChannelMemberListSortingKey_Tests: XCTestCase {
     func test_sortDescriptor_keyPaths_areValid() throws {
         // Put all `ChannelMemberListSortingKey`s in an array
         // We don't use `CaseIterable` since we only need this for tests
-        let sortingKeys: [ChannelMemberListSortingKey] = [.createdAt, .name, .role, .userId]
+        let sortingKeys: [ChannelMemberListSortingKey] = [.createdAt, .name, .channelRole, .userId]
 
         // Iterate over keys...
         for key in sortingKeys {
@@ -24,7 +24,7 @@ final class ChannelMemberListSortingKey_Tests: XCTestCase {
                     ChannelMemberListSortingKey.name.rawValue,
                     NSExpression(forKeyPath: \MemberDTO.user.name).keyPath
                 )
-            case .role:
+            case .channelRole:
                 XCTAssertEqual(key.rawValue, KeyPath.string(\MemberDTO.channelRoleRaw))
             case .userId:
                 XCTAssertEqual(key.rawValue, NSExpression(forKeyPath: \MemberDTO.user.id).keyPath)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-605](https://linear.app/stream/issue/IOS-605/)

### 🎯 Goal

No way for filtering by `channel_role` and sorting by `channel_role` in member list queries.

### 📝 Summary

- Add member list filtering keys: `FilterKey.channelRole` and `FilterKey.email`
- Add member list sorting key: `ChannelMemberListSortingKey.channelRole`
- Encode `MemberRole.member` as `channel_member` and `MemberRole.moderator` as `channel_moderator`

### 🛠 Implementation

### 🧪 Manual Testing Notes

Example snippet for testing filtering and sorting (`chewbacca`)

```swift
let query = ChannelMemberListQuery(
    cid: ChannelId(type: .messaging, id: "83100323-A"),
    filter: .equal(.channelRole, to: .member),
    sort: [.init(key: .channelRole)]
)
let memberList = self.makeMemberList(with: query)
do {
    try await memberList.get()
    let members = await memberList.state.members
    print(members.count)
    for member in members {
        print(member.id, member.memberRole.rawValue)
    }
} catch {
    print(error)
}
```


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
