### PR TITLE
Add FilterKey.members and support for equal operator to match an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add `ChannelListSortingKey.pinnedAt`
   - Add `ChatChannel.membership.pinnedAt`
   - Add `ChatChannel.isPinned`
+- Add channel list filtering key: `FilterKey.members` [#3536](https://github.com/GetStream/stream-chat-swift/pull/3536)
 ### 🐞 Fixed
 - End background task before starting a new one [#3528](https://github.com/GetStream/stream-chat-swift/pull/3528)
 

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -65,6 +65,10 @@ final class DemoChatChannelListVC: ChatChannelListVC {
         .containMembers(userIds: [currentUserId]),
         .equal(.pinned, to: true)
     ]))
+    
+    lazy var equalMembersQuery: ChannelListQuery = .init(filter:
+        .equal(.members, values: [currentUserId, "r2-d2"])
+    )
 
     var demoRouter: DemoChatChannelListRouter? {
         router as? DemoChatChannelListRouter
@@ -170,6 +174,14 @@ final class DemoChatChannelListVC: ChatChannelListVC {
             self?.title = "Pinned Channels"
             self?.setPinnedChannelsQuery()
         }
+        
+        let equalMembersAction = UIAlertAction(
+            title: "R2-D2 Channels (Equal Members)",
+            style: .default
+        ) { [weak self] _ in
+            self?.title = "R2-D2 Channels (Equal Members)"
+            self?.setEqualMembersChannelsQuery()
+        }
 
         presentAlert(
             title: "Filter Channels",
@@ -180,7 +192,8 @@ final class DemoChatChannelListVC: ChatChannelListVC {
                 mutedChannelsAction,
                 coolChannelsAction,
                 pinnedChannelsAction,
-                archivedChannelsAction
+                archivedChannelsAction,
+                equalMembersAction
             ].sorted(by: { $0.title ?? "" < $1.title ?? "" }),
             preferredStyle: .actionSheet,
             sourceView: filterChannelsButton
@@ -215,6 +228,10 @@ final class DemoChatChannelListVC: ChatChannelListVC {
     
     func setPinnedChannelsQuery() {
         replaceQuery(pinnedChannelsQuery)
+    }
+    
+    func setEqualMembersChannelsQuery() {
+        replaceQuery(equalMembersQuery)
     }
 
     func setInitialChannelsQuery() {

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -46,12 +46,6 @@ extension Filter where Scope: AnyChannelListFilterScope {
     }
 }
 
-// We don't want to expose `members` publicly because it can't be used with any other operator
-// than `$in`. We expose it publicly via the `containMembers` filter helper.
-extension FilterKey where Scope: AnyChannelListFilterScope {
-    static var members: FilterKey<Scope, UserId> { .init(rawValue: "members", keyPathString: #keyPath(ChannelDTO.members.user.id)) }
-}
-
 /// Filter values to be used with `.invite` FilterKey.
 public enum InviteFilterValue: String, FilterValue {
     case pending
@@ -88,12 +82,13 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     /// A filter key for matching the `createdBy` value.
     /// Supported operators: `equal`
     static var createdBy: FilterKey<Scope, UserId> { .init(rawValue: "created_by_id", keyPathString: #keyPath(ChannelDTO.createdBy.id)) }
+    
     /// A filter key for matching the `createdAt` value.
-    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `exists`
     static var createdAt: FilterKey<Scope, Date> { .init(rawValue: "created_at", keyPathString: #keyPath(ChannelDTO.createdAt)) }
 
     /// A filter key for matching the `updatedAt` value.
-    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`
     static var updatedAt: FilterKey<Scope, Date> { .init(rawValue: "updated_at", keyPathString: #keyPath(ChannelDTO.updatedAt)) }
 
     /// A filter key for matching the `deletedAt` value.
@@ -114,6 +109,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var blocked: FilterKey<Scope, Bool> { .init(rawValue: "blocked", keyPathString: #keyPath(ChannelDTO.isBlocked)) }
     
     /// A filter key for matching the `archived` value.
+    /// Supported operators: `equal`
     static var archived: FilterKey<Scope, Bool> {
         .init(
             rawValue: "archived",
@@ -131,6 +127,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     }
     
     /// A filter key for matching the `pinned` value.
+    /// Supported operators: `equal`
     static var pinned: FilterKey<Scope, Bool> {
         .init(
             rawValue: "pinned",
@@ -147,8 +144,12 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
         )
     }
 
+    /// A filter key for matching channel members.
+    /// Supported operators: `in`, `equal`
+    static var members: FilterKey<Scope, UserId> { .init(rawValue: "members", keyPathString: #keyPath(ChannelDTO.members.user.id)) }
+    
     /// A filter key for matching the `memberCount` value.
-    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`
     static var memberCount: FilterKey<Scope, Int> { .init(rawValue: "member_count", keyPathString: #keyPath(ChannelDTO.memberCount)) }
 
     /// A filter key for matching the `team` value.
@@ -192,12 +193,12 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var invite: FilterKey<Scope, InviteFilterValue> { "invite" }
 
     /// Filter for checking the `name` property of a user who is a member of the channel
-    /// Supported operators: `equal`, `notEqual`, `autocomplete`
+    /// Supported operators: `equal`, `autocomplete`
     /// - Warning: This filter is considerably expensive for the backend so avoid using this when possible.
     static var memberName: FilterKey<Scope, String> { .init(rawValue: "member.user.name", keyPathString: #keyPath(ChannelDTO.members.user.name), isCollectionFilter: true) }
 
     /// Filter for the time of the last message in the channel. If the channel has no messages, then the time the channel was created.
-    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`
     static var lastUpdatedAt: FilterKey<Scope, Date> { .init(rawValue: "last_updated", keyPathString: #keyPath(ChannelDTO.lastMessageAt)) }
 }
 

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// An enum with possible operators to use in filters.
 public enum FilterOperator: String {
-    /// Matches values that are equal to a specified value.
+    /// Matches values that are equal to a specified value or matches all of the values in an array.
     case equal = "$eq"
 
     /// Matches all values that are not equal to a specified value.
@@ -294,6 +294,17 @@ public extension Filter {
             operator: .equal,
             key: key,
             value: value,
+            valueMapper: key.valueMapper,
+            keyPathString: key.keyPathString
+        )
+    }
+    
+    /// Matches values that are equal to a specified values.
+    static func equal<Value: Encodable>(_ key: FilterKey<Scope, Value>, values: [Value]) -> Filter {
+        .init(
+            operator: .equal,
+            key: key,
+            value: values,
             valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )

--- a/Tests/StreamChatTests/Query/Filter_Tests.swift
+++ b/Tests/StreamChatTests/Query/Filter_Tests.swift
@@ -12,6 +12,11 @@ final class Filter_Tests: XCTestCase {
         XCTAssertEqual(filter.key, FilterKey<FilterTestScope, String>.testKey.rawValue)
         XCTAssertEqual(filter.value as? String, "equal value")
         XCTAssertEqual(filter.operator, FilterOperator.equal.rawValue)
+        
+        filter = .equal(.testKey, values: ["eq value 1", "eq value 2"])
+        XCTAssertEqual(filter.key, FilterKey<FilterTestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? [String], ["eq value 1", "eq value 2"])
+        XCTAssertEqual(filter.operator, FilterOperator.equal.rawValue)
 
         filter = .notEqual(.testKey, to: "not equal value")
         XCTAssertEqual(filter.key, FilterKey<FilterTestScope, String>.testKey.rawValue)
@@ -92,6 +97,11 @@ final class Filter_Tests: XCTestCase {
         // Test in filter
         filter = .init(operator: FilterOperator.in.rawValue, key: "test_key", value: [1, 2, 3], isCollectionFilter: false)
         XCTAssertEqual(filter.serialized, #"{"test_key":{"$in":[1,2,3]}}"#)
+        XCTAssertEqual(jsonString.deserializeFilter(), filter)
+        
+        // Test eq values filter
+        filter = .init(operator: FilterOperator.equal.rawValue, key: "test_key", value: [1, 2, 3], isCollectionFilter: false)
+        XCTAssertEqual(filter.serialized, #"{"test_key":{"$eq":[1,2,3]}}"#)
         XCTAssertEqual(jsonString.deserializeFilter(), filter)
 
         // Test group filter


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-609](https://linear.app/stream/issue/IOS-609)

### 🎯 Goal

Enable filtering channel list with `$eq` and an array of channel member ids

### 📝 Summary

- Add `FilterKey.members`
- Add support for `$eq` to match an array of values

### 🛠 Implementation

Filtering by `members` supports `$in` and `$eq` operators. We did not expose the latter. For supporting it, some changes were required for enabling Core Data to match channels with `$eq` and an array of values.

### 🎨 Showcase

### 🧪 Manual Testing Notes

1. Log in with `chewbacca`
2. Try different channel queries (R2-D2 Channels uses the new members equals query and returns all the channels where members equal to `current user` and `r2-d2`)

Example snippet
```swift
DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5)) {
    Task {
        let query = ChannelListQuery(filter: .equal(.members, values: ["chewbacca", "luke_skywalker"]))
        let channelList = self.makeChannelList(with: query)
        try await channelList.get()
        let channels = channelList.state.channels
        for channel in channels {
            print(channel.cid, channel.memberCount, channel.lastActiveMembers.map(\.id).sorted())
        }
    }
}
```

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)