### PR TITLE
Fix message transformer not being applied when editing a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Update channel's preview message when coming back to online [#3574](https://github.com/GetStream/stream-chat-swift/pull/3574)
+- Fix message transformer not being applied when editing a message [#3602](https://github.com/GetStream/stream-chat-swift/pull/3602)
 ### 🔄 Changed
 
 # [4.72.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.72.0)

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -259,12 +259,21 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
         extraData: [String: RawJSON]? = nil,
         completion: ((Error?) -> Void)? = nil
     ) {
+        var transformableInfo = NewMessageTransformableInfo(
+            text: text,
+            attachments: attachments,
+            extraData: extraData ?? message?.extraData ?? [:]
+        )
+        if let transformer = client.config.modelsTransformer {
+            transformableInfo = transformer.transform(newMessageInfo: transformableInfo)
+        }
+
         messageUpdater.editMessage(
             messageId: messageId,
-            text: text,
+            text: transformableInfo.text,
             skipEnrichUrl: skipEnrichUrl,
-            attachments: attachments,
-            extraData: extraData
+            attachments: transformableInfo.attachments,
+            extraData: transformableInfo.extraData
         ) { result in
             self.callback {
                 completion?(result.error)


### PR DESCRIPTION
### 🔗 Issue Links
IOS-709

### 🎯 Goal

Fix the message transformer not being applied when editing a message.

### 🧪 Manual Testing Notes

N/A. Covered by unit tests.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
