### PR TITLE
[CI] Resolve SwiftUI XCFramework compilation issue

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,8 +51,18 @@ lane :build_xcframeworks do
     )
     sh('../Scripts/removeUnneededSymbols.sh', sdk, output_directory)
     codesign << lane_context[SharedValues::XCFRAMEWORK_OUTPUT_PATH]
+    resolve_swiftui_xcframework_issue if sdk == 'StreamChatUI'
   end
   sh(codesign.join(' ')) # We need to sign all frameworks at once
+end
+
+desc 'https://linear.app/stream/issue/IOS-630'
+private_lane :resolve_swiftui_xcframework_issue do
+  Dir.glob("#{lane_context[SharedValues::XCFRAMEWORK_OUTPUT_PATH]}/**/*.swiftinterface").each do |file|
+    old_text = File.read(file)
+    new_text = old_text.gsub(/SwiftUICore.View/, 'View')
+    File.open(file, 'w') { |f| f.puts(new_text) } if old_text != new_text
+  end
 end
 
 desc 'Start a new release'


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-630

### 🎯 Goal

Resolve SwiftUI XCFramework compilation issue

### 🛠 Implementation

Get rid of `SwiftUICore` in all `StreamChatUI`-related swiftinterfaces (inside xcframework)

### 🎨 Showcase

- https://github.com/GetStream/apple-internal-testing-pipeline/actions/runs/12631550370/job/35193503476

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
