### PR TITLE
Fix video player not playing when GalleryVC is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix the height of the attachment view in the composer when using larger dynamic type [3762](https://github.com/GetStream/stream-chat-swift/pull/3762)
 - Remove animation in message reactions when opening a sheet in the channel view [#3763](https://github.com/GetStream/stream-chat-swift/pull/3763)
+- Fix video player not playable when GalleryVC is opened [#3773](https://github.com/GetStream/stream-chat-swift/pull/3773)
 
 # [4.83.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.83.0)
 _July 28, 2025_

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -250,9 +250,9 @@ open class GalleryVC: _ViewController,
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        self.updateContent()
-        self.attachmentsCollectionView.scrollToItem(
-            at: .init(item: self.content.currentPage, section: 0),
+        updateContent()
+        attachmentsCollectionView.scrollToItem(
+            at: .init(item: content.currentPage, section: 0),
             at: .centeredHorizontally,
             animated: false
         )

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -249,8 +249,10 @@ open class GalleryVC: _ViewController,
     
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        attachmentsCollectionView.scrollToItem(
-            at: .init(item: content.currentPage, section: 0),
+
+        self.updateContent()
+        self.attachmentsCollectionView.scrollToItem(
+            at: .init(item: self.content.currentPage, section: 0),
             at: .centeredHorizontally,
             animated: false
         )


### PR DESCRIPTION
### 🔗 Issue Links

Caught in regression testing: https://github.com/GetStream/stream-chat-swift/pull/3770

### 🎯 Goal

Fix video player not playing when GalleryVC is opened.

### 🛠 Implementation

Caused by https://github.com/GetStream/stream-chat-swift/pull/3745. When doing the fix, the `updateContent()` function was forgotten to be called on viewDidAppear(). This is where we start the video player if needed.

### 🧪 Manual Testing Notes

1. Open a message with a video
2. The video player should play

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the video player was not playable when opening the gallery view. The content now refreshes properly, ensuring videos play as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->