### PR TITLE
Play voice messages through bluetooth if a device is connected

### DIFF
--- a/Sources/StreamChat/Audio/AudioSessionProtocol.swift
+++ b/Sources/StreamChat/Audio/AudioSessionProtocol.swift
@@ -9,6 +9,7 @@ import AVFoundation
 protocol AudioSessionProtocol {
     var category: AVAudioSession.Category { get }
     var availableInputs: [AVAudioSessionPortDescription]? { get }
+    var currentRoute: AVAudioSessionRouteDescription { get }
 
     func setCategory(
         _ category: AVAudioSession.Category,


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Linear and/or Github issues related to this PR, if applicable._

### 🎯 Goal

_Describe why we are making this change._

Play voice messages through bluetooth if a device is connected

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded audio playback options to support Bluetooth, Bluetooth A2DP, and AirPlay devices during playback sessions.
  * Added detection of Bluetooth connections to optimize audio routing.

* **Bug Fixes**
  * Enhanced audio output handling to automatically select the appropriate audio route when Bluetooth devices are connected, improving playback experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->