### PR TITLE
Fix message actions view with flag action when user has no capability

### DIFF
--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -114,6 +114,7 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
             let canUpdateOwnMessage = channel?.canUpdateOwnMessage ?? true
             let canDeleteAnyMessage = channel?.canDeleteAnyMessage ?? false
             let canDeleteOwnMessage = channel?.canDeleteOwnMessage ?? true
+            let canFlagMessage = channel?.canFlagMessage ?? false
             let isSentByCurrentUser = message.isSentByCurrentUser
 
             if canQuoteMessage {
@@ -152,7 +153,7 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
                 actions.append(deleteActionItem())
             }
 
-            if !isSentByCurrentUser {
+            if !isSentByCurrentUser && canFlagMessage {
                 actions.append(flagActionItem())
             }
 

--- a/Tests/StreamChatUITests/SnapshotTests/MessageActionsPopup/ChatMessageActionsVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/MessageActionsPopup/ChatMessageActionsVC_Tests.swift
@@ -336,9 +336,21 @@ final class ChatMessageActionsVC_Tests: XCTestCase {
             state: .remoteDataFetched
         )
 
-        vc.channel = .mock(cid: .unique, ownCapabilities: [])
+        vc.channel = .mock(cid: .unique, ownCapabilities: [.flagMessage])
 
         XCTAssertTrue(vc.messageActions.contains(where: { $0 is FlagActionItem }))
+    }
+
+    func test_messageActions_whenMessageIsSentByAnotherUser_whenNoCapability_doesNotContainFlagAction() {
+        chatMessageController.simulateInitial(
+            message: ChatMessage.mock(isSentByCurrentUser: false),
+            replies: [],
+            state: .remoteDataFetched
+        )
+
+        vc.channel = .mock(cid: .unique, ownCapabilities: [])
+
+        XCTAssertFalse(vc.messageActions.contains(where: { $0 is FlagActionItem }))
     }
 
     func test_messageActions_whenSendingFailed_thenContainsResendActionEditActionDeleteAction() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-937/flag-message-action-is-not-removed-if-has-no-permission

### 🎯 Goal

Fix the message actions view with the flag action when the user has no capability.

### 🧪 Manual Testing Notes

1. Disable the capability for a user in the dashboard
2. When long pressing a message
3. Should not show flag action

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
