### PR TITLE
Fix missing final attributes for supplementary views exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix thread reply action shown when inside a Thread [#3561](https://github.com/GetStream/stream-chat-swift/pull/3561)
 - Fix reaction author's view with shrinked reaction images in iOS 18 [#3568](https://github.com/GetStream/stream-chat-swift/pull/3568)
+- Fix missing final attributes for supplementary views exception [#3570](https://github.com/GetStream/stream-chat-swift/pull/3570)
 
 # [4.70.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.70.0)
 _January 14, 2025_


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-667](https://linear.app/stream/issue/IOS-667)

### 🎯 Goal

Fix exception of missing final attributes for supplementary view in the `ListCollectionViewLayout`

<img width="1202" alt="Screenshot 2025-01-27 at 14 47 05" src="https://github.com/user-attachments/assets/5cd06e4a-a7a1-4686-81e7-e59e47d517d9" />

### 📝 Summary

* Provide `layoutAttributesForSupplementaryView(ofKind:at:)` implementation

### 🛠 Implementation

While looking at the exception the only idea I have is that could implementing `layoutAttributesForSupplementaryView(ofKind:at:)` help to resolve it. 
[layoutAttributesForSupplementaryView(ofKind:at:)](https://developer.apple.com/documentation/uikit/uicollectionviewlayout/layoutattributesforsupplementaryview(ofkind:at:)) documentation:
> If your layout object defines any supplementary views, you must override this method and use it to return layout information for those views.

I have not been able to reproduce this and therefore hard to know exactly why this happens.

### 🎨 Showcase

### 🧪 Manual Testing Notes

Open channel list, scroll to load more channels
Result: separator lines area always rendered correctly

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
