### PR TITLE
[CI] Skip git hooks on merge and squash commits

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,3 +4,6 @@ pre-commit:
     - run: bundle exec fastlane run_swift_format
       glob: "*.{swift}"
       stage_fixed: true
+      skip:
+        - merge
+        - rebase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hook configuration to skip Swift formatting during merge and rebase operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->