### PR TITLE
Fix default channel list sorting by replacing updated_at with last_updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `Fonts.title2` for supporting markdown headers [#3590](https://github.com/GetStream/stream-chat-swift/pull/3590)
 ### 🐞 Fixed
 - Fix background task warning by making task tracking thread-safe [#3604](https://github.com/GetStream/stream-chat-swift/pull/3604)
+- Fix the order of channels when using `ChannelListSortingKey.default` [3615](https://github.com/GetStream/stream-chat-swift/pull/3615)
 
 ### StreamChatUI
 ### 🔄 Changed

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -203,7 +203,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
 
     /// Filter for the time of the last message in the channel. If the channel has no messages, then the time the channel was created.
     /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`
-    static var lastUpdatedAt: FilterKey<Scope, Date> { .init(rawValue: "last_updated", keyPathString: #keyPath(ChannelDTO.lastMessageAt)) }
+    static var lastUpdatedAt: FilterKey<Scope, Date> { .init(rawValue: "last_updated", keyPathString: #keyPath(ChannelDTO.defaultSortingAt)) }
 }
 
 /// Internal filter queries for the channel list.

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -6,11 +6,11 @@ import Foundation
 
 /// `ChannelListSortingKey` is keys by which you can get sorted channels after query.
 public struct ChannelListSortingKey: SortingKey, Equatable {
-    /// The default sorting is by the last massage date or a channel created date. The same as by `updatedDate`.
+    /// The default sorting is by the last message date or a channel created date if no messages.
     public static let `default` = Self(
         keyPath: \.defaultSortingAt,
         localKey: #keyPath(ChannelDTO.defaultSortingAt),
-        remoteKey: ChannelCodingKeys.updatedAt.rawValue
+        remoteKey: "last_updated"
     )
 
     /// Sort channels by date they were created.

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -1004,7 +1004,7 @@ final class ChannelDTO_Tests: XCTestCase {
         let encoder = JSONEncoder.stream
 
         var channelListSortingKey = ChannelListSortingKey.default
-        XCTAssertEqual(encoder.encodedString(channelListSortingKey), "updated_at")
+        XCTAssertEqual(encoder.encodedString(channelListSortingKey), "last_updated")
         XCTAssertEqual(
             channelListSortingKey.sortDescriptor(isAscending: true),
             NSSortDescriptor(key: "defaultSortingAt", ascending: true)

--- a/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
@@ -55,7 +55,7 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         XCTAssertEqual(Key<TeamId>.team.keyPathString, "team")
         XCTAssertEqual(Key<UserId>.members.keyPathString, "members.user.id")
         XCTAssertEqual(Key<String>.memberName.keyPathString, "members.user.name")
-        XCTAssertEqual(Key<Date>.lastUpdatedAt.keyPathString, "lastMessageAt")
+        XCTAssertEqual(Key<Date>.lastUpdatedAt.keyPathString, "defaultSortingAt")
         XCTAssertEqual(Key<Bool>.joined.keyPathString, "membership")
         XCTAssertEqual(Key<Bool>.muted.keyPathString, "mute")
         XCTAssertEqual(Key<Bool>.archived.keyPathString, "membership.archivedAt")

--- a/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
@@ -31,7 +31,7 @@ final class ChannelListSortingKey_Tests: XCTestCase {
                     key.localKey,
                     NSExpression(forKeyPath: \ChannelDTO.defaultSortingAt).keyPath
                 )
-                XCTAssertEqual(key.remoteKey, "updated_at")
+                XCTAssertEqual(key.remoteKey, "last_updated")
                 XCTAssertFalse(key.requiresRuntimeSorting)
             case .createdAt:
                 XCTAssertNotNil(key.sortDescriptor(isAscending: true))


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-687](https://linear.app/stream/issue/IOS-687)

### 🎯 Goal

Fix the issue where reordering happens when paginating with `ChannelListSortingKey.default`

### 📝 Summary

* Turns out that we use incorrect remote key

### 🛠 Implementation

The default sorting key backend uses is [last_updated](https://getstream.io/chat/docs/ios-swift/query_channels/), not `updated_at`. This caused reordering issues because channel list backend returns has different order.

### 🎨 Showcase

Note how channels reorder when pagination happens.

| Before | After |
| ------ | ----- |
|  ![img](https://github.com/user-attachments/assets/de4010da-45cf-43e6-81c7-c5858a460222)   |  ![img](https://github.com/user-attachments/assets/08d9e2e0-f111-4b13-9993-1ca8215799be)  |

### 🧪 Manual Testing Notes

Demo app sorts by pinned state and then uses default sorting (last message at or created at).

1. Create a new channel
Result: Channel appears at the top (after pinned)

1. One of the old channels receives a message
Result: Channel moves to the top (after pinned)

1. Log in and paginate channels
Result: Reordering does not happen while paginating

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
