### PR TITLE
Add sending messages to only specific members

### DIFF
--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -570,6 +570,16 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     channelController.createNewMessage(text: message, skipPush: true)
                 }
             }),
+            .init(title: "Say Hi to a specific member", isEnabled: canSendMessage, handler: { [unowned self] _ in
+                self.rootViewController.presentAlert(title: "Enter the channel member id", textFieldPlaceholder: "Send message") { userId in
+                    guard let userId, !userId.isEmpty,
+                          channelController.channel?.lastActiveMembers.map(\.id).contains(userId) == true else {
+                        self.rootViewController.presentAlert(title: "user id is not valid")
+                        return
+                    }
+                    channelController.createNewMessage(text: "Hi", restrictedVisibility: [userId])
+                }
+            }),
             .init(title: "Send system message", isEnabled: canSendMessage, handler: { [unowned self] _ in
                 self.rootViewController.presentAlert(title: "Enter the message text", textFieldPlaceholder: "Send message") { message in
                     guard let message = message, !message.isEmpty else {

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -49,6 +49,7 @@ enum MessagePayloadsCodingKeys: String, CodingKey, CaseIterable {
     case set
     case unset
     case skipEnrichUrl = "skip_enrich_url"
+    case restrictedVisibility = "restricted_visibility"
 }
 
 extension MessagePayload {
@@ -272,6 +273,7 @@ struct MessageRequestBody: Encodable {
     var pinned: Bool
     var pinExpires: Date?
     var pollId: String?
+    var restrictedVisibility: [UserId]?
     let extraData: [String: RawJSON]
 
     init(
@@ -290,6 +292,7 @@ struct MessageRequestBody: Encodable {
         pinned: Bool = false,
         pinExpires: Date? = nil,
         pollId: String? = nil,
+        restrictedVisibility: [UserId]? = nil,
         extraData: [String: RawJSON]
     ) {
         self.id = id
@@ -307,6 +310,7 @@ struct MessageRequestBody: Encodable {
         self.pinned = pinned
         self.pinExpires = pinExpires
         self.pollId = pollId
+        self.restrictedVisibility = restrictedVisibility
         self.extraData = extraData
     }
 
@@ -324,6 +328,7 @@ struct MessageRequestBody: Encodable {
         try container.encode(isSilent, forKey: .isSilent)
         try container.encodeIfPresent(pollId, forKey: .pollId)
         try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(restrictedVisibility, forKey: .restrictedVisibility)
 
         if !attachments.isEmpty {
             try container.encode(attachments, forKey: .attachments)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -747,6 +747,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - skipPush: If true, skips sending push notification to channel members.
     ///   - skipEnrichUrl: If true, the url preview won't be attached to the message.
+    ///   - restrictedVisibility: The list of user ids that should be able to see the message.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -760,6 +761,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         quotedMessageId: MessageId? = nil,
         skipPush: Bool = false,
         skipEnrichUrl: Bool = false,
+        restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -782,6 +784,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             quotedMessageId: quotedMessageId,
             skipPush: skipPush,
             skipEnrichUrl: skipEnrichUrl,
+            restrictedVisibility: restrictedVisibility,
             extraData: transformableInfo.extraData,
             poll: nil,
             completion: completion
@@ -1432,6 +1435,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         quotedMessageId: MessageId? = nil,
         skipPush: Bool = false,
         skipEnrichUrl: Bool = false,
+        restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON] = [:],
         poll: PollPayload?,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -1461,6 +1465,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             quotedMessageId: quotedMessageId,
             skipPush: skipPush,
             skipEnrichUrl: skipEnrichUrl,
+            restrictedVisibility: restrictedVisibility,
             poll: poll,
             extraData: extraData
         ) { result in

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -92,6 +92,8 @@ class MessageDTO: NSManagedObject {
     ///
     /// For messages authored NOT by the current user this field is always empty.
     @NSManaged var reads: Set<ChannelReadDTO>
+    
+    @NSManaged var restrictedVisibility: Set<String>?
 
     @NSManaged var pinned: Bool
     @NSManaged var pinnedBy: UserDTO?
@@ -647,6 +649,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         skipPush: Bool,
         skipEnrichUrl: Bool,
         poll: PollPayload?,
+        restrictedVisibility: [UserId],
         extraData: [String: RawJSON]
     ) throws -> MessageDTO {
         guard let currentUserDTO = currentUser else {
@@ -686,6 +689,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         message.reactionScores = [:]
         message.reactionCounts = [:]
         message.reactionGroups = []
+        message.restrictedVisibility = Set(restrictedVisibility)
 
         // Message type
         if parentMessageId != nil {
@@ -1301,6 +1305,11 @@ extension MessageDTO {
 
         // At the moment, we only provide the type for system messages when creating a message.
         let systemType = type == MessageType.system.rawValue ? type : nil
+        
+        var restrictedVisibilityArray: [UserId]?
+        if let restrictedVisibility {
+            restrictedVisibilityArray = Array(restrictedVisibility)
+        }
 
         return .init(
             id: id,
@@ -1318,6 +1327,7 @@ extension MessageDTO {
             pinned: pinned,
             pinExpires: pinExpires?.bridgeDate,
             pollId: poll?.id,
+            restrictedVisibility: restrictedVisibilityArray,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -104,6 +104,7 @@ protocol MessageDatabaseSession {
         skipPush: Bool,
         skipEnrichUrl: Bool,
         poll: PollPayload?,
+        restrictedVisibility: [UserId],
         extraData: [String: RawJSON]
     ) throws -> MessageDTO
 
@@ -246,6 +247,7 @@ extension MessageDatabaseSession {
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         pollPayload: PollPayload? = nil,
+        restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON] = [:]
     ) throws -> MessageDTO {
         try createNewMessage(
@@ -266,6 +268,7 @@ extension MessageDatabaseSession {
             skipPush: skipPush,
             skipEnrichUrl: skipEnrichUrl,
             poll: pollPayload,
+            restrictedVisibility: restrictedVisibility,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24A348" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -227,6 +227,7 @@
         <attribute name="reactionCounts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="reactionScores" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="replyCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictedVisibility" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
         <attribute name="showInsideThread" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="showReplyInChannel" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="skipEnrichUrl" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -308,6 +308,7 @@ class ChannelUpdater: Worker {
         quotedMessageId: MessageId?,
         skipPush: Bool,
         skipEnrichUrl: Bool,
+        restrictedVisibility: [UserId] = [],
         poll: PollPayload? = nil,
         extraData: [String: RawJSON],
         completion: ((Result<ChatMessage, Error>) -> Void)? = nil
@@ -332,6 +333,7 @@ class ChannelUpdater: Worker {
                 skipPush: skipPush,
                 skipEnrichUrl: skipEnrichUrl,
                 poll: poll,
+                restrictedVisibility: restrictedVisibility,
                 extraData: extraData
             )
             if quotedMessageId != nil {

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -236,6 +236,7 @@ class MessageUpdater: Worker {
                 skipPush: skipPush,
                 skipEnrichUrl: skipEnrichUrl,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: extraData
             )
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ChatChannelController_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ChatChannelController_Mock.swift
@@ -65,6 +65,7 @@ class ChatChannelController_Mock: ChatChannelController {
         quotedMessageId: MessageId? = nil,
         skipPush: Bool = false,
         skipEnrichUrl: Bool = false,
+        restrictedVisibility: [UserId] = [],
         extraData: [String : RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -140,6 +140,7 @@ class DatabaseSession_Mock: DatabaseSession {
         skipPush: Bool,
         skipEnrichUrl: Bool,
         poll: PollPayload?,
+        restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON]
     ) throws -> MessageDTO {
         try throwErrorIfNeeded()
@@ -162,6 +163,7 @@ class DatabaseSession_Mock: DatabaseSession {
             skipPush: skipPush,
             skipEnrichUrl: skipEnrichUrl, 
             poll: poll,
+            restrictedVisibility: restrictedVisibility,
             extraData: extraData
         )
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -353,6 +353,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         quotedMessageId: MessageId?,
         skipPush: Bool,
         skipEnrichUrl: Bool,
+        restrictedVisibility: [UserId] = [],
         poll: PollPayload?,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<ChatMessage, Error>) -> Void)? = nil

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -155,6 +155,7 @@ final class MessageRequestBody_Tests: XCTestCase {
             mentionedUserIds: [.unique],
             pinned: true,
             pinExpires: "2021-05-15T06:43:08.776Z".toDate(),
+            restrictedVisibility: ["test"],
             extraData: ["secret_note": .string("Anakin is Vader ;-)")]
         )
 
@@ -171,7 +172,8 @@ final class MessageRequestBody_Tests: XCTestCase {
             "secret_note": "Anakin is Vader ;-)",
             "command": payload.command!,
             "pinned": true,
-            "pin_expires": "2021-05-15T06:43:08.776Z"
+            "pin_expires": "2021-05-15T06:43:08.776Z",
+            "restricted_visibility": ["test"]
         ]
         let expectedJSON = try JSONSerialization.data(withJSONObject: expected, options: [])
         AssertJSONEqual(serializedJSON, expectedJSON)

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -954,6 +954,7 @@ final class ChannelController_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
             // Simulate sending failed for this message

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -1201,6 +1201,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: messageExtraData
             )
 
@@ -1290,6 +1291,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
         }
@@ -1394,6 +1396,7 @@ final class MessageDTO_Tests: XCTestCase {
                     skipPush: false,
                     skipEnrichUrl: false,
                     poll: nil,
+                    restrictedVisibility: [],
                     extraData: [:]
                 )
                 message1Id = message1DTO.id
@@ -1418,6 +1421,7 @@ final class MessageDTO_Tests: XCTestCase {
                     skipPush: false,
                     skipEnrichUrl: false,
                     poll: nil,
+                    restrictedVisibility: [],
                     extraData: [:]
                 )
                 // Reset the `locallyCreateAt` value of the second message to simulate the message was sent
@@ -1561,6 +1565,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: true,
                 skipEnrichUrl: true,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
             newMessageId = messageDTO.id
@@ -1632,6 +1637,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: true,
                 skipEnrichUrl: true,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
             newMessageId = messageDTO.id
@@ -1682,6 +1688,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
             messageId = messageDTO.id
@@ -1729,6 +1736,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
             threadReplyId = replyShownInChannelDTO.id
@@ -1789,6 +1797,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
         }
@@ -1818,6 +1827,7 @@ final class MessageDTO_Tests: XCTestCase {
                     skipPush: false,
                     skipEnrichUrl: false,
                     poll: nil,
+                    restrictedVisibility: [],
                     extraData: [:]
                 )
             }, completion: completion)
@@ -1861,6 +1871,7 @@ final class MessageDTO_Tests: XCTestCase {
                     skipPush: false,
                     skipEnrichUrl: false,
                     poll: nil,
+                    restrictedVisibility: [],
                     extraData: [:]
                 )
             }, completion: completion)
@@ -1950,6 +1961,7 @@ final class MessageDTO_Tests: XCTestCase {
                 skipPush: false,
                 skipEnrichUrl: false,
                 poll: nil,
+                restrictedVisibility: [],
                 extraData: [:]
             )
             // Get reply messageId


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-688/private-messages-sdk-support.

### 🎯 Goal

Allow sending messages only to a specific member of a channel.

### 📝 Summary

Exposed new property that's available to support this feature.

Important note: there's a bug on the backend for our filter, so the message appears in the channel list for other members. This is being currently addressed by the backend team, and we should wait before merging. 

### 🛠 Implementation

Just exposes a new field.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

There's a new action in the channel, "Say Hi to a specific member". You need to enter a valid member id and verify that only that member received the message in the channel.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
