### PR TITLE
Fix attachments with very big size

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactions+Types.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactions+Types.swift
@@ -6,7 +6,7 @@ import StreamChat
 import UIKit
 
 /// The information of a reaction ready to be displayed in a view.
-public struct ChatMessageReactionData {
+public struct ChatMessageReactionData: Equatable {
     /// The type of the reaction.
     public let type: MessageReactionType
     /// The score value of the reaction. By default it is the same value as `count`.

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.swift
@@ -8,7 +8,12 @@ import UIKit
 /// The view that shows the list of reactions attached to the message.
 open class ChatMessageReactionsView: _View, ThemeProvider {
     public var content: Content? {
-        didSet { updateContentIfNeeded() }
+        didSet {
+            if oldValue?.reactions == content?.reactions {
+                return
+            }
+            updateContentIfNeeded()
+        }
     }
 
     open var reactionItemView: ChatMessageReactionItemView.Type {
@@ -56,7 +61,6 @@ open class ChatMessageReactionsView: _View, ThemeProvider {
             )
             stackView.addArrangedSubview(itemView)
         }
-        stackView.layoutIfNeeded()
     }
 
     private func logWarning(unavailableReaction reaction: ChatMessageReactionData) {


### PR DESCRIPTION
### 🔗 Issue Links

N/A. Found while regression testing.

### 🎯 Goal

Fixes attachments growing very big when it has a reaction. The previous fix introduced here was reverted: https://github.com/GetStream/stream-chat-swift/pull/3763

The new fix is that whenever reactions have the same content, we don't re-render them. This way, there is no animation glitches, and it is even more efficient.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
