### PR TITLE
Do not ignore bundle when creating ChatClient mock

### DIFF
--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -141,6 +141,7 @@ extension ChatClient {
                 databaseContainerBuilder: {
                     DatabaseContainer_Spy(
                         kind: $0,
+                        bundle: bundle,
                         chatClientConfig: $1
                     )
                 },


### PR DESCRIPTION
[IOS-682](https://linear.app/stream/issue/IOS-682/pass-bundle-into-databasecontainer-spy-in-streamchattesttools)

### 🎯 Goal

Allow passing in bundle when creating mocked ChatClient

### 📝 Summary

* Other modules need to pass in different bundles for loading the Core Data model

### 🛠 Implementation

### 🎨 Showcase

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
