### PR TITLE
[CI] Update danger usage

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 100
       - uses: ./.github/actions/bootstrap
       - name: Run Danger
-        run: bundle exec danger
+        run: bundle exec fastlane lint_pr
       - name: Run Fastlane Linting
         run: bundle exec fastlane rubocop
       - name: Run SwiftFormat Linting

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -793,6 +793,11 @@ lane :rubocop do
   sh('bundle exec rubocop')
 end
 
+desc 'Run PR linting'
+lane :lint_pr do
+  danger(dangerfile: 'Dangerfile') if is_ci
+end
+
 lane :install_runtime do |options|
   install_ios_runtime(version: options[:ios], custom_script: 'Scripts/install_ios_runtime.sh')
 end


### PR DESCRIPTION
### 📝 Summary

For some reason, danger fails on CI during a day or so after updating ruby gems.
This PR introduces the use of danger through fastlane in the hope of solving the mysterious issue. In general, nothing changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated code review process to use a new PR linting command in continuous integration workflows. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->