### PR TITLE
Remove animation in message reactions when opening a sheet in the channel view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add pending messages support [#3754](https://github.com/GetStream/stream-chat-swift/pull/3754)
 
+## StreamChatUI
+### 🐞 Fixed
+- Remove animation in message reactions when opening a sheet in the channel view [#3763](https://github.com/GetStream/stream-chat-swift/pull/3763)
+
 # [4.83.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.83.0)
 _July 28, 2025_
 

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.swift
@@ -56,6 +56,7 @@ open class ChatMessageReactionsView: _View, ThemeProvider {
             )
             stackView.addArrangedSubview(itemView)
         }
+        stackView.layoutIfNeeded()
     }
 
     private func logWarning(unavailableReaction reaction: ChatMessageReactionData) {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-1040](https://linear.app/stream/issue/IOS-1040/)

### 🎯 Goal

Remove animation in message reactions when opening a sheet in the channel view

### 📝 Summary

* Force layout of the view when rebuilding reactions

### 🛠 Implementation

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  ![img](https://github.com/user-attachments/assets/784f83c5-ddbf-4ec1-b93b-7cd2b15e3002)   |  ![img](https://github.com/user-attachments/assets/2205dd98-974a-4ab9-9a4f-18835094672c)  |

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an animation when opening the reactions sheet in the channel view for a smoother user experience.

* **Documentation**
  * Updated the changelog to reflect the latest fix related to message reactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->