### PR TITLE
Fix reaction picker in `ChatMessagePopupVC` below notch in rare scenarios

### DIFF
--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -129,6 +129,7 @@ open class ChatMessagePopupVC: _ViewController, ComponentsProvider {
     /// Add the scroll view to the view hierarchy.
     open func addScrollView() {
         view.addSubview(scrollView)
+        scrollView.contentInsetAdjustmentBehavior = .always
 
         NSLayoutConstraint.activate([
             scrollView.widthAnchor.pin(equalTo: view.widthAnchor),


### PR DESCRIPTION
### 🔗 Issue Links
TODO

### 🎯 Goal

Fix reaction picker in `ChatMessagePopupVC` below notch in rare scenarios.

### 🧪 Manual Testing Notes

1. Use iPhone 16 Pro Max simulator
2. Create a message with the following text:
```
Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.

Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
```
3. Long tap the message
4. The popup view should be scrollable and the reaction picker should not be below the notch.


### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
