### PR TITLE
Fix thread reply action shown when inside a Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Fix thread reply action shown when inside a Thread [#3561](https://github.com/GetStream/stream-chat-swift/pull/3561)
 
 # [4.70.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.70.0)
 _January 14, 2025_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -487,6 +487,7 @@ open class ChatMessageListVC: _ViewController,
 
         let actionsController = components.messageActionsVC.init()
         actionsController.messageController = messageController
+        actionsController.isInsideThread = dataSource is ChatThreadVC
         actionsController.channel = dataSource?.channel(for: self)
         actionsController.delegate = self
 

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -21,6 +21,9 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
     /// `ChatMessageController` instance used to obtain the message data.
     public var messageController: ChatMessageController!
 
+    /// A boolean value indicating if the actions are being shown inside a thread.
+    public var isInsideThread: Bool = false
+
     /// The channel which the actions will be performed.
     public var channel: ChatChannel? {
         didSet {
@@ -117,7 +120,7 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
                 actions.append(inlineReplyActionItem())
             }
 
-            if canSendReply && !message.isPartOfThread {
+            if canSendReply && !message.isPartOfThread && !isInsideThread {
                 actions.append(threadReplyActionItem())
             }
 

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -200,6 +200,44 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertEqual(mockedMessageWithoutCid.cid, nil)
     }
 
+    func test_didSelectMessageCell_whenDataSourceIsChatThreadVC_shouldSetIsIndideThreadForActions() {
+        mockedListView.mockedCellForRow = .init()
+        mockedListView.mockedCellForRow?.mockedMessage = .mock()
+
+        let mockedRouter = ChatMessageListRouter_Mock(rootViewController: UIViewController())
+        sut.router = mockedRouter
+
+        let threadVC = ChatThreadVC()
+        let mock = ChatChannelController_Mock.mock()
+        mock.channel_mock = .mock(cid: .unique)
+        threadVC.channelController = mock
+        sut.dataSource = threadVC
+
+        sut.didSelectMessageCell(at: IndexPath(item: 0, section: 0))
+
+        XCTAssertEqual(mockedRouter.showMessageActionsPopUpCallCount, 1)
+        XCTAssertEqual(mockedRouter.showMessageActionsPopUpCalledWith?.messageActionsController.isInsideThread, true)
+    }
+
+    func test_didSelectMessageCell_whenDataSourceIsChatChannelVC_shouldNotSetIsIndideThreadForActions() {
+        mockedListView.mockedCellForRow = .init()
+        mockedListView.mockedCellForRow?.mockedMessage = .mock()
+
+        let mockedRouter = ChatMessageListRouter_Mock(rootViewController: UIViewController())
+        sut.router = mockedRouter
+
+        let channelVC = ChatChannelVC()
+        let mock = ChatChannelController_Mock.mock()
+        mock.channel_mock = .mock(cid: .unique)
+        channelVC.channelController = mock
+        sut.dataSource = channelVC
+
+        sut.didSelectMessageCell(at: IndexPath(item: 0, section: 0))
+
+        XCTAssertEqual(mockedRouter.showMessageActionsPopUpCallCount, 1)
+        XCTAssertEqual(mockedRouter.showMessageActionsPopUpCalledWith?.messageActionsController.isInsideThread, false)
+    }
+
     // MARK: - isContentEqual (Message Diffing)
 
     func test_messageIsContentEqual_whenCustomAttachmentDataDifferent() throws {

--- a/Tests/StreamChatUITests/SnapshotTests/MessageActionsPopup/ChatMessageActionsVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/MessageActionsPopup/ChatMessageActionsVC_Tests.swift
@@ -196,6 +196,19 @@ final class ChatMessageActionsVC_Tests: XCTestCase {
         XCTAssertFalse(vc.messageActions.contains(where: { $0 is ThreadReplyActionItem }))
     }
 
+    func test_messageActions_whenSendReply_messageIsNotPartOfThread_alreadyInsideThread_doesNotContainThreadReplyAction() {
+        chatMessageController.simulateInitial(
+            message: ChatMessage.mock(parentMessageId: nil),
+            replies: [],
+            state: .remoteDataFetched
+        )
+
+        vc.isInsideThread = true
+        vc.channel = .mock(cid: .unique, ownCapabilities: [.sendReply])
+
+        XCTAssertFalse(vc.messageActions.contains(where: { $0 is ThreadReplyActionItem }))
+    }
+
     func test_messageActions_whenUpdateOwnMessage_messageIsSentByCurrentUser_thenContainsEditAction() {
         chatMessageController.simulateInitial(
             message: ChatMessage.mock(isSentByCurrentUser: true),


### PR DESCRIPTION
### 🔗 Issue Links

Resolves IOS-187

### 🎯 Goal

Fix thread reply action shown when inside a Thread.

### 🛠 Implementation

We need context in the Message Actions where the view is being presented. This was previously requested by other customers since this can be useful for other things. So now, whenever we present the message actions, we have a new boolean property that tells if the actions are being presented inside a thread or not.

### 🧪 Manual Testing Notes

1. Open a Thread
2. Long press the Parent Message
3. Should not show "Thread Reply Action"

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
