### PR TITLE
Expose canSendPoll capability and handle it in the Composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add `ChatChannelController.deletePoll()` for deleting polls [#3632](https://github.com/GetStream/stream-chat-swift/pull/3632)
+- Add `ChatChannel.canSendPoll` capability [#3635](https://github.com/GetStream/stream-chat-swift/pull/3635)
+- Add `ChatChannel.canCastPollVote` capability [#3635](https://github.com/GetStream/stream-chat-swift/pull/3635)
+
+## StreamChatUI
+### 🐞 Fixed
+- Fix showing Create Poll action in the composer if the user does not have the capability [#3635](https://github.com/GetStream/stream-chat-swift/pull/3635)
 
 # [4.76.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.76.0)
 _March 31, 2025_

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -426,6 +426,10 @@ public struct ChannelCapability: RawRepresentable, ExpressibleByStringLiteral, H
     public static let joinCall: Self = "join-call"
     /// Ability to create a call.
     public static let createCall: Self = "create-call"
+    /// Ability to send a poll.
+    public static let sendPoll: Self = "send-poll"
+    /// Ability to cast a poll vote.
+    public static let castPollVote: Self = "cast-poll-vote"
 }
 
 public extension ChatChannel {
@@ -572,5 +576,15 @@ public extension ChatChannel {
     /// Is slow mode active in this channel.
     var isSlowMode: Bool {
         ownCapabilities.contains(.slowMode)
+    }
+
+    /// Can the current user send a poll in this channel.
+    var canSendPoll: Bool {
+        ownCapabilities.contains(.sendPoll)
+    }
+
+    /// Can the current user cast a poll vote in this channel.
+    var canCastPollVote: Bool {
+        ownCapabilities.contains(.castPollVote)
     }
 }

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -876,7 +876,7 @@ open class ComposerVC: _ViewController,
     /// Returns actions for attachments picker.
     open var attachmentsPickerActions: [UIAlertAction] {
         let isCameraAvailable = UIImagePickerController.isSourceTypeAvailable(.camera)
-        let isPollCreationEnabled = channelConfig?.pollsEnabled == true
+        let isPollCreationEnabled = channelConfig?.pollsEnabled == true && channelController?.channel?.canSendPoll == true
 
         let showFilePickerAction = UIAlertAction(
             title: L10n.Composer.Picker.file,

--- a/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
+++ b/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
@@ -285,6 +285,22 @@ final class ChatChannel_Tests: XCTestCase {
         XCTAssertEqual(channelWithoutCapability.isSlowMode, false)
     }
 
+    func test_canSendPoll() throws {
+        let channel = setupChannel(withCapabilities: [.sendPoll])
+        XCTAssertEqual(channel.canSendPoll, true)
+
+        let channelWithoutCapability = setupChannel(withCapabilities: [])
+        XCTAssertEqual(channelWithoutCapability.canSendPoll, false)
+    }
+
+    func test_canCastPollVote() throws {
+        let channel = setupChannel(withCapabilities: [.castPollVote])
+        XCTAssertEqual(channel.canCastPollVote, true)
+
+        let channelWithoutCapability = setupChannel(withCapabilities: [])
+        XCTAssertEqual(channelWithoutCapability.canCastPollVote, false)
+    }
+
     func test_lastReadMessageId_readsDontContainUser() {
         let userId: UserId = "current"
         let channel = ChatChannel.mock(cid: .unique, reads: [


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-728/polls-capability-handling

### 🎯 Goal

Expose the `channel.canSendPoll` capability and don't show Poll Creation in the composer.

Bonus: Also exposed `channel.canCastPollVote`. No UI was changed for this capability since there is no Official UI for this at the moment.

Next Step: SwiftUI

### 🧪 Manual Testing Notes

1. Open the Stream Dashboard
2. Disable poll ability in a channel
3. When opening the attachments, actions
4. Should not show poll creation

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
