### PR TITLE
Dismiss thread when hard deleting root message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    - Add `ChatMessage.replacing()`
    - Add `ChatChannel.replacing()`
    - Add `ChatChannelMember.replacing()`
-- Fix duplicated `didReceiveEvent` inside `ChatThreadVC` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 - Fix hard deleted message events not being reported in `EventsController` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 ### 🔄 Changed
 - Deprecates `MessageDeletedEvent.isHardDeleted` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
@@ -33,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix thread reply action shown when inside a Thread [#3561](https://github.com/GetStream/stream-chat-swift/pull/3561)
 - Fix reaction author's view with shrinked reaction images in iOS 18 [#3568](https://github.com/GetStream/stream-chat-swift/pull/3568)
+- Fix duplicated `didReceiveEvent` inside `ChatThreadVC` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 ### 🔄 Changed
 - Deprecates `ChatThreadVC.channelEventsController` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add `MessageHardDeletedEvent` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
+- Expose `Event.name` to easily check which event it is [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 ### 🐞 Fixed
 - Calling async `connectUser()` methods can sometimes throw `CurrentUserDoesNotExist()` unexpectedly [#3565](https://github.com/GetStream/stream-chat-swift/pull/3565)
 - Fix creating controllers from background threads leading to rare crashes [#3566](https://github.com/GetStream/stream-chat-swift/pull/3566)
@@ -14,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    - Add `ChatMessage.replacing()`
    - Add `ChatChannel.replacing()`
    - Add `ChatChannelMember.replacing()`
-- Expose `Event.name` to easily check which event it is [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 - Fix duplicated `didReceiveEvent` inside `ChatThreadVC` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 - Fix hard deleted message events not being reported in `EventsController` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 ### 🔄 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### ✅ Added
-- Add `MessageHardDeletedEvent` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 - Expose `Event.name` to easily check which event it is [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 ### 🐞 Fixed
 - Calling async `connectUser()` methods can sometimes throw `CurrentUserDoesNotExist()` unexpectedly [#3565](https://github.com/GetStream/stream-chat-swift/pull/3565)
@@ -16,8 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    - Add `ChatChannel.replacing()`
    - Add `ChatChannelMember.replacing()`
 - Fix hard deleted message events not being reported in `EventsController` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
-### 🔄 Changed
-- Deprecates `MessageDeletedEvent.isHardDeleted` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
+- Fix hard deleting a parent message not deleting its replies [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ✅ Added
+- Add `MessageHardDeletedEvent` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 ### 🐞 Fixed
 - Calling async `connectUser()` methods can sometimes throw `CurrentUserDoesNotExist()` unexpectedly [#3565](https://github.com/GetStream/stream-chat-swift/pull/3565)
 - Fix creating controllers from background threads leading to rare crashes [#3566](https://github.com/GetStream/stream-chat-swift/pull/3566)
@@ -12,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    - Add `ChatMessage.replacing()`
    - Add `ChatChannel.replacing()`
    - Add `ChatChannelMember.replacing()`
+- Expose `Event.name` to easily check which event it is [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
+- Fix duplicated `didReceiveEvent` inside `ChatThreadVC` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
+- Fix hard deleted message events not being reported in `EventsController` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
+### 🔄 Changed
+- Deprecates `MessageDeletedEvent.isHardDeleted` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 
 ## StreamChatUI
 ### ✅ Added
@@ -26,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix thread reply action shown when inside a Thread [#3561](https://github.com/GetStream/stream-chat-swift/pull/3561)
 - Fix reaction author's view with shrinked reaction images in iOS 18 [#3568](https://github.com/GetStream/stream-chat-swift/pull/3568)
+### 🔄 Changed
+- Deprecates `ChatThreadVC.channelEventsController` [#3569](https://github.com/GetStream/stream-chat-swift/pull/3569)
 
 # [4.70.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.70.0)
 _January 14, 2025_

--- a/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
@@ -70,16 +70,13 @@ class DemoChatThreadVC: ChatThreadVC, CurrentChatUserControllerDelegate {
         ])
     }
 
-    override func messageController(
-        _ controller: ChatMessageController,
-        didChangeReplies changes: [ListChange<ChatMessage>]
-    ) {
-        // If the message is hard deleted, dismiss the thread.
-        if controller.message == nil {
+    override func eventsController(_ controller: EventsController, didReceiveEvent event: any Event) {
+        super.eventsController(controller, didReceiveEvent: event)
+
+        // Dismiss the thread if the root message was hard deleted.
+        if let event = event as? MessageHardDeletedEvent, event.messageId == messageController.messageId {
             navigationController?.popViewController(animated: true)
-            return
         }
-        super.messageController(controller, didChangeReplies: changes)
     }
 
     // MARK: - Loading previous and next messages state handling.

--- a/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
@@ -70,6 +70,18 @@ class DemoChatThreadVC: ChatThreadVC, CurrentChatUserControllerDelegate {
         ])
     }
 
+    override func messageController(
+        _ controller: ChatMessageController,
+        didChangeReplies changes: [ListChange<ChatMessage>]
+    ) {
+        // If the message is hard deleted, dismiss the thread.
+        if controller.message == nil {
+            navigationController?.popViewController(animated: true)
+            return
+        }
+        super.messageController(controller, didChangeReplies: changes)
+    }
+
     // MARK: - Loading previous and next messages state handling.
 
     override func loadPreviousReplies(completion: @escaping (Error?) -> Void) {

--- a/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
@@ -77,7 +77,7 @@ class DemoChatThreadVC: ChatThreadVC, CurrentChatUserControllerDelegate {
         didChangeReplies changes: [ListChange<ChatMessage>]
     ) {
         // If the message is hard deleted, do not update the UI
-        // (Otherwise it would should the root message disappearing)
+        // (Otherwise it would show the root message disappearing)
         if controller.message == nil {
             navigationController?.popViewController(animated: true)
             return

--- a/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
@@ -89,7 +89,7 @@ class DemoChatThreadVC: ChatThreadVC, CurrentChatUserControllerDelegate {
         super.eventsController(controller, didReceiveEvent: event)
 
         // Dismiss the thread if the root message was hard deleted.
-        if let event = event as? MessageHardDeletedEvent, event.messageId == messageController.messageId {
+        if let event = event as? MessageDeletedEvent, event.isHardDelete, event.message.id == messageController.messageId {
             navigationController?.popViewController(animated: true)
         }
     }

--- a/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
@@ -72,19 +72,6 @@ class DemoChatThreadVC: ChatThreadVC, CurrentChatUserControllerDelegate {
 
     // MARK: - Dismissing the thread if the root message was hard deleted.
 
-    override func messageController(
-        _ controller: ChatMessageController,
-        didChangeReplies changes: [ListChange<ChatMessage>]
-    ) {
-        // If the message is hard deleted, do not update the UI
-        // (Otherwise it would show the root message disappearing)
-        if controller.message == nil {
-            navigationController?.popViewController(animated: true)
-            return
-        }
-        super.messageController(controller, didChangeReplies: changes)
-    }
-
     override func eventsController(_ controller: EventsController, didReceiveEvent event: any Event) {
         super.eventsController(controller, didReceiveEvent: event)
 

--- a/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatThreadVC.swift
@@ -70,6 +70,21 @@ class DemoChatThreadVC: ChatThreadVC, CurrentChatUserControllerDelegate {
         ])
     }
 
+    // MARK: - Dismissing the thread if the root message was hard deleted.
+
+    override func messageController(
+        _ controller: ChatMessageController,
+        didChangeReplies changes: [ListChange<ChatMessage>]
+    ) {
+        // If the message is hard deleted, do not update the UI
+        // (Otherwise it would should the root message disappearing)
+        if controller.message == nil {
+            navigationController?.popViewController(animated: true)
+            return
+        }
+        super.messageController(controller, didChangeReplies: changes)
+    }
+
     override func eventsController(_ controller: EventsController, didReceiveEvent event: any Event) {
         super.eventsController(controller, didReceiveEvent: event)
 

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -216,6 +216,9 @@ class MessageRepository {
 
             if messageDTO.isHardDeleted {
                 session.delete(message: deletedMessage)
+                messageDTO.replies.forEach {
+                    session.delete(message: $0)
+                }
             }
         }, completion: {
             completion?($0)

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -7,7 +7,7 @@ import Foundation
 /// An `Event` object representing an event in the chat system.
 public protocol Event {}
 
-extension Event {
+public extension Event {
     var name: String {
         String(describing: Self.self).replacingOccurrences(of: "DTO", with: "")
     }

--- a/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
@@ -163,7 +163,7 @@ class MessageDeletedEventDTO: EventDTO {
 
         // If the message is hard deleted, it is not available as DTO.
         // So we map the Payload Directly to the Model.
-        let message = (try? messageDTO?.asModel()) ?? message.asModel()
+        let message = (try? messageDTO?.asModel()) ?? message.asModel(currentUser: session.currentUser)
 
         return try? MessageDeletedEvent(
             user: userDTO?.asModel(),
@@ -254,7 +254,7 @@ public struct NewMessageErrorEvent: Event {
 // So some of the data will be incorrect, but for this is use case is more than enough.
 
 private extension MessagePayload {
-    func asModel() -> ChatMessage {
+    func asModel(currentUser: CurrentUserDTO?) -> ChatMessage {
         .init(
             id: id,
             cid: cid,
@@ -270,7 +270,7 @@ private extension MessagePayload {
             showReplyInChannel: showReplyInChannel,
             replyCount: replyCount,
             extraData: extraData,
-            quotedMessage: quotedMessage?.asModel(),
+            quotedMessage: quotedMessage?.asModel(currentUser: currentUser),
             isBounced: false,
             isSilent: isSilent,
             isShadowed: isShadowed,
@@ -286,7 +286,7 @@ private extension MessagePayload {
             isFlaggedByCurrentUser: false,
             latestReactions: [],
             currentUserReactions: [],
-            isSentByCurrentUser: false,
+            isSentByCurrentUser: user.id == currentUser?.user.id,
             pinDetails: nil,
             translations: nil,
             originalLanguage: originalLanguage.map { TranslationLanguage(languageCode: $0) },

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -24,6 +24,7 @@ open class ChatThreadVC: _ViewController,
     public var initialReplyId: MessageId?
 
     /// Controller for observing typing events for this thread.
+    @available(*, deprecated, message: "Events are now handled by the `eventsController`.")
     open lazy var channelEventsController: ChannelEventsController = client.channelEventsController(for: messageController.cid)
 
     /// A controller for observing web socket events.
@@ -123,7 +124,6 @@ open class ChatThreadVC: _ViewController,
         }
 
         messageController.delegate = self
-        channelEventsController.delegate = self
         eventsController.delegate = self
 
         messageListVC.swipeToReplyGestureHandler.onReply = { [weak self] message in

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -198,8 +198,9 @@ class DatabaseSession_Mock: DatabaseSession {
         underlyingSession.unpin(message: message)
     }
 
+    var mockedMessageDTO: MessageDTO?
     func message(id: MessageId) -> MessageDTO? {
-        underlyingSession.message(id: id)
+        mockedMessageDTO ?? underlyingSession.message(id: id)
     }
 
     func messageExists(id: MessageId) -> Bool {
@@ -297,9 +298,10 @@ class DatabaseSession_Mock: DatabaseSession {
         try throwErrorIfNeeded()
         return try underlyingSession.saveChannel(payload: payload, query: query, cache: cache)
     }
-    
+
+    var mockedChannelDTO: ChannelDTO?
     func channel(cid: ChannelId) -> ChannelDTO? {
-        underlyingSession.channel(cid: cid)
+        mockedChannelDTO ?? underlyingSession.channel(cid: cid)
     }
 
     func saveMember(

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -198,9 +198,8 @@ class DatabaseSession_Mock: DatabaseSession {
         underlyingSession.unpin(message: message)
     }
 
-    var mockedMessageDTO: MessageDTO?
     func message(id: MessageId) -> MessageDTO? {
-        mockedMessageDTO ?? underlyingSession.message(id: id)
+        underlyingSession.message(id: id)
     }
 
     func messageExists(id: MessageId) -> Bool {
@@ -299,9 +298,8 @@ class DatabaseSession_Mock: DatabaseSession {
         return try underlyingSession.saveChannel(payload: payload, query: query, cache: cache)
     }
 
-    var mockedChannelDTO: ChannelDTO?
     func channel(cid: ChannelId) -> ChannelDTO? {
-        mockedChannelDTO ?? underlyingSession.channel(cid: cid)
+        underlyingSession.channel(cid: cid)
     }
 
     func saveMember(

--- a/Tests/StreamChatTests/WebSocketClient/Events/MessageEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/MessageEvents_Tests.swift
@@ -82,6 +82,34 @@ final class MessageEvents_Tests: XCTestCase {
         XCTAssertEqual(event?.hardDelete, true)
     }
 
+    func test_messageDeletedEvent_toDomainEvent_thenIsMessageDeletedEvent() throws {
+        let json = XCTestCase.mockData(fromJSONFile: "MessageDeleted")
+        let event = try eventDecoder.decode(from: json) as? MessageDeletedEventDTO
+
+        let channelId = try XCTUnwrap(event?.cid)
+        let message = try XCTUnwrap(event?.message)
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
+        _ = try session.saveChannel(payload: .dummy(cid: channelId), query: nil, cache: nil)
+        _ = try session.saveMessage(payload: message, for: channelId, cache: nil)
+
+        let domainEvent = event?.toDomainEvent(session: session)
+        XCTAssertEqual(domainEvent is MessageDeletedEvent, true)
+    }
+
+    func test_messageDeletedEvent_toDomainEvent_whenIsHardDeleted_thenIsMessageHardDeletedEvent() throws {
+        let json = XCTestCase.mockData(fromJSONFile: "MessageDeletedHard")
+        let event = try eventDecoder.decode(from: json) as? MessageDeletedEventDTO
+
+        let channelId = try XCTUnwrap(event?.cid)
+        let message = try XCTUnwrap(event?.message)
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
+        _ = try session.saveChannel(payload: .dummy(cid: channelId), query: nil, cache: nil)
+        _ = try session.saveMessage(payload: message, for: channelId, cache: nil)
+
+        let domainEvent = event?.toDomainEvent(session: session)
+        XCTAssertEqual(domainEvent is MessageHardDeletedEvent, true)
+    }
+
     func test_read() throws {
         let json = XCTestCase.mockData(fromJSONFile: "MessageRead")
         let event = try eventDecoder.decode(from: json) as? MessageReadEventDTO


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://linear.app/stream/issue/IOS-282/hard-delete-on-a-root-message-from-a-thread-is-broken

### 🎯 Goal

Fix the Thread not dismissing when the root message is hard deleted.

### 🛠 Implementation

I've decided to implement this on the Demo App since hard deleting is an action that only exists on the Demo App. Usually, we do not advertise the feature much since it is not recommended.

Besides that, the logic will most likely differ depending on the app. So this is mostly app logic and not SDK logic.

Either way, while doing this, I spotted some bugs:
- The `ChatThreadVC.didReceiveEvent` delegate was always being called twice. This was due to the fact that we had `channelEventsController` and `eventsController` assigning both delegates to the `ChatThreadVC`
- The `MessageDeletedEvent` was not being surfaced to the `didReceiveEvent` delegate. This only happened for the hard deleted message, and the reason is that this event requires a `message: ChatMessage` property. But, since the mesasge is hard deleted, it also does not exist in CoreData, so we can't provide the whole message, only the ID. For this reason, I created a new event `MessageHardDeletedEvent` and deprecated the `MessageDeletedEvent.isHardDeleted` property. This was the only option to avoid breaking changes.

**UPDATE:** In order to avoid creating a new `MessageHardDeletedEvent`, and diverge from the other SDKs, we decided to map the message payload directly to the model so that the `MessageDeletedEvent.message` is present.

### 🧪 Manual Testing Notes

#### Dismissing Thread
1. Create / Open a Thread
2. Hard delete the root message inside a thread
3. Should dismiss the view

#### Hard Deleting Thread from Channel
1. Create a Thread
2. Send a reply also in channel
3. Go back to the Channel
4. Hard delete the root thread
5. Should delete the thread and replies also in channel

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
