### PR TITLE
Handle Push v3 Reaction Notifications + Skip edit message push notification

### DIFF
--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -180,6 +180,7 @@ class AppConfigViewController: UITableViewController {
 
     enum ComponentsConfigOption: String, CaseIterable {
         case isUniqueReactionsEnabled
+        case isReactionPushEmojisEnabled
         case shouldMessagesStartAtTheTop
         case shouldAnimateJumpToMessageWhenOpeningChannel
         case shouldJumpToUnreadWhenOpeningChannel
@@ -445,6 +446,10 @@ class AppConfigViewController: UITableViewController {
         case .isUniqueReactionsEnabled:
             cell.accessoryView = makeSwitchButton(Components.default.isUniqueReactionsEnabled) { newValue in
                 Components.default.isUniqueReactionsEnabled = newValue
+            }
+        case .isReactionPushEmojisEnabled:
+            cell.accessoryView = makeSwitchButton(Components.default.isReactionPushEmojisEnabled) { newValue in
+                Components.default.isReactionPushEmojisEnabled = newValue
             }
         case .shouldMessagesStartAtTheTop:
             cell.accessoryView = makeSwitchButton(Components.default.shouldMessagesStartAtTheTop) { newValue in

--- a/Sources/StreamChat/APIClient/ChatRemoteNotificationHandler.swift
+++ b/Sources/StreamChat/APIClient/ChatRemoteNotificationHandler.swift
@@ -9,15 +9,18 @@ import UserNotifications
 public class MessageNotificationContent {
     public let message: ChatMessage
     public let channel: ChatChannel?
+    public let reaction: PushReactionInfo?
     public let type: PushNotificationType
 
     init(
         message: ChatMessage,
         channel: ChatChannel?,
+        reaction: PushReactionInfo?,
         type: PushNotificationType
     ) {
         self.message = message
         self.channel = channel
+        self.reaction = reaction
         self.type = type
     }
 }
@@ -90,6 +93,35 @@ public class ChatPushNotificationInfo {
     }
 }
 
+/// The information about a reaction in a push notification.
+public struct PushReactionInfo {
+    /// The type of the reaction.
+    public let rawType: String
+    /// The id of the user who created the reaction.
+    public let reactionUserId: UserId
+    /// The image URL of the user who created the reaction.
+    public let reactionUserImageUrl: URL?
+    /// The id of the user who is the receiver of the reaction, usually the creator of the message.
+    public let receiverUserId: UserId
+
+    init?(payload: [String: String]) {
+        guard let rawType = payload["reaction_type"],
+              let reactionUserId = payload["reaction_user_id"],
+              let receiverUserId = payload["receiver_id"] else {
+            return nil
+        }
+        self.rawType = rawType
+        self.reactionUserId = UserId(reactionUserId)
+        self.receiverUserId = UserId(receiverUserId)
+
+        if let imageUrlString = payload["reaction_user_image"] {
+            reactionUserImageUrl = URL(string: imageUrlString)
+        } else {
+            reactionUserImageUrl = nil
+        }
+    }
+}
+
 public class ChatRemoteNotificationHandler {
     var client: ChatClient
     var content: UNNotificationContent
@@ -118,7 +150,7 @@ public class ChatRemoteNotificationHandler {
             return completion(.unknown(UnknownNotificationContent(content: content)))
         }
 
-        guard let cid = dict["cid"], let id = dict["id"], let channelId = try? ChannelId(cid: cid) else {
+        guard let cid = dict["cid"], let id = dict["id"] ?? dict["message_id"], let channelId = try? ChannelId(cid: cid) else {
             completion(.unknown(UnknownNotificationContent(content: content)))
             return
         }
@@ -136,6 +168,7 @@ public class ChatRemoteNotificationHandler {
             let content = MessageNotificationContent(
                 message: message,
                 channel: channel,
+                reaction: PushReactionInfo(payload: dict),
                 type: pushType
             )
             completion(.message(content))

--- a/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
@@ -25,7 +25,7 @@ extension Endpoint {
         )
     }
 
-    static func editMessage(payload: MessageRequestBody, skipEnrichUrl: Bool)
+    static func editMessage(payload: MessageRequestBody, skipEnrichUrl: Bool, skipPush: Bool)
         -> Endpoint<EmptyResponse> {
         .init(
             path: .editMessage(payload.id),
@@ -34,7 +34,8 @@ extension Endpoint {
             requiresConnectionId: false,
             body: [
                 "message": AnyEncodable(payload),
-                "skip_enrich_url": AnyEncodable(skipEnrichUrl)
+                "skip_enrich_url": AnyEncodable(skipEnrichUrl),
+                "skip_push": AnyEncodable(skipPush)
             ]
         )
     }

--- a/Sources/StreamChat/APIClient/Endpoints/ReactionEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ReactionEndpoints.swift
@@ -30,13 +30,17 @@ extension Endpoint {
         score: Int,
         enforceUnique: Bool,
         extraData: [String: RawJSON],
+        skipPush: Bool,
+        emojiCode: String?,
         messageId: MessageId
     ) -> Endpoint<EmptyResponse> {
         let body = MessageReactionRequestPayload(
             enforceUnique: enforceUnique,
+            skipPush: skipPush,
             reaction: ReactionRequestPayload(
                 type: type,
                 score: score,
+                emojiCode: emojiCode,
                 extraData: extraData
             )
         )

--- a/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
@@ -9,14 +9,17 @@ struct MessageReactionRequestPayload: Encodable {
     enum CodingKeys: String, CodingKey {
         case enforceUnique = "enforce_unique"
         case reaction
+        case skipPush = "skip_push"
     }
 
     let enforceUnique: Bool
+    let skipPush: Bool
     let reaction: ReactionRequestPayload
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(enforceUnique, forKey: .enforceUnique)
+        try container.encode(skipPush, forKey: .skipPush)
         try container.encode(reaction, forKey: .reaction)
     }
 }
@@ -25,16 +28,19 @@ struct ReactionRequestPayload: Encodable {
     private enum CodingKeys: String, CodingKey {
         case type
         case score
+        case emojiCode = "emoji_code"
     }
 
     let type: MessageReactionType
     let score: Int
+    let emojiCode: String?
     let extraData: [String: RawJSON]
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type, forKey: .type)
         try container.encode(score, forKey: .score)
+        try container.encodeIfPresent(emojiCode, forKey: .emojiCode)
         try extraData.encode(to: encoder)
     }
 }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -270,6 +270,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     /// - Parameters:
     ///   - text: The updated message text.
     ///   - skipEnrichUrl: If true, the url preview won't be attached to the message.
+    ///   - skipPush: If true, skips sending push notification when message is edited.
     ///   - attachments: An array of the attachments for the message.
     ///   - restrictedVisibility: The list of user ids that can see the message.
     ///   - extraData: Custom extra data. When `nil` is passed the message custom fields stay the same. Equals `nil` by default.
@@ -277,6 +278,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     public func editMessage(
         text: String,
         skipEnrichUrl: Bool = false,
+        skipPush: Bool = false,
         attachments: [AnyAttachmentPayload] = [],
         restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON]? = nil,
@@ -295,6 +297,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
             messageId: messageId,
             text: transformableInfo.text,
             skipEnrichUrl: skipEnrichUrl,
+            skipPush: skipPush,
             attachments: transformableInfo.attachments,
             restrictedVisibility: restrictedVisibility,
             extraData: transformableInfo.extraData
@@ -685,12 +688,16 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     ///   - type: The reaction type.
     ///   - score: The reaction score.
     ///   - enforceUnique: If set to `true`, new reaction will replace all reactions the user has (if any) on this message.
+    ///   - skipPush: If set to `true`, skips sending push notification when reacting a message.
+    ///   - pushEmojiCode: The emoji code when receiving a reaction push notification.
     ///   - extraData: The reaction extra data.
     ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     public func addReaction(
         _ type: MessageReactionType,
         score: Int = 1,
         enforceUnique: Bool = false,
+        skipPush: Bool = false,
+        pushEmojiCode: String? = nil,
         extraData: [String: RawJSON] = [:],
         completion: ((Error?) -> Void)? = nil
     ) {
@@ -698,6 +705,8 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
             type,
             score: score,
             enforceUnique: enforceUnique,
+            skipPush: skipPush,
+            pushEmojiCode: pushEmojiCode,
             extraData: extraData,
             messageId: messageId
         ) { error in

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -577,6 +577,7 @@ public class Chat {
     ///   - extraData: Additional extra data of the message object.
     ///   - restrictedVisibility: The list of user ids that can see the message.
     ///   - skipEnrichURL: If true, the url preview won't be attached to the message.
+    ///   - skipPush: If set to `true`, skips sending push notification when updating the message.
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An instance of `ChatMessage` which was updated.
@@ -586,13 +587,15 @@ public class Chat {
         attachments: [AnyAttachmentPayload] = [],
         extraData: [String: RawJSON]? = nil,
         restrictedVisibility: [UserId] = [],
-        skipEnrichURL: Bool = false
+        skipEnrichURL: Bool = false,
+        skipPush: Bool = false
     ) async throws -> ChatMessage {
         Task { try await stopTyping() } // errors explicitly ignored
         let localMessage = try await messageUpdater.editMessage(
             messageId: messageId,
             text: text,
             skipEnrichUrl: skipEnrichURL,
+            skipPush: skipPush,
             attachments: attachments,
             restrictedVisibility: restrictedVisibility,
             extraData: extraData
@@ -847,6 +850,8 @@ public class Chat {
     ///   - type: The type that describes a message reaction. Common examples are: “like”, “love”, “smile”, etc. An user can have only 1 reaction of each type per message.
     ///   - score: The score of the reaction for cumulative reactions (example: n number of claps).
     ///   - enforceUnique: If `true`, the added reaction will replace all reactions the user has (if any) on this message.
+    ///   - skipPush: If set to `true`, skips sending push notification when reacting a message.
+    ///   - pushEmojiCode: The emoji code for the reaction when a push notification is received.
     ///   - extraData: The reaction's extra data.
     ///
     /// - Throws: An error while communicating with the Stream API.
@@ -855,12 +860,16 @@ public class Chat {
         with type: MessageReactionType,
         score: Int = 1,
         enforceUnique: Bool = false,
+        skipPush: Bool = false,
+        pushEmojiCode: String? = nil,
         extraData: [String: RawJSON] = [:]
     ) async throws {
         try await messageUpdater.addReaction(
             type,
             score: score,
             enforceUnique: enforceUnique,
+            skipPush: skipPush,
+            pushEmojiCode: pushEmojiCode,
             extraData: extraData,
             messageId: messageId
         )

--- a/Sources/StreamChat/Workers/Background/MessageEditor.swift
+++ b/Sources/StreamChat/Workers/Background/MessageEditor.swift
@@ -79,7 +79,13 @@ class MessageEditor: Worker {
 
             let requestBody = dto.asRequestBody() as MessageRequestBody
             messageRepository?.updateMessage(withID: messageId, localState: .syncing) { _ in
-                self?.apiClient.request(endpoint: .editMessage(payload: requestBody, skipEnrichUrl: dto.skipEnrichUrl)) { apiResult in
+                self?.apiClient.request(
+                    endpoint: .editMessage(
+                        payload: requestBody,
+                        skipEnrichUrl: dto.skipEnrichUrl,
+                        skipPush: dto.skipPush
+                    )
+                ) { apiResult in
                     let newMessageState: LocalMessageState? = apiResult.error == nil ? nil : .syncingFailed
 
                     messageRepository?.updateMessage(

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -101,7 +101,8 @@ class MessageUpdater: Worker {
     ///  - Parameters:
     ///   - messageId: The message identifier.
     ///   - text: The updated message text.
-    ///   - skipEnrichUrl: If true, the url preview won't be attached to the message.
+    ///   - skipEnrichUrl: If true, the url preview won't be attached to the message
+    ///   - skipPush: If true, skips sending push notification when message is edited.
     ///   - attachments: An array of the attachments for the message.
     ///   - extraData: Extra Data for the message.
     ///   - completion: The completion handler with the local updated message.
@@ -109,6 +110,7 @@ class MessageUpdater: Worker {
         messageId: MessageId,
         text: String,
         skipEnrichUrl: Bool,
+        skipPush: Bool,
         attachments: [AnyAttachmentPayload] = [],
         restrictedVisibility: [UserId],
         extraData: [String: RawJSON]? = nil,
@@ -133,6 +135,7 @@ class MessageUpdater: Worker {
                 messageDTO.localMessageState = localState
 
                 messageDTO.skipEnrichUrl = skipEnrichUrl
+                messageDTO.skipPush = skipPush
                 messageDTO.restrictedVisibility = Set(restrictedVisibility)
 
                 messageDTO.quotedBy.forEach { message in
@@ -565,6 +568,8 @@ class MessageUpdater: Worker {
     ///   - type: The reaction type.
     ///   - score: The reaction score.
     ///   - enforceUnique: If set to `true`, new reaction will replace all reactions the user has (if any) on this message.
+    ///   - skipPush: If set to `true`, skips sending push notification when reacting a message.
+    ///   - pushEmojiCode: The emoji code for the reaction when a push notification is received.
     ///   - extraData: The extra data attached to the reaction.
     ///   - messageId: The message identifier the reaction will be added to.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
@@ -572,6 +577,8 @@ class MessageUpdater: Worker {
         _ type: MessageReactionType,
         score: Int,
         enforceUnique: Bool,
+        skipPush: Bool,
+        pushEmojiCode: String?,
         extraData: [String: RawJSON],
         messageId: MessageId,
         completion: ((Error?) -> Void)? = nil
@@ -583,6 +590,8 @@ class MessageUpdater: Worker {
             score: score,
             enforceUnique: enforceUnique,
             extraData: extraData,
+            skipPush: skipPush,
+            emojiCode: pushEmojiCode,
             messageId: messageId
         )
 
@@ -1154,6 +1163,8 @@ extension MessageUpdater {
         _ type: MessageReactionType,
         score: Int,
         enforceUnique: Bool,
+        skipPush: Bool,
+        pushEmojiCode: String?,
         extraData: [String: RawJSON],
         messageId: MessageId
     ) async throws {
@@ -1162,6 +1173,8 @@ extension MessageUpdater {
                 type,
                 score: score,
                 enforceUnique: enforceUnique,
+                skipPush: skipPush,
+                pushEmojiCode: pushEmojiCode,
                 extraData: extraData,
                 messageId: messageId
             ) { error in
@@ -1272,6 +1285,7 @@ extension MessageUpdater {
         messageId: MessageId,
         text: String,
         skipEnrichUrl: Bool,
+        skipPush: Bool,
         attachments: [AnyAttachmentPayload] = [],
         restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON]? = nil
@@ -1281,6 +1295,7 @@ extension MessageUpdater {
                 messageId: messageId,
                 text: text,
                 skipEnrichUrl: skipEnrichUrl,
+                skipPush: skipPush,
                 attachments: attachments,
                 restrictedVisibility: restrictedVisibility,
                 extraData: extraData

--- a/Sources/StreamChatUI/Appearance+Images.swift
+++ b/Sources/StreamChatUI/Appearance+Images.swift
@@ -107,7 +107,7 @@ public extension Appearance {
         public var reactionWutSmall: UIImage = loadImageSafely(with: "reaction_wut_small")
         public var reactionWutBig: UIImage = loadImageSafely(with: "reaction_wut_big")
 
-        private var _availableReactions: [MessageReactionType: ChatMessageReactionAppearanceType]?
+        /// The reactions appearance used to display reactions in the message list.
         public var availableReactions: [MessageReactionType: ChatMessageReactionAppearanceType] {
             get {
                 _availableReactions ??
@@ -136,6 +136,25 @@ public extension Appearance {
             }
             set { _availableReactions = newValue }
         }
+
+        private var _availableReactions: [MessageReactionType: ChatMessageReactionAppearanceType]?
+
+        /// The reactions emoji unicode rendered in the push notifications.
+        public var availableReactionPushEmojis: [MessageReactionType: String] {
+            get {
+                _availableReactionPushEmojis ??
+                    [
+                        "love": "❤️",
+                        "haha": "😂",
+                        "like": "👍",
+                        "sad": "👎",
+                        "wow": "😮"
+                    ]
+            }
+            set { _availableReactionPushEmojis = newValue }
+        }
+
+        private var _availableReactionPushEmojis: [MessageReactionType: String]?
 
         // MARK: - MessageList
 

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsPickerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsPickerVC.swift
@@ -64,9 +64,18 @@ open class ChatMessageReactionsPickerVC: _ViewController, ThemeProvider, ChatMes
         }
 
         let shouldRemove = message.currentUserReactions.contains { $0.type == reaction }
-        shouldRemove
-            ? messageController.deleteReaction(reaction, completion: completion)
-            : messageController.addReaction(reaction, enforceUnique: components.isUniqueReactionsEnabled, completion: completion)
+        if shouldRemove {
+            messageController.deleteReaction(reaction, completion: completion)
+        } else {
+            let availableEmojis = appearance.images.availableReactionPushEmojis
+            messageController.addReaction(
+                reaction,
+                enforceUnique: components.isUniqueReactionsEnabled,
+                skipPush: false,
+                pushEmojiCode: components.isReactionPushEmojisEnabled ? availableEmojis[reaction] : nil,
+                completion: completion
+            )
+        }
     }
 
     // MARK: - MessageControllerDelegate

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -438,6 +438,17 @@ public struct Components {
     /// By default it is false, so each user can have multiple reaction types.
     public var isUniqueReactionsEnabled: Bool = false
 
+    /// A boolean value that determines whether an emoji will be defined when a reaction is sent.
+    /// The emoji will be used for the push notification message.
+    ///
+    /// By default reaction push notifications will render emojis based on the mapping in `Appearance.Images.availableReactionsPushEmojis`.
+    ///
+    /// There is also an option to customise the appearance of the reaction push notification
+    /// by implementing a Notification Service Extension, and updating the `UNNotificationContent` with custom emojis.
+    ///
+    /// **Note:** This is only available in Push v3.
+    public var isReactionPushEmojisEnabled: Bool = true
+
     // MARK: - Thread components
 
     /// The router responsible for navigation on thread list screen.

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1062,10 +1062,10 @@ open class ComposerVC: _ViewController,
             cid: cid,
             messageId: id
         )
-        // TODO: Adjust LLC to edit mentions
         messageController?.editMessage(
             text: newText,
             skipEnrichUrl: content.skipEnrichUrl,
+            skipPush: false,
             attachments: content.attachments,
             extraData: content.extraData
         )

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -25,6 +25,7 @@ final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var editMessage_messageId: MessageId?
     @Atomic var editMessage_text: String?
     @Atomic var editMessage_skipEnrichUrl: Bool?
+    @Atomic var editMessage_skipPush: Bool?
     @Atomic var editMessage_restrictedVisibility: [UserId]?
     @Atomic var editMessage_attachments: [AnyAttachmentPayload]?
     @Atomic var editMessage_completion: ((Result<ChatMessage, Error>) -> Void)?
@@ -132,12 +133,12 @@ final class MessageUpdater_Mock: MessageUpdater {
     var markThreadRead_threadId: MessageId?
     var markThreadRead_cid: ChannelId?
     var markThreadRead_callCount = 0
-    var markThreadRead_completion: ((Error?) -> Void)? = nil
+    var markThreadRead_completion: ((Error?) -> Void)?
 
     var markThreadUnread_threadId: MessageId?
     var markThreadUnread_cid: ChannelId?
     var markThreadUnread_callCount = 0
-    var markThreadUnread_completion: ((Error?) -> Void)? = nil
+    var markThreadUnread_completion: ((Error?) -> Void)?
 
     var updateThread_callCount = 0
     var updateThread_messageId: MessageId?
@@ -166,6 +167,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         
         editMessage_messageId = nil
         editMessage_text = nil
+        editMessage_skipPush = nil
         editMessage_completion = nil
 
         createNewReply_cid = nil
@@ -294,7 +296,7 @@ final class MessageUpdater_Mock: MessageUpdater {
     override func downloadAttachment<Payload>(
         _ attachment: ChatMessageAttachment<Payload>,
         completion: @escaping (Result<ChatMessageAttachment<Payload>, any Error>) -> Void
-    ) where Payload : DownloadableAttachmentPayload {
+    ) where Payload: DownloadableAttachmentPayload {
         downloadAttachment_attachmentId = attachment.id
         switch downloadAttachment_completion_result {
         case .success(let anyAttachment):
@@ -309,13 +311,14 @@ final class MessageUpdater_Mock: MessageUpdater {
             break
         }
         
-        //downloadAttachment_completion_result?  .invoke(with: completion)
+        // downloadAttachment_completion_result?  .invoke(with: completion)
     }
     
     override func editMessage(
         messageId: MessageId,
         text: String,
         skipEnrichUrl: Bool,
+        skipPush: Bool,
         attachments: [AnyAttachmentPayload] = [],
         restrictedVisibility: [UserId] = [],
         extraData: [String: RawJSON]? = nil,
@@ -324,6 +327,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         editMessage_messageId = messageId
         editMessage_text = text
         editMessage_skipEnrichUrl = skipEnrichUrl
+        editMessage_skipPush = skipPush
         editMessage_restrictedVisibility = restrictedVisibility
         editMessage_attachments = attachments
         editMessage_extraData = extraData
@@ -463,6 +467,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         deleteReaction_completion = completion
         deleteReaction_completion_result?.invoke(with: completion)
     }
+
     override func pinMessage(messageId: MessageId, pinning: MessagePinning, completion: ((Result<ChatMessage, any Error>) -> Void)? = nil) {
         pinMessage_messageId = messageId
         pinMessage_pinning = pinning

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -78,6 +78,8 @@ final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var addReaction_type: MessageReactionType?
     @Atomic var addReaction_score: Int?
     @Atomic var addReaction_enforceUnique: Bool?
+    @Atomic var addReaction_skipPush: Bool?
+    @Atomic var addReaction_pushEmojiCode: String?
     @Atomic var addReaction_extraData: [String: RawJSON]?
     @Atomic var addReaction_messageId: MessageId?
     @Atomic var addReaction_completion: ((Error?) -> Void)?
@@ -205,6 +207,9 @@ final class MessageUpdater_Mock: MessageUpdater {
 
         addReaction_type = nil
         addReaction_score = nil
+        addReaction_enforceUnique = nil
+        addReaction_skipPush = nil
+        addReaction_pushEmojiCode = nil
         addReaction_extraData = nil
         addReaction_messageId = nil
         addReaction_completion = nil
@@ -443,16 +448,20 @@ final class MessageUpdater_Mock: MessageUpdater {
     override func addReaction(
         _ type: MessageReactionType,
         score: Int,
-        enforceUnique: Bool = false,
+        enforceUnique: Bool,
+        skipPush: Bool,
+        pushEmojiCode: String?,
         extraData: [String: RawJSON],
         messageId: MessageId,
         completion: ((Error?) -> Void)? = nil
     ) {
         addReaction_type = type
         addReaction_score = score
+        addReaction_enforceUnique = enforceUnique
+        addReaction_skipPush = skipPush
+        addReaction_pushEmojiCode = pushEmojiCode
         addReaction_extraData = extraData
         addReaction_messageId = messageId
-        addReaction_enforceUnique = enforceUnique
         addReaction_completion = completion
         addReaction_completion_result?.invoke(with: completion)
     }

--- a/Tests/StreamChatTests/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -95,6 +95,35 @@ final class MessageEndpoints_Tests: XCTestCase {
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
         XCTAssertEqual("messages/\(payload.id)", endpoint.path.value)
     }
+
+    func test_editMessage_withSkipPush_buildsCorrectly() {
+        let payload = MessageRequestBody(
+            id: .unique,
+            user: .init(id: .unique, name: .unique, imageURL: .unique(), extraData: .init()),
+            text: .unique,
+            type: nil,
+            extraData: [:]
+        )
+
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .message(payload.id),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: [
+                "message": AnyEncodable(payload),
+                "skip_enrich_url": AnyEncodable(true),
+                "skip_push": AnyEncodable(true)
+            ]
+        )
+
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .editMessage(payload: payload, skipEnrichUrl: true, skipPush: true)
+
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("messages/\(payload.id)", endpoint.path.value)
+    }
     
     func test_pinMessage_buildsCorrectly() {
         let messageId: MessageId = .unique

--- a/Tests/StreamChatTests/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -84,12 +84,17 @@ final class MessageEndpoints_Tests: XCTestCase {
             requiresConnectionId: false,
             body: [
                 "message": AnyEncodable(payload),
-                "skip_enrich_url": AnyEncodable(true)
+                "skip_enrich_url": AnyEncodable(true),
+                "skip_push": AnyEncodable(false)
             ]
         )
 
         // Build endpoint
-        let endpoint: Endpoint<EmptyResponse> = .editMessage(payload: payload, skipEnrichUrl: true)
+        let endpoint: Endpoint<EmptyResponse> = .editMessage(
+            payload: payload,
+            skipEnrichUrl: true,
+            skipPush: false
+        )
 
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Tests/StreamChatTests/APIClient/Endpoints/ReactionEndpoint_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ReactionEndpoint_Tests.swift
@@ -55,7 +55,8 @@ final class ReactionEndpoints_Tests: XCTestCase {
             requiresConnectionId: false,
             body: MessageReactionRequestPayload(
                 enforceUnique: false,
-                reaction: ReactionRequestPayload(type: reaction, score: score, extraData: extraData)
+                skipPush: false,
+                reaction: ReactionRequestPayload(type: reaction, score: score, emojiCode: nil, extraData: extraData)
             )
         )
 
@@ -65,6 +66,49 @@ final class ReactionEndpoints_Tests: XCTestCase {
             score: score,
             enforceUnique: false,
             extraData: extraData,
+            skipPush: false,
+            emojiCode: nil,
+            messageId: messageId
+        )
+
+        // Assert endpoint is built correctly.
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("messages/\(messageId)/reaction", endpoint.path.value)
+    }
+
+    func test_addReaction_withSkipPushAndEmojiCode_buildsCorrectly() {
+        let messageId: MessageId = .unique
+        let reaction: MessageReactionType = .init(rawValue: "love")
+        let score = 3
+        let skipPush = true
+        let emojiCode = "❤️"
+        let extraData: [String: RawJSON] = ["custom": .string("value")]
+
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .addReaction(messageId),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: MessageReactionRequestPayload(
+                enforceUnique: true,
+                skipPush: skipPush,
+                reaction: ReactionRequestPayload(
+                    type: reaction,
+                    score: score,
+                    emojiCode: emojiCode,
+                    extraData: extraData
+                )
+            )
+        )
+
+        // Build endpoint.
+        let endpoint: Endpoint<EmptyResponse> = .addReaction(
+            reaction,
+            score: score,
+            enforceUnique: true,
+            extraData: extraData,
+            skipPush: skipPush,
+            emojiCode: emojiCode,
             messageId: messageId
         )
 

--- a/Tests/StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
@@ -11,7 +11,13 @@ final class MessageReactionRequestPayload_Tests: XCTestCase {
         // Build the payload.
         let payload = MessageReactionRequestPayload(
             enforceUnique: false,
-            reaction: ReactionRequestPayload(type: "like", score: 10, extraData: ["mood": .string("good one")])
+            skipPush: true,
+            reaction: ReactionRequestPayload(
+                type: "like",
+                score: 10,
+                emojiCode: "👍",
+                extraData: ["mood": .string("good one")]
+            )
         )
 
         // Encode the payload.
@@ -20,9 +26,11 @@ final class MessageReactionRequestPayload_Tests: XCTestCase {
         // Assert encoding is correct.
         AssertJSONEqual(json, [
             "enforce_unique": payload.enforceUnique,
+            "skip_push": payload.skipPush,
             "reaction": [
                 "type": payload.reaction.type.rawValue,
                 "score": payload.reaction.score,
+                "emoji_code": payload.reaction.emojiCode ?? "",
                 "mood": "good one"
             ] as [String: Any]
         ])

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -988,6 +988,30 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.editMessage_extraData, extraData)
     }
 
+    func test_editMessage_callsMessageUpdater_withSkipPushParameter() {
+        let updatedText: String = .unique
+
+        // Simulate `editMessage` call with skipPush set to true
+        controller.editMessage(text: updatedText, skipPush: true)
+
+        // Assert message updater is called with correct `skipPush` value
+        XCTAssertEqual(env.messageUpdater.editMessage_messageId, controller.messageId)
+        XCTAssertEqual(env.messageUpdater.editMessage_text, updatedText)
+        XCTAssertEqual(env.messageUpdater.editMessage_skipPush, true)
+    }
+
+    func test_editMessage_callsMessageUpdater_withSkipPushDefaultValue() {
+        let updatedText: String = .unique
+
+        // Simulate `editMessage` call without specifying skipPush (should use default false)
+        controller.editMessage(text: updatedText)
+
+        // Assert message updater is called with correct default `skipPush` value
+        XCTAssertEqual(env.messageUpdater.editMessage_messageId, controller.messageId)
+        XCTAssertEqual(env.messageUpdater.editMessage_text, updatedText)
+        XCTAssertEqual(env.messageUpdater.editMessage_skipPush, false)
+    }
+
     func test_editMessage_whenMessageTransformerIsProvided_callsUpdaterWithTransformedValues() throws {
         class MockTransformer: StreamModelsTransformer {
             var mockTransformedMessage = NewMessageTransformableInfo(

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -1989,20 +1989,39 @@ final class MessageController_Tests: XCTestCase {
         let score = 5
         let enforceUnique = true
         let extraData: [String: RawJSON] = [:]
+        let skipPush = true
+        let pushEmojiCode = "👍"
 
-        // Simulate `addReaction` call.
-        controller.addReaction(type, score: score, enforceUnique: true, extraData: extraData)
+        controller.addReaction(
+            type,
+            score: score,
+            enforceUnique: true,
+            skipPush: skipPush,
+            pushEmojiCode: pushEmojiCode,
+            extraData: extraData
+        )
 
-        // Assert updater is called with correct `type`.
         XCTAssertEqual(env.messageUpdater.addReaction_type, type)
-        // Assert updater is called with correct `score`.
         XCTAssertEqual(env.messageUpdater.addReaction_score, score)
-        // Assert updater is called with correct `enforceUnique`.
         XCTAssertEqual(env.messageUpdater.addReaction_enforceUnique, enforceUnique)
-        // Assert updater is called with correct `extraData`.
         XCTAssertEqual(env.messageUpdater.addReaction_extraData, extraData)
-        // Assert updater is called with correct `messageId`.
+        XCTAssertEqual(env.messageUpdater.addReaction_skipPush, skipPush)
+        XCTAssertEqual(env.messageUpdater.addReaction_pushEmojiCode, pushEmojiCode)
         XCTAssertEqual(env.messageUpdater.addReaction_messageId, controller.messageId)
+    }
+
+    func test_addReaction_callsUpdater_withDefaultValue() {
+        let type: MessageReactionType = "like"
+
+        controller.addReaction(type)
+
+        XCTAssertEqual(env.messageUpdater.addReaction_type, type)
+        XCTAssertEqual(env.messageUpdater.addReaction_skipPush, false)
+        XCTAssertEqual(env.messageUpdater.addReaction_messageId, controller.messageId)
+        XCTAssertEqual(env.messageUpdater.addReaction_score, 1)
+        XCTAssertEqual(env.messageUpdater.addReaction_enforceUnique, true)
+        XCTAssertEqual(env.messageUpdater.addReaction_extraData, [:])
+        XCTAssertNil(env.messageUpdater.addReaction_pushEmojiCode)
     }
 
     func test_addReaction_keepsControllerAlive() {

--- a/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
@@ -187,17 +187,17 @@ final class ChatThreadListController_Tests: XCTestCase {
                 threads: [
                     .dummy(
                         parentMessageId: .unique,
-                        updatedAt: date.addingTimeInterval(3),
+                        lastMessageAt: date.addingTimeInterval(30),
                         title: "1"
                     ),
                     .dummy(
                         parentMessageId: .unique,
-                        updatedAt: date.addingTimeInterval(2),
+                        lastMessageAt: date.addingTimeInterval(20),
                         title: "2"
                     ),
                     .dummy(
                         parentMessageId: .unique,
-                        updatedAt: date.addingTimeInterval(1),
+                        lastMessageAt: date.addingTimeInterval(1),
                         title: "3"
                     )
                 ],

--- a/Tests/StreamChatTests/Workers/Background/MessageEditor_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageEditor_Tests.swift
@@ -71,12 +71,30 @@ final class MessageEditor_Tests: XCTestCase {
 
         // Check only the message1 was synced
         AssertAsync {
-            Assert.willBeTrue(self.apiClient.request_allRecordedCalls.contains(where: {
-                $0.endpoint == AnyEndpoint(.editMessage(payload: message1Payload, skipEnrichUrl: false))
-            }))
-            Assert.staysFalse(self.apiClient.request_allRecordedCalls.contains(where: {
-                $0.endpoint == AnyEndpoint(.editMessage(payload: message2Payload, skipEnrichUrl: false))
-            }))
+            Assert.willBeTrue(
+                self.apiClient.request_allRecordedCalls.contains(
+                    where: {
+                        $0.endpoint == AnyEndpoint(
+                            .editMessage(
+                                payload: message1Payload,
+                                skipEnrichUrl: false,
+                                skipPush: false
+                            )
+                        )
+                    })
+            )
+            Assert.staysFalse(
+                self.apiClient.request_allRecordedCalls.contains(
+                    where: {
+                        $0.endpoint == AnyEndpoint(
+                            .editMessage(
+                                payload: message2Payload,
+                                skipEnrichUrl: false,
+                                skipPush: false
+                            )
+                        )
+                    })
+            )
         }
 
         XCTAssertCall("updateMessage(withID:localState:completion:)", on: messageRepository, times: 1)
@@ -112,9 +130,18 @@ final class MessageEditor_Tests: XCTestCase {
                 .asRequestBody()
         )
         AssertAsync {
-            Assert.willBeEqual(self.apiClient.request_allRecordedCalls.filter {
-                $0.endpoint == AnyEndpoint(.editMessage(payload: message1Payload, skipEnrichUrl: false))
-            }.count, 1)
+            Assert.willBeEqual(
+                self.apiClient.request_allRecordedCalls.filter {
+                    $0.endpoint == AnyEndpoint(
+                        .editMessage(
+                            payload: message1Payload,
+                            skipEnrichUrl: false,
+                            skipPush: false
+                        )
+                    )
+                }.count,
+                1
+            )
         }
         XCTAssertCall("updateMessage(withID:localState:completion:)", on: messageRepository, times: 1)
     }

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -62,7 +62,14 @@ final class MessageUpdater_Tests: XCTestCase {
     func test_editMessage_propagates_CurrentUserDoesNotExist_Error() throws {
         // Simulate `editMessage(messageId:, text:)` call
         let completionResult = try waitFor {
-            messageUpdater.editMessage(messageId: .unique, text: .unique, skipEnrichUrl: false, restrictedVisibility: [], completion: $0)
+            messageUpdater.editMessage(
+                messageId: .unique,
+                text: .unique,
+                skipEnrichUrl: false,
+                skipPush: false,
+                restrictedVisibility: [],
+                completion: $0
+            )
         }
 
         // Assert `CurrentUserDoesNotExist` is received
@@ -75,7 +82,14 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Simulate `editMessage(messageId:, text:)` call
         let completionResult = try waitFor {
-            messageUpdater.editMessage(messageId: .unique, text: .unique, skipEnrichUrl: false, restrictedVisibility: [], completion: $0)
+            messageUpdater.editMessage(
+                messageId: .unique,
+                text: .unique,
+                skipEnrichUrl: false,
+                skipPush: false,
+                restrictedVisibility: [],
+                completion: $0
+            )
         }
 
         // Assert `MessageDoesNotExist` is received
@@ -128,7 +142,14 @@ final class MessageUpdater_Tests: XCTestCase {
 
             // Edit created message with new text
             let completionResult = try waitFor {
-                messageUpdater.editMessage(messageId: messageId, text: updatedText, skipEnrichUrl: true, restrictedVisibility: [], completion: $0)
+                messageUpdater.editMessage(
+                    messageId: messageId,
+                    text: updatedText,
+                    skipEnrichUrl: true,
+                    skipPush: false,
+                    restrictedVisibility: [],
+                    completion: $0
+                )
             }
 
             // Load the edited message
@@ -198,7 +219,14 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Edit created message with new text
         let completionResult = try waitFor {
-            messageUpdater.editMessage(messageId: messageId, text: updatedText, skipEnrichUrl: false, restrictedVisibility: [], completion: $0)
+            messageUpdater.editMessage(
+                messageId: messageId,
+                text: updatedText,
+                skipEnrichUrl: false,
+                skipPush: false,
+                restrictedVisibility: [],
+                completion: $0
+            )
         }
 
         // Load the edited message
@@ -243,7 +271,14 @@ final class MessageUpdater_Tests: XCTestCase {
 
             // Edit created message with new text
             let completionResult = try waitFor {
-                messageUpdater.editMessage(messageId: messageId, text: updatedText, skipEnrichUrl: false, restrictedVisibility: [], completion: $0)
+                messageUpdater.editMessage(
+                    messageId: messageId,
+                    text: updatedText,
+                    skipEnrichUrl: false,
+                    skipPush: false,
+                    restrictedVisibility: [],
+                    completion: $0
+                )
             }
 
             // Load the message
@@ -291,6 +326,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 messageId: messageId,
                 text: updatedText,
                 skipEnrichUrl: false,
+                skipPush: false,
                 restrictedVisibility: [],
                 extraData: updatedExtraData,
                 completion: $0
@@ -336,6 +372,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 messageId: messageId,
                 text: updatedText,
                 skipEnrichUrl: false,
+                skipPush: false,
                 restrictedVisibility: [],
                 extraData: nil,
                 completion: $0
@@ -382,6 +419,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 messageId: messageId,
                 text: updatedText,
                 skipEnrichUrl: false,
+                skipPush: false,
                 attachments: updatedAttachmentsTypes.map { AnyAttachmentPayload.mock(type: $0) },
                 restrictedVisibility: [],
                 completion: $0
@@ -1510,6 +1548,8 @@ final class MessageUpdater_Tests: XCTestCase {
             reactionType,
             score: 1,
             enforceUnique: false,
+            skipPush: false,
+            pushEmojiCode: nil,
             extraData: [:],
             messageId: messageId
         ) { error in
@@ -1553,7 +1593,13 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Simulate `addReaction` call
         messageUpdater.addReaction(
-            reactionType, score: 1, enforceUnique: false, extraData: [:], messageId: messageId
+            reactionType,
+            score: 1,
+            enforceUnique: false,
+            skipPush: false,
+            pushEmojiCode: nil,
+            extraData: [:],
+            messageId: messageId
         ) { error in
             XCTAssertNil(error)
             dbCall.fulfill()
@@ -1594,7 +1640,13 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Simulate `addReaction` call
         messageUpdater.addReaction(
-            reactionType, score: 1, enforceUnique: false, extraData: [:], messageId: messageId
+            reactionType,
+            score: 1,
+            enforceUnique: false,
+            skipPush: false,
+            pushEmojiCode: nil,
+            extraData: [:],
+            messageId: messageId
         ) { error in
             XCTAssertNil(error)
             dbCall.fulfill()

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1441,6 +1441,8 @@ final class MessageUpdater_Tests: XCTestCase {
             reactionType,
             score: reactionScore,
             enforceUnique: false,
+            skipPush: false,
+            pushEmojiCode: nil,
             extraData: reactionExtraData,
             messageId: messageId
         ) { error in
@@ -1463,6 +1465,8 @@ final class MessageUpdater_Tests: XCTestCase {
                 score: reactionScore,
                 enforceUnique: false,
                 extraData: reactionExtraData,
+                skipPush: false,
+                emojiCode: nil,
                 messageId: messageId
             ))
         )
@@ -1477,6 +1481,8 @@ final class MessageUpdater_Tests: XCTestCase {
             .init(rawValue: .unique),
             score: 1,
             enforceUnique: false,
+            skipPush: false,
+            pushEmojiCode: nil,
             extraData: [:],
             messageId: messageId
         ) { error in


### PR DESCRIPTION
### 🔗 Issue Links

Related to https://linear.app/stream/issue/IOS-855/ios-support-push-preferences

### 🎯 Goal

Handle Push v3 changes related to skip push and emoji code in reactions.

### 📝 Summary

- Add `skipPush` parameter to `MessageController.editMessage()`
- Add `skipPush` and `emojiCode` to `MessageController.addReaction()`
- Add `Components.availableReactionsPushEmojis` for rendering emojis in reaction push notifications
- Add `Components.isReactionPushEmojisEnabled` to control whether an emoji should be set when adding a reaction
- Add `MessageNotificationContent.reaction` that can be used by Notification Service Extension

### 🛠 Implementation

By default, when adding a reaction, an emoji will be assigned to a reaction. If it is not assigned, the customer can always use the NSE to customise the content of the push notification and render the emoji or whatever they need in the NSE.

### 🧪 Manual Testing Notes

1. Add a reaction with User A
2. User B (recipient) should receive a push notification with an emoji
3. Go to the Demo App configuration (On both devices)
4. Change the isReactionPushEmojisEnabled to false (On both devices)
5. Repeat the process
6. It should still render the emoji (This time it will use the NSE)

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
