### PR TITLE
Fix not able to send images with floating point numbers in the original size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix showing Create Poll action in the composer if the user does not have the capability [#3635](https://github.com/GetStream/stream-chat-swift/pull/3635)
+- Fix error when send images with floating point numbers in the original size [#3636](https://github.com/GetStream/stream-chat-swift/pull/3636)
 
 # [4.76.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.76.0)
 _March 31, 2025_

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1458,9 +1458,12 @@ open class ComposerVC: _ViewController,
 
         var localMetadata = AnyAttachmentLocalMetadata()
         if let image = info[.originalImage] as? UIImage {
+            // At the moment the backend is not accepting floating numbers.
+            // So we round down the width and height. We do not round up
+            // to make sure there is no empty space in the image.
             localMetadata.originalResolution = (
-                width: Double(image.size.width),
-                height: Double(image.size.height)
+                width: Double(image.size.width).rounded(.down),
+                height: Double(image.size.height).rounded(.down)
             )
         }
 


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-699/[uikit]-image-uploading-fails-if-copy-pasted-from-the-app

### 🎯 Goal

Fix not able to send images with floating point numbers in the original size.

### 🛠 Implementation

When pasting images with sizes that are not integers, the backend fails to accept them. 

Ideally, the backend should support this, but until then, we can round down the images that have floating-point numbers.

### 🧪 Manual Testing Notes

1. Open a Channel
2. Send a random image
3. Tap on the image
4. Tap on the left bottom icon (Share Icon)
5. Tap on Copy
6. Go to the composer
7. Paste the Photo
8. Publish the message
9. Should not error

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
