### PR TITLE
Wait for current user data to be synced when connectUser() is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Calling async `connectUser()` methods can sometimes throw `CurrentUserDoesNotExist()` unexpectedly [#3565](https://github.com/GetStream/stream-chat-swift/pull/3565)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix thread reply action shown when inside a Thread [#3561](https://github.com/GetStream/stream-chat-swift/pull/3561)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -339,7 +339,7 @@ public class ChatClient {
                 continuation.resume(with: error)
             }
         }
-        return try makeConnectedUser()
+        return try await retrieveConnectedUser()
     }
 
     /// Connects the client with the given user.
@@ -391,7 +391,7 @@ public class ChatClient {
                 continuation.resume(with: error)
             }
         }
-        return try makeConnectedUser()
+        return try await retrieveConnectedUser()
     }
 
     /// Connects a guest user.
@@ -423,7 +423,7 @@ public class ChatClient {
                 continuation.resume(with: error)
             }
         }
-        return try makeConnectedUser()
+        return try await retrieveConnectedUser()
     }
 
     /// Connects an anonymous user
@@ -447,7 +447,7 @@ public class ChatClient {
                 continuation.resume(with: error)
             }
         }
-        return try makeConnectedUser()
+        return try await retrieveConnectedUser()
     }
     
     /// Sets the user token to the client, this method is only needed to perform API calls
@@ -695,6 +695,15 @@ extension ChatClient: ConnectionDetailsProviderDelegate {
 
     func provideConnectionId(timeout: TimeInterval = 10, completion: @escaping (Result<ConnectionId, Error>) -> Void) {
         connectionRepository.provideConnectionId(timeout: timeout, completion: completion)
+    }
+
+    @discardableResult
+    func provideConnectionId(timeout: TimeInterval = 10) async throws -> ConnectionId {
+        try await withCheckedThrowingContinuation { continuation in
+            provideConnectionId(timeout: timeout) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 }
 

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -10,12 +10,23 @@ extension ChatClient {
     /// Creates an instance of ``ConnectedUser`` which represents the logged-in user state and its actions.
     ///
     /// - Throws: An error if no user is currently logged-in.
+    /// - Returns: An instance of ``ConnectedUser`` which represents the logged-in user.
     public func makeConnectedUser() throws -> ConnectedUser {
         let user = try databaseContainer.readAndWait { session in
             guard let dto = session.currentUser else { throw ClientError.CurrentUserDoesNotExist() }
             return try dto.asModel()
         }
         return ConnectedUser(user: user, client: self)
+    }
+    
+    /// Creates an instance of ``ConnectedUser`` by optionally waiting for the current user data to be synced through web-socket events.
+    ///
+    /// - Throws: An error if the current user data failed to sync.
+    /// - Returns: An instance of ``ConnectedUser`` which represents the logged-in user.
+    func retrieveConnectedUser() async throws -> ConnectedUser {
+        // Returns immediately when data is in sync and therefore ensuring that current user is available locally.
+        try await provideConnectionId()
+        return try makeConnectedUser()
     }
 }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
@@ -30,6 +30,8 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
     var completeWaitersConnectionId: ConnectionId?
     var connectionUpdateState: WebSocketConnectionState?
     var simulateExpiredTokenOnConnectionUpdate = false
+    
+    var provideConnectionIdResult: Result<ConnectionId, Error>?
 
     convenience init() {
         self.init(isClientInActiveMode: true,
@@ -103,6 +105,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
 
     override func provideConnectionId(timeout: TimeInterval = 10, completion: @escaping (Result<ConnectionId, Error>) -> Void) {
         record()
+        provideConnectionIdResult?.invoke(with: completion)
     }
 
     override func handleConnectionUpdate(state: WebSocketConnectionState, onExpiredToken: () -> Void) {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-655](https://linear.app/stream/issue/IOS-655)

### 🎯 Goal

Wait for current user data to be synced before accessing current user data in async connect methods.

### 📝 Summary

Current user data comes with web-socket event. Therefore, it caused a data race between accessing the current user data and receiving the event. `CurrentChatUserController.synchronize()` uses the same mechanism of calling `provideConnectionId`. Most of the time this issue does not happen, but it can.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
