### PR TITLE
Do not touch layoutManager in the Demo App by default to improve performance when opening channel

### DIFF
--- a/DemoApp/StreamChat/Components/CustomAttachments/DemoComposerVC.swift
+++ b/DemoApp/StreamChat/Components/CustomAttachments/DemoComposerVC.swift
@@ -54,3 +54,25 @@ class DemoComposerVC: ComposerVC {
 //        )])
     }
 }
+
+class DemoInputTextView: InputTextView {
+    override func setUpAppearance() {
+        backgroundColor = .clear
+        textContainer.lineFragmentPadding = 8
+        font = appearance.fonts.body
+        textColor = appearance.colorPalette.text
+        textAlignment = .natural
+        adjustsFontForContentSizeCategory = true
+
+        // Calling the layoutManager in debug builds loads a dynamic lib
+        // Which causes a big performance penalty. So in our Demo App
+        // we avoid the performance penalty, unless it is using the our internal scheme.
+        if StreamRuntimeCheck.isStreamInternalConfiguration {
+            layoutManager.allowsNonContiguousLayout = false
+        }
+
+        placeholderLabel.font = font
+        placeholderLabel.textColor = appearance.colorPalette.subtitleText
+        placeholderLabel.adjustsFontSizeToFitWidth = true
+    }
+}

--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -57,6 +57,7 @@ extension StreamChatWrapper {
         Components.default.messageListVC = DemoChatMessageListVC.self
         Components.default.quotedMessageView = DemoQuotedChatMessageView.self
         Components.default.messageComposerVC = DemoComposerVC.self
+        Components.default.inputTextView = DemoInputTextView.self
         Components.default.channelContentView = DemoChatChannelListItemView.self
         Components.default.channelListRouter = DemoChatChannelListRouter.self
         Components.default.channelVC = DemoChatChannelVC.self

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -142,7 +142,10 @@ open class InputTextView: UITextView, ThemeProvider {
         textAlignment = .natural
         adjustsFontForContentSizeCategory = true
 
-        // This makes scrollToCaretPosition() more precise.
+        // This makes scrollToCaretPosition() more precise. When writing multiple lines fast
+        // in the composer, the caret position should remain in the last character.
+        // Without this the composer jumps a lot into different character positions.
+        //
         // This should be disabled by default according to Apple, but in some iOS versions is not.
         // Reference: https://stackoverflow.com/a/48602171/5493299
         layoutManager.allowsNonContiguousLayout = false


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-769/[uikit]-improve-performance-of-the-first-channel-view-open

### 🎯 Goal

Do not give the impression to customers that opening a channel is slow.

### 📝 Summary

When accessing the `UITextView.layoutManager` in the `InputTextView`, it triggers loading a dynamic lib (Most likely TextKit 1), which causes a small freeze when opening the channel. This only happens on Debug builds, but when customers use our Demo App, they might think it is slow opening a channel, which in fact it is not.

Accessing the layoutManager and calling `allowsNonContiguousLayout = false` is necessary, otherwise it will cause imprecise scrolling in the Composer as we can see in the Showcase section.

### 🛠 Implementation

Now, in the Demo App, using the default scheme, we do not call the layout manager. For this, we use a custom `InputTextView` and re-implement the `setUpApperance()` method.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before allowsNonContiguousLayout | After allowsNonContiguousLayout |
| ------ | ----- |
|  <video src="https://github.com/user-attachments/assets/b8a42919-81ef-4f91-a2b4-336f57ff64e3"/>   |   <video src="https://github.com/user-attachments/assets/c70891c2-0054-4dfa-80c4-d0f19e78f619"/>   |


### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
