### PR TITLE
Fix message not marked as published if it was previously intercepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix an issue where completion handler was called twice after waiting for token refresh [#3683](https://github.com/GetStream/stream-chat-swift/pull/3683)
+- Fix message not marked as published if it was previously intercepted [#3687](https://github.com/GetStream/stream-chat-swift/pull/3687)
 
 # [4.79.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.79.0)
 _May 28, 2025_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -864,6 +864,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         if dto.localMessageState == .pendingSend || dto.localMessageState == .pendingSync {
             return dto
         }
+
         // Local text edit before receiving the WS event
         if let localDate = dto.textUpdatedAt?.bridgeDate,
            let payloadDate = payload.messageTextUpdatedAt,

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -817,6 +817,10 @@ extension DatabaseSession {
         if isNewMessage && isThreadReply {
             savedMessage.showInsideThread = true
         }
+
+        if isNewMessage && savedMessage.localMessageState != nil {
+            savedMessage.markMessageAsSent()
+        }
     }
 
     func updateChannelPreview(from payload: EventPayload) {


### PR DESCRIPTION
### 🔗 Issue Links
Resolves bug found in https://linear.app/stream/issue/IOS-857

### 🎯 Goal

Fix message not marked as published on `message.new` event if it was previously intercepted.

### 📝 Summary

In the `message.new` event, we do not mark the message as published, because we usually do it after the request is finished. In the interceptor use case, the request is not finished when it completes; it should rely on the `message.new` event instead. So, the goal of this PR is to mark the message as published whenever we receive `message.new` event in case it is not yet marked as published.

### 🧪 Manual Testing Notes
N/A. Covered by unit tests.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
