### PR TITLE
Fix `CurrentUserUnreads.totalUnreadChannelsCount` with incorrect value

### DIFF
--- a/Sources/StreamChat/Models/CurrentUser.swift
+++ b/Sources/StreamChat/Models/CurrentUser.swift
@@ -120,6 +120,8 @@ public class CurrentChatUser: ChatUser {
 
 /// The total unread information from the current user.
 public struct CurrentUserUnreads {
+    /// The total number of unread messages.
+    public let totalUnreadMessagesCount: Int
     /// The total number of unread channels.
     public let totalUnreadChannelsCount: Int
     /// The total number of unread threads.
@@ -166,14 +168,16 @@ public struct UnreadThread {
 
 extension CurrentUserUnreadsPayload {
     func asModel() -> CurrentUserUnreads {
-        CurrentUserUnreads(
-            totalUnreadChannelsCount: totalUnreadCount,
+        let unreadChannels: [UnreadChannel] = channels.map { .init(
+            channelId: $0.channelId,
+            unreadMessagesCount: $0.unreadCount,
+            lastRead: $0.lastRead
+        ) }
+        return CurrentUserUnreads(
+            totalUnreadMessagesCount: totalUnreadCount,
+            totalUnreadChannelsCount: unreadChannels.count,
             totalUnreadThreadsCount: totalUnreadThreadsCount,
-            unreadChannels: channels.map { .init(
-                channelId: $0.channelId,
-                unreadMessagesCount: $0.unreadCount,
-                lastRead: $0.lastRead
-            ) },
+            unreadChannels: unreadChannels,
             unreadThreads: threads.map { .init(
                 parentMessageId: $0.parentMessageId,
                 unreadRepliesCount: $0.unreadCount,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
@@ -34,6 +34,8 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
     @Atomic var deleteAllLocalAttachmentDownloads_completion: ((Error?) -> Void)?
     @Atomic var deleteAllLocalAttachmentDownloads_completion_result: Result<Void, Error>?
 
+    @Atomic var loadAllUnreads_completion: ((Result<CurrentUserUnreads, Error>) -> Void)?
+
     override func updateUserData(
         currentUserId: UserId,
         name: String?,
@@ -88,6 +90,10 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         deleteAllLocalAttachmentDownloads_completion_result?.invoke(with: completion)
     }
 
+    override func loadAllUnreads(completion: @escaping ((Result<CurrentUserUnreads, Error>) -> Void)) {
+        loadAllUnreads_completion = completion
+    }
+
     // Cleans up all recorded values
     func cleanUp() {
         updateUserData_currentUserId = nil
@@ -114,6 +120,8 @@ final class CurrentUserUpdater_Mock: CurrentUserUpdater {
         
         deleteAllLocalAttachmentDownloads_completion = nil
         deleteAllLocalAttachmentDownloads_completion_result = nil
+
+        loadAllUnreads_completion = nil
     }
 
     override func markAllRead(completion: ((Error?) -> Void)? = nil) {

--- a/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -777,6 +777,98 @@ final class CurrentUserController_Tests: XCTestCase {
         env.currentUserUpdater.deleteAllLocalAttachmentDownloads_completion?(nil)
         wait(for: [expectation], timeout: defaultTimeout)
     }
+
+    // MARK: - Load All Unreads
+    
+    func test_loadAllUnreads_callsUpdaterCorrectly() {
+        // Simulate having a current user
+        client.authenticationRepository.setMockToken()
+        
+        // Call loadAllUnreads
+        var receivedUnreads: CurrentUserUnreads?
+        let exp = expectation(description: "loadAllUnreads called")
+        controller.loadAllUnreads { result in
+            receivedUnreads = try? result.get()
+            exp.fulfill()
+        }
+        
+        // Simulate successful response
+        let expectedUnreads = CurrentUserUnreads(
+            totalUnreadMessagesCount: 10,
+            totalUnreadChannelsCount: 5,
+            totalUnreadThreadsCount: 3,
+            unreadChannels: [
+                UnreadChannel(
+                    channelId: .init(type: .messaging, id: "channel1"),
+                    unreadMessagesCount: 5,
+                    lastRead: Date()
+                )
+            ],
+            unreadThreads: [
+                UnreadThread(
+                    parentMessageId: "thread1",
+                    unreadRepliesCount: 3,
+                    lastRead: Date(),
+                    lastReadMessageId: "lastRead1"
+                )
+            ],
+            unreadChannelsByType: [
+                UnreadChannelByType(
+                    channelType: .messaging,
+                    unreadChannelCount: 5,
+                    unreadMessagesCount: 10
+                )
+            ]
+        )
+        
+        // Simulate completion with success
+        env.currentUserUpdater.loadAllUnreads_completion?(.success(expectedUnreads))
+        
+        wait(for: [exp], timeout: defaultTimeout)
+
+        // Assert the result is correct
+        XCTAssertEqual(receivedUnreads?.totalUnreadMessagesCount, expectedUnreads.totalUnreadMessagesCount)
+    }
+    
+    func test_loadAllUnreads_propagatesError() {
+        // Simulate having a current user
+        client.authenticationRepository.setMockToken()
+        
+        // Call loadAllUnreads
+        var receivedError: Error?
+        let exp = expectation(description: "loadAllUnreads called")
+        controller.loadAllUnreads { [callbackQueueID] result in
+            AssertTestQueue(withId: callbackQueueID)
+            receivedError = result.error
+            exp.fulfill()
+        }
+        
+        // Simulate error response
+        let expectedError = TestError()
+        env.currentUserUpdater.loadAllUnreads_completion?(.failure(expectedError))
+
+        wait(for: [exp], timeout: defaultTimeout)
+
+        // Assert error is received correctly
+        XCTAssertEqual(receivedError as? TestError, expectedError)
+    }
+    
+    func test_loadAllUnreads_keepsControllerAlive() {
+        // Simulate having a current user
+        client.authenticationRepository.setMockToken()
+        
+        // Create weak reference to controller
+        weak var weakController = controller
+        
+        // Call loadAllUnreads
+        controller.loadAllUnreads { _ in }
+        
+        // Try to deallocate controller
+        controller = nil
+        
+        // Verify controller is still alive due to the async operation
+        AssertAsync.staysTrue(weakController != nil)
+    }
 }
 
 private class TestEnvironment {

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -712,6 +712,83 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         }
     }
     
+    // MARK: - Load All Unreads
+    
+    func test_loadAllUnreads_makesCorrectAPICall() {
+        // Call loadAllUnreads
+        var receivedUnreads: CurrentUserUnreads?
+        currentUserUpdater.loadAllUnreads { result in
+            receivedUnreads = try? result.get()
+        }
+        
+        // Assert request is made to the correct endpoint
+        XCTAssertNotNil(apiClient.request_endpoint)
+        let endpoint = apiClient.request_endpoint
+        XCTAssertEqual(endpoint?.path.value, "unread")
+        XCTAssertEqual(endpoint?.method, .get)
+        
+        // Create test payload for the response
+        let payload = CurrentUserUnreadsPayload(
+            totalUnreadCount: 10,
+            totalUnreadThreadsCount: 3,
+            channels: [
+                CurrentUserChannelUnreadPayload(
+                    channelId: .init(type: .messaging, id: "channel1"),
+                    unreadCount: 5,
+                    lastRead: Date()
+                ),
+                CurrentUserChannelUnreadPayload(
+                    channelId: .init(type: .messaging, id: "channel2"),
+                    unreadCount: 5,
+                    lastRead: Date()
+                )
+            ],
+            channelType: [
+                ChannelUnreadByTypePayload(
+                    channelType: .messaging,
+                    channelCount: 2,
+                    unreadCount: 10
+                )
+            ],
+            threads: [
+                CurrentUserThreadUnreadPayload(
+                    parentMessageId: "thread1",
+                    lastRead: Date(),
+                    lastReadMessageId: "message1",
+                    unreadCount: 3
+                )
+            ]
+        )
+        
+        // Simulate API response
+        apiClient.test_simulateResponse(.success(payload))
+        
+        // Verify the result is correctly transformed into the model
+        XCTAssertEqual(receivedUnreads?.totalUnreadMessagesCount, payload.totalUnreadCount)
+        XCTAssertEqual(receivedUnreads?.totalUnreadChannelsCount, payload.channels.count)
+        XCTAssertEqual(receivedUnreads?.totalUnreadThreadsCount, payload.totalUnreadThreadsCount)
+        XCTAssertEqual(receivedUnreads?.unreadChannels.count, payload.channels.count)
+        XCTAssertEqual(receivedUnreads?.unreadThreads.count, payload.threads.count)
+        XCTAssertEqual(receivedUnreads?.unreadChannelsByType.count, payload.channelType.count)
+    }
+    
+    func test_loadAllUnreads_propagatesNetworkError() {
+        // Call loadAllUnreads
+        var receivedError: Error?
+        currentUserUpdater.loadAllUnreads { result in
+            if case let .failure(error) = result {
+                receivedError = error
+            }
+        }
+        
+        // Simulate API error
+        let expectedError = TestError()
+        apiClient.test_simulateResponse(Result<CurrentUserUnreadsPayload, Error>.failure(expectedError))
+        
+        // Verify the error is propagated
+        XCTAssertEqual(receivedError as? TestError, expectedError)
+    }
+    
     // MARK: -
     
     private func setUpDownloadedAttachment(with payload: AnyAttachmentPayload, messageId: MessageId = .unique, cid: ChannelId = .unique) throws -> AttachmentId {


### PR DESCRIPTION
### 🔗 Issue Links

IOS-800
https://github.com/GetStream/stream-chat-swift/issues/3649

### 🎯 Goal

Fix `CurrentUserUnreads.totalUnreadChannelsCount` with incorrect value.

### 📝 Summary

- Fix `CurrentUserUnreads.totalUnreadChannelsCount` with total unread messages count instead
- Add `CurrentUserUnreads.totalUnreadMessagesCount`

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
