### PR TITLE
Access UIApplication on demand in IOSBackgroundTaskScheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix draft local attachments erased when the draft updated event is triggered [#3625](https://github.com/GetStream/stream-chat-swift/pull/3625)
+- Fix background tasks not running in `IOSBackgroundTaskScheduler` sometimes [#3628](https://github.com/GetStream/stream-chat-swift/pull/3628)
 
 ### StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/WebSocketClient/BackgroundTaskScheduler.swift
+++ b/Sources/StreamChat/WebSocketClient/BackgroundTaskScheduler.swift
@@ -24,7 +24,7 @@ protocol BackgroundTaskScheduler {
 import UIKit
 
 class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
-    private let app: UIApplication? = {
+    private lazy var app: UIApplication? = {
         // We can't use `UIApplication.shared` directly because there's no way to convince the compiler
         // this code is accessible only for non-extension executables.
         UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
@@ -35,7 +35,6 @@ class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
     private let queue = DispatchQueue(label: "io.getstream.IOSBackgroundTaskScheduler", target: .global())
 
     var isAppActive: Bool {
-        let app = self.app
         if Thread.isMainThread {
             return app?.applicationState == .active
         }
@@ -44,7 +43,7 @@ class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
         let group = DispatchGroup()
         group.enter()
         DispatchQueue.main.async {
-            isActive = app?.applicationState == .active
+            isActive = self.app?.applicationState == .active
             group.leave()
         }
         group.wait()


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-653/

### 🎯 Goal

* Revert UIApplication accessor to use lazy var

### 📝 Summary

We got a report that `IOSBackgroundTaskScheduler` has app property nil sometimes. It was changed in 4.74.0 from lazy var to let. I'll revert that change (can't reproduce this myself)

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
