### PR TITLE
Restrictions should only have one (e)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -81,7 +81,7 @@ party or to operate a service; (c) allow any third party to access or use the
 Software Source Code; (d) sublicense or distribute the Software Source Code or
 any Modifications in Source Code or other derivative works based on any part of
 the Software Source Code; (e) use the Software in any manner that competes with
-Stream.io or its business; or (e) otherwise use the Software in any manner that
+Stream.io or its business; or (f) otherwise use the Software in any manner that
 exceeds the scope of use permitted in this Agreement. Customer shall use the
 Software in compliance with any accompanying documentation any laws applicable
 to Customer.


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Fix apparent typo in LICENSE file

### 📝 Summary

The Restrictions section of the license has two `(e)` sub bullets.

### 🛠 Implementation

Second `(e)` became `(f)`

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)

Remaining checklist does not apply:
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the numbering of restrictions in the license agreement for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->