### PR TITLE
Fix `unsetProperties` not having any effect in `CurrentUserController.updateUserData()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix `FilterKey.id` not returning any channels in `ChannelListQuery` [#3643](https://github.com/GetStream/stream-chat-swift/pull/3643)
 - Fix incorrect channel list sorting when sorted by `.hasUnread` [#3646](https://github.com/GetStream/stream-chat-swift/pull/3646)
+- Fix `unsetProperties` not having any effect in `CurrentUserController.updateUserData()` [#3650](https://github.com/GetStream/stream-chat-swift/pull/3650)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `FilterKey.id` not returning any channels in `ChannelListQuery` [#3643](https://github.com/GetStream/stream-chat-swift/pull/3643)
 - Fix incorrect channel list sorting when sorted by `.hasUnread` [#3646](https://github.com/GetStream/stream-chat-swift/pull/3646)
 - Fix `unsetProperties` not having any effect in `CurrentUserController.updateUserData()` [#3650](https://github.com/GetStream/stream-chat-swift/pull/3650)
+### 🔄 Changed
+- Change the `teamsRole` parameter from `[String: String]` to `[TeamId: UserRole]` [#3650](https://github.com/GetStream/stream-chat-swift/pull/3650)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -661,7 +661,8 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
             .init(title: "Add a team role for the current user", isEnabled: true, handler: { [unowned self] _ in
                 self.rootViewController.presentAlert(title: "Enter the team role", textFieldPlaceholder: "Enter role") { role in
                     if let role, !role.isEmpty {
-                        client.currentUserController().updateUserData(teamsRole: ["ios": role]) { error in
+                        let userRole = UserRole(rawValue: role)
+                        client.currentUserController().updateUserData(teamsRole: ["ios": userRole]) { error in
                             if let error {
                                 log.error("Couldn't add role to custom team for the current user: \(error)")
                             }

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -651,18 +651,12 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                 }
             }),
             .init(title: "Reset User Image", handler: { [unowned self] _ in
-                do {
-                    let connectedUser = try self.rootViewController.controller.client.makeConnectedUser()
-                    Task {
-                        do {
-                            try await connectedUser.update(unset: ["image"])
-                        } catch {
+                channelController.client.currentUserController()
+                    .updateUserData(unsetProperties: ["image"]) { [unowned self] error in
+                        if let error {
                             self.rootViewController.presentAlert(title: error.localizedDescription)
                         }
                     }
-                } catch {
-                    self.rootViewController.presentAlert(title: error.localizedDescription)
-                }
             }),
             .init(title: "Add a team role for the current user", isEnabled: true, handler: { [unowned self] _ in
                 self.rootViewController.presentAlert(title: "Enter the team role", textFieldPlaceholder: "Enter role") { role in

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/UserPayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/UserPayloads.swift
@@ -173,14 +173,14 @@ struct UserUpdateRequestBody: Encodable {
     let privacySettings: UserPrivacySettingsPayload?
     let role: UserRole?
     let extraData: [String: RawJSON]?
-    let teamsRole: [String: String]?
+    let teamsRole: [TeamId: UserRole]?
 
     init(
         name: String?,
         imageURL: URL?,
         privacySettings: UserPrivacySettingsPayload?,
         role: UserRole?,
-        teamsRole: [String: String]?,
+        teamsRole: [TeamId: UserRole]?,
         extraData: [String: RawJSON]?
     ) {
         self.name = name

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -185,7 +185,7 @@ public extension CurrentChatUserController {
     ///
     /// By default all data is `nil`, and it won't be updated unless a value is provided.
     ///
-    /// - Note: This operation does a partial user update which keeps existing data if not modified. Use ``unset`` for clearing the existing state.
+    /// - Note: This operation does a partial user update which keeps existing data if not modified. Use ``unsetProperties`` for clearing the existing state.
     ///
     /// - Parameters:
     ///   - name: Optionally provide a new name to be updated.

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -194,14 +194,14 @@ public extension CurrentChatUserController {
     ///   - role: The role for the user.
     ///   - teamsRole: The role for the user in a specific team. Example: `["teamId": "role"]`.
     ///   - userExtraData: Optionally provide new user extra data to be updated.
-    ///   - unset: Existing values for specified properties are removed. For example, `image` or `name`.
+    ///   - unsetProperties: Remove existing properties from the user. For example, `image` or `name`.
     ///   - completion: Called when user is successfuly updated, or with error.
     func updateUserData(
         name: String? = nil,
         imageURL: URL? = nil,
         privacySettings: UserPrivacySettings? = nil,
         role: UserRole? = nil,
-        teamsRole: [String: String]? = nil,
+        teamsRole: [TeamId: UserRole]? = nil,
         userExtraData: [String: RawJSON] = [:],
         unsetProperties: Set<String> = [],
         completion: ((Error?) -> Void)? = nil
@@ -218,7 +218,8 @@ public extension CurrentChatUserController {
             privacySettings: privacySettings,
             role: role,
             teamsRole: teamsRole,
-            userExtraData: userExtraData
+            userExtraData: userExtraData,
+            unset: unsetProperties
         ) { error in
             self.callback {
                 completion?(error)
@@ -232,7 +233,7 @@ public extension CurrentChatUserController {
     ///
     /// - Parameters:
     ///   - extraData: The additional data to be added to the member object.
-    ///   - unsetProperties: The custom properties to be removed from the member object.
+    ///   - unsetProperties: The properties to be removed from the member object.
     ///   - channelId: The channel where the member data is updated.
     ///   - completion: Returns the updated member object or an error if the update fails.
     func updateMemberData(

--- a/Sources/StreamChat/StateLayer/ConnectedUser.swift
+++ b/Sources/StreamChat/StateLayer/ConnectedUser.swift
@@ -55,7 +55,7 @@ public final class ConnectedUser {
         imageURL: URL? = nil,
         privacySettings: UserPrivacySettings? = nil,
         role: UserRole? = nil,
-        teamRoles: [String: String]? = nil,
+        teamRoles: [TeamId: UserRole]? = nil,
         extraData: [String: RawJSON] = [:],
         unset: Set<String> = []
     ) async throws {

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -25,9 +25,9 @@ class CurrentUserUpdater: Worker {
         imageURL: URL?,
         privacySettings: UserPrivacySettings?,
         role: UserRole?,
-        teamsRole: [String: String]? = nil,
+        teamsRole: [TeamId: UserRole]?,
         userExtraData: [String: RawJSON]?,
-        unset: Set<String> = [],
+        unset: Set<String>,
         completion: ((Error?) -> Void)? = nil
     ) {
         let params: [Any?] = [name, imageURL, userExtraData]
@@ -290,7 +290,7 @@ extension CurrentUserUpdater {
         imageURL: URL?,
         privacySettings: UserPrivacySettings?,
         role: UserRole?,
-        teamsRole: [String: String]?,
+        teamsRole: [TeamId: UserRole]?,
         userExtraData: [String: RawJSON]?,
         unset: Set<String>
     ) async throws {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
@@ -13,6 +13,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
     @Atomic var updateUserData_userExtraData: [String: RawJSON]?
     @Atomic var updateUserData_privacySettings: UserPrivacySettings?
     @Atomic var updateUserData_unset: Set<String>?
+    @Atomic var updateUserData_teamsRole: [TeamId: UserRole]?
     @Atomic var updateUserData_completion: ((Error?) -> Void)?
 
     @Atomic var addDevice_id: DeviceId?
@@ -40,7 +41,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         imageURL: URL?,
         privacySettings: UserPrivacySettings?,
         role: UserRole?,
-        teamsRole: [String: String]?,
+        teamsRole: [TeamId: UserRole]?,
         userExtraData: [String: RawJSON]?,
         unset: Set<String>,
         completion: ((Error?) -> Void)? = nil
@@ -51,6 +52,7 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         updateUserData_userExtraData = userExtraData
         updateUserData_privacySettings = privacySettings
         updateUserData_unset = unset
+        updateUserData_teamsRole = teamsRole
         updateUserData_completion = completion
     }
 

--- a/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -299,7 +299,9 @@ final class CurrentUserController_Tests: XCTestCase {
             privacySettings: .init(
                 typingIndicators: .init(enabled: true), readReceipts: .init(enabled: true)
             ),
-            userExtraData: [:]
+            teamsRole: ["teamId": "role"],
+            userExtraData: [:],
+            unsetProperties: ["image"]
         )
 
         // Assert udpater is called with correct data
@@ -307,6 +309,8 @@ final class CurrentUserController_Tests: XCTestCase {
         XCTAssertEqual(env.currentUserUpdater.updateUserData_imageURL, expectedImageUrl)
         XCTAssertEqual(env.currentUserUpdater.updateUserData_privacySettings?.typingIndicators?.enabled, true)
         XCTAssertEqual(env.currentUserUpdater.updateUserData_privacySettings?.readReceipts?.enabled, true)
+        XCTAssertEqual(env.currentUserUpdater.updateUserData_unset, ["image"])
+        XCTAssertEqual(env.currentUserUpdater.updateUserData_teamsRole, ["teamId": "role"])
         XCTAssertNotNil(env.currentUserUpdater.updateUserData_completion)
     }
 

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -69,6 +69,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             role: expectedRole,
             teamsRole: ["ios": "guest"],
             userExtraData: nil,
+            unset: ["image"],
             completion: { error in
                 XCTAssertNil(error)
             }
@@ -104,7 +105,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 teamsRole: ["ios": "guest"],
                 extraData: [:]
             ),
-            unset: []
+            unset: ["image"]
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
     }
@@ -122,6 +123,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             imageURL: nil,
             privacySettings: nil,
             role: nil,
+            teamsRole: nil,
             userExtraData: nil,
             unset: ["image"],
             completion: { _ in }
@@ -167,7 +169,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 readReceipts: .init(enabled: false)
             ),
             role: expectedRole,
+            teamsRole: nil,
             userExtraData: nil,
+            unset: [],
             completion: { _ in
                 completionCalled = true
             }
@@ -218,7 +222,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             imageURL: nil,
             privacySettings: nil,
             role: nil,
-            userExtraData: [:],
+            teamsRole: nil,
+            userExtraData: nil,
+            unset: [],
             completion: { error in
                 completionError = error
             }
@@ -251,7 +257,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
                 imageURL: nil,
                 privacySettings: nil,
                 role: nil,
+                teamsRole: nil,
                 userExtraData: nil,
+                unset: [],
                 completion: $0
             )
         }
@@ -279,7 +287,9 @@ final class CurrentUserUpdater_Tests: XCTestCase {
             imageURL: nil,
             privacySettings: nil,
             role: nil,
+            teamsRole: nil,
             userExtraData: nil,
+            unset: [],
             completion: { error in
                 completionError = error
             }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-803/unsetproperties-does-not-do-anything-in-current-user-controller

### 🎯 Goal

Fix `unsetProperties` not having any effect in `CurrentUserController.updateUserData()`.

### 📝 Summary

- Fixes `unsetProperties` not doing anything in`CurrentUserController.updateUserData()`.
- Makes sure the current user updater does not have default values.
- Changes teamsRole parameter to use existing types.

### 🧪 Manual Testing Notes

1. Log in with a user who has an image set
2. Open a channel and its debug menu: Reset User Image
Result: User's image is reset in the channel list (image in the top left corner)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
