### PR TITLE
Fix swipe to reply enabled when quoting a message is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix swipe to reply enabled when quoting a message is disabled [#3662](https://github.com/GetStream/stream-chat-swift/pull/3662)
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.78.0)
 _April 24, 2025_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -456,9 +456,9 @@ open class ChatMessageListVC: _ViewController,
     ///
     /// By default, this will trigger the swipe to reply gesture recognition.
     @objc open func handlePan(_ gesture: UIPanGestureRecognizer) {
-        let canReply = dataSource?.channel(for: self)?.canSendReply ?? false
+        let canQuoteReply = dataSource?.channel(for: self)?.canQuoteMessage ?? false
         let isSwipeToReplyEnabled = components.messageSwipeToReplyEnabled
-        if canReply && isSwipeToReplyEnabled {
+        if canQuoteReply && isSwipeToReplyEnabled {
             swipeToReplyGestureHandler.handle(gesture: gesture)
         }
     }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -1156,13 +1156,13 @@ final class ChatMessageListVC_Tests: XCTestCase {
 
     // MARK: - handlePan
 
-    func test_handlePan_whenCanReply_whenSwipeToReplyIsEnabled_thenShouldHandleSwipingToReply() {
+    func test_handlePan_whenCanQuoteReply_whenSwipeToReplyIsEnabled_thenShouldHandleSwipingToReply() {
         // Given
         let handlerMock = SwipeToReplyGestureHandler_Mock(listView: sut.listView)
         sut.swipeToReplyGestureHandler = handlerMock
 
         // When
-        mockedDataSource.mockedChannel = .mock(cid: .unique, ownCapabilities: [.sendReply])
+        mockedDataSource.mockedChannel = .mock(cid: .unique, ownCapabilities: [.quoteMessage])
         sut.components.messageSwipeToReplyEnabled = true
 
         // Then
@@ -1170,13 +1170,13 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertEqual(handlerMock.handleCallCount, 1)
     }
 
-    func test_handlePan_whenCanReply_whenSwipeToReplyIsDisabled_thenDoesNotHandleSwipingToReply() {
+    func test_handlePan_whenCanQuoteReply_whenSwipeToReplyIsDisabled_thenDoesNotHandleSwipingToReply() {
         // Given
         let handlerMock = SwipeToReplyGestureHandler_Mock(listView: sut.listView)
         sut.swipeToReplyGestureHandler = handlerMock
 
         // When
-        mockedDataSource.mockedChannel = .mock(cid: .unique, ownCapabilities: [.sendReply])
+        mockedDataSource.mockedChannel = .mock(cid: .unique, ownCapabilities: [.quoteMessage])
         sut.components.messageSwipeToReplyEnabled = false
 
         // Then
@@ -1184,7 +1184,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertEqual(handlerMock.handleCallCount, 0)
     }
 
-    func test_handlePan_whenCanNotReply_thenDoesNotHandleSwipingToReply() {
+    func test_handlePan_whenCanNotQuoteReply_thenDoesNotHandleSwipingToReply() {
         // Given
         let handlerMock = SwipeToReplyGestureHandler_Mock(listView: sut.listView)
         sut.swipeToReplyGestureHandler = handlerMock


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-809/swipe-to-reply-does-not-work-if-threads-are-disabled-in-the-dashboard

### 🎯 Goal

Fix swipe to reply enabled when quoting a message is disabled

### 🧪 Manual Testing Notes

1. Go to Stream Dashboard of UIKit Demo App
2. Go to Channel Types
3. Go to Messaging
4. Disable Quotes
5. Go to the Demo App
6. Swipe to reply in a message should not work

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
