### PR TITLE
Demo app: Create new direct message does not send attachments

### DIFF
--- a/DemoApp/Screens/Create Chat/CreateChatViewController.swift
+++ b/DemoApp/Screens/Create Chat/CreateChatViewController.swift
@@ -15,24 +15,20 @@ class CreateChatViewController: UIViewController {
 
     // Composer subclass intended to be only used in this VC
     class DemoComposerVC: ComposerVC {
-        override func createNewMessage(text: String) {
+        override func publishMessage(sender: UIButton) {
             guard let navController = parent?.parent as? UINavigationController,
                   let controller = channelController else { return }
-
-            let createMessage: (String) -> Void = {
-                super.createNewMessage(text: $0)
+            let publish: () -> Void = {
+                super.publishMessage(sender: sender)
             }
-
             // Create the Channel on backend
             controller.synchronize { [weak self] error in
                 if let error = error {
                     self?.presentAlert(title: "Error when creating the channel", message: error.localizedDescription)
                     return
                 }
-
-                // Send the message
-                createMessage(text)
-
+                publish()
+                
                 // Present the new chat and controller
                 let vc = ChatChannelVC()
                 vc.channelController = controller


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-988

### 🎯 Goal

Create new 1:1 channel should send attachments

### 📝 Summary

Demo app's create new flow currently resets content state while creating the new channel.

### 🛠 Implementation

Publish is called when button is tapped and at the end of the publish call content.clear is triggered which resets the state while waiting for the channel to be created.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

1. Open new channel view in the demo app
2. Tap on a contact
3. Add attachment
4. Tap on the send

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
