### PR TITLE
[SwiftFormat] Disable opaqueGenericParameters

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -8,6 +8,7 @@
 --disable andOperator
 --disable hoistPatternLet
 --disable typeSugar
+--disable opaqueGenericParameters
 
 --disable redundantGet # it removes get async throws from getters
 


### PR DESCRIPTION
https://github.com/nicklockwood/SwiftFormat/blob/main/Rules.md#opaquegenericparameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting tool configuration to skip formatting of opaque generic parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->