### PR TITLE
Fix `ChatClient.currentUserId` not removed instantly after calling `logout()`

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -508,17 +508,17 @@ public class ChatClient {
         completion: @escaping () -> Void
     ) {
         let currentUserController = currentUserController()
+
+        // We need to call logout after creating the current user controller.
+        // Otherwise we would not be able to create the controller without currentUserId.
+        authenticationRepository.logOutUser()
+
         if removeDevice, let currentUserDevice = currentUserController.currentUser?.currentDevice {
-            currentUserController.removeDevice(id: currentUserDevice.id) { [weak self] error in
+            currentUserController.removeDevice(id: currentUserDevice.id) { error in
                 if let error {
                     log.error(error)
                 }
-                self?.authenticationRepository.logOutUser()
             }
-        }
-
-        if !removeDevice {
-            authenticationRepository.logOutUser()
         }
 
         // Stop tracking active components

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -325,13 +325,16 @@ final class ChatClient_Tests: XCTestCase {
             try $0.saveCurrentUser(payload: .dummy(userId: userId, role: .admin))
             try $0.saveCurrentDevice(.unique)
         }
+
         let expectation = self.expectation(description: "logout completes")
         client.logout {
             expectation.fulfill()
         }
-        waitForExpectations(timeout: defaultTimeout)
+        /// Erasing current user id should be called right after calling logout.
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.logOut, on: testEnv.authenticationRepository!)
 
         // THEN
+        waitForExpectations(timeout: defaultTimeout)
         XCTAssertCall(ConnectionRepository_Mock.Signature.disconnect, on: testEnv.connectionRepository!)
         XCTAssertEqual(testEnv.apiClient?.request_endpoint?.path, .devices)
         XCTAssertEqual(testEnv.apiClient?.request_endpoint?.method, .delete)


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1056

### 🎯 Goal

Fixes `ChatClient.currentUserId` not removed instantly after calling `logout()`.

### 🛠 Implementation

Initially, I removed the currentUser data, only after the removeDevice was called, since it was not possible to create the current user controller without the currentUserId. But actually, now I just realised that we can just create the controller, and right after erase the current user local data.

This was if a customer runs this code, it will be correct:

```swift
client.logout()
print(client.currentUserId) // nil
```

### 🧪 Manual Testing Notes
N/A. Covered by tests.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
