### PR TITLE
Handle member related events and channel truncated event in `LivestreamChannelController`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### ✅ Added
+- Handle member-related events in `LivestreamChannelController` [#3775](https://github.com/GetStream/stream-chat-swift/pull/3775)
+- Handle channel truncation events in `LivestreamChannelController` [#3775](https://github.com/GetStream/stream-chat-swift/pull/3775)
 
 # [4.84.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.84.0)
 _August 06, 2025_

--- a/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
+++ b/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
@@ -50,6 +50,35 @@ class DemoLivestreamChatChannelVC: _ViewController,
         .channelAvatarView.init()
         .withoutAutoresizingMaskConstraints
 
+    /// Title label shown in the navigation bar.
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.subheadlineBold
+        label.textColor = appearance.colorPalette.text
+        label.textAlignment = .center
+        label.setContentHuggingPriority(.required, for: .vertical)
+        return label
+    }()
+
+    /// Subtitle label showing members and online watchers in the navigation bar.
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.subtitleText
+        label.textAlignment = .center
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        return label
+    }()
+
+    /// Stack view containing title and subtitle for the navigation bar.
+    private lazy var titleStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 0
+        return stack
+    }()
+
     /// The message composer bottom constraint used for keyboard animation handling.
     var messageComposerBottomConstraint: NSLayoutConstraint?
 
@@ -159,6 +188,10 @@ class DemoLivestreamChatChannelVC: _ViewController,
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: channelAvatarView)
         channelAvatarView.content = (livestreamChannelController.channel, client.currentUserId)
+
+        // Set up custom title view with channel name and member/online counts
+        navigationItem.titleView = titleStackView
+        updateNavigationTitle()
 
         // Add pause banner
         view.addSubview(pauseBannerView)
@@ -381,7 +414,7 @@ class DemoLivestreamChatChannelVC: _ViewController,
         didUpdateChannel channel: ChatChannel
     ) {
         channelAvatarView.content = (livestreamChannelController.channel, client.currentUserId)
-        navigationItem.title = channel.name
+        updateNavigationTitle()
     }
 
     func livestreamChannelController(
@@ -437,6 +470,19 @@ class DemoLivestreamChatChannelVC: _ViewController,
             self.pauseBannerView.isHidden = !show
             self.pauseBannerView.alpha = show ? 1.0 : 0.0
         })
+    }
+
+    /// Updates the navigation title and subtitle with channel name, member count and online watcher count.
+    private func updateNavigationTitle() {
+        let channel = livestreamChannelController.channel
+        titleLabel.text = channel?.name ?? ""
+
+        let memberCount = channel?.memberCount ?? 0
+        let watcherCount = channel?.watcherCount ?? 0
+
+        let membersText = memberCount == 1 ? "1 member" : "\(memberCount) members"
+        let onlineText = watcherCount == 1 ? "1 online" : "\(watcherCount) online"
+        subtitleLabel.text = "\(membersText), \(onlineText)"
     }
 }
 

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -892,6 +892,14 @@ public class LivestreamChannelController: DataStoreProvider, EventsControllerDel
              is NotificationInviteRejectedEvent:
             updateChannelFromDataStore()
 
+        case let channelTruncatedEvent as ChannelTruncatedEvent:
+            channel = channelTruncatedEvent.channel
+            if let message = channelTruncatedEvent.message {
+                messages = [message]
+            } else {
+                messages = []
+            }
+
         default:
             break
         }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -882,6 +882,16 @@ public class LivestreamChannelController: DataStoreProvider, EventsControllerDel
         case let channelUpdatedEvent as ChannelUpdatedEvent:
             handleChannelUpdated(channelUpdatedEvent)
 
+        case is MemberAddedEvent,
+             is MemberRemovedEvent,
+             is MemberUpdatedEvent,
+             is NotificationAddedToChannelEvent,
+             is NotificationRemovedFromChannelEvent,
+             is NotificationInvitedEvent,
+             is NotificationInviteAcceptedEvent,
+             is NotificationInviteRejectedEvent:
+            updateChannelFromDataStore()
+
         default:
             break
         }
@@ -952,6 +962,15 @@ public class LivestreamChannelController: DataStoreProvider, EventsControllerDel
 
     private func handleChannelUpdated(_ event: ChannelUpdatedEvent) {
         channel = event.channel
+    }
+
+    // For events that do not have the channel data, and still
+    // go through the middleware, lets fetch it from DB and update it.
+    private func updateChannelFromDataStore() {
+        guard let cid = cid, let updatedChannel = dataStore.channel(cid: cid) else {
+            return
+        }
+        channel = updatedChannel
     }
 
     private func createNewMessage(

--- a/TestTools/StreamChatTestTools/TestData/DummyData/ChannelDetailPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/ChannelDetailPayload.swift
@@ -26,6 +26,7 @@ extension ChannelDetailPayload {
         isDisabled: Bool = false,
         isHidden: Bool? = nil,
         members: [MemberPayload] = [],
+        memberCount: Int? = nil,
         team: String? = nil,
         cooldownDuration: Int = 0
     ) -> Self {
@@ -48,7 +49,7 @@ extension ChannelDetailPayload {
             isBlocked: isBlocked,
             isHidden: isHidden,
             members: members,
-            memberCount: members.count,
+            memberCount: memberCount ?? members.count,
             team: team,
             cooldownDuration: cooldownDuration
         )

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -1138,11 +1138,137 @@ extension LivestreamChannelController_Tests {
             ),
             didReceiveEvent: event
         )
-        
+
         // Then
         XCTAssertEqual(controller.channel?.name, "Updated Name")
     }
-    
+
+    // MARK: - Member Update Events Tests
+
+    func test_didReceiveEvent_memberRelatedEvents_updateChannelFromDataStore() {
+        let cid = controller.cid!
+
+        // Test data for all member-related events
+        let memberEvents: [(event: Event, description: String)] = [
+            (
+                MemberAddedEvent(
+                    user: .mock(id: .unique),
+                    cid: cid,
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "MemberAddedEvent"
+            ),
+            (
+                MemberRemovedEvent(
+                    user: .mock(id: .unique),
+                    cid: cid,
+                    createdAt: .unique
+                ),
+                "MemberRemovedEvent"
+            ),
+            (
+                MemberUpdatedEvent(
+                    user: .mock(id: .unique),
+                    cid: cid,
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "MemberUpdatedEvent"
+            ),
+            (
+                NotificationAddedToChannelEvent(
+                    channel: .mock(cid: cid),
+                    unreadCount: nil,
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "NotificationAddedToChannelEvent"
+            ),
+            (
+                NotificationRemovedFromChannelEvent(
+                    user: .mock(id: .unique),
+                    cid: cid,
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "NotificationRemovedFromChannelEvent"
+            ),
+            (
+                NotificationInvitedEvent(
+                    user: .mock(id: .unique),
+                    cid: cid,
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "NotificationInvitedEvent"
+            ),
+            (
+                NotificationInviteAcceptedEvent(
+                    user: .mock(id: .unique),
+                    channel: .mock(cid: cid),
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "NotificationInviteAcceptedEvent"
+            ),
+            (
+                NotificationInviteRejectedEvent(
+                    user: .mock(id: .unique),
+                    channel: .mock(cid: cid),
+                    member: .mock(id: .unique),
+                    createdAt: .unique
+                ),
+                "NotificationInviteRejectedEvent"
+            )
+        ]
+
+        // Test each member-related event
+        for (index, (event, description)) in memberEvents.enumerated() {
+            let initialMemberCount = 10 + index
+            let updatedMemberCount = 20 + index
+
+            // Given - Set up initial channel in database
+            let initialChannelPayload = ChannelPayload.dummy(
+                channel: .dummy(cid: cid, memberCount: initialMemberCount)
+            )
+            try! client.databaseContainer.writeSynchronously { session in
+                try session.saveChannel(payload: initialChannelPayload)
+            }
+
+            // Load initial data
+            let exp = expectation(description: "sync completes")
+            controller.synchronize { _ in
+                exp.fulfill()
+            }
+            client.mockAPIClient.test_simulateResponse(.success(initialChannelPayload))
+
+            waitForExpectations(timeout: defaultTimeout)
+            XCTAssertEqual(controller.channel?.memberCount, initialMemberCount, "Initial setup failed for \(description)")
+
+            // Update channel in database with new member count
+            let updatedChannelPayload = ChannelPayload.dummy(
+                channel: .dummy(cid: cid, memberCount: updatedMemberCount)
+            )
+            try! client.databaseContainer.writeSynchronously { session in
+                try session.saveChannel(payload: updatedChannelPayload)
+            }
+
+            // When
+            controller.eventsController(
+                EventsController(notificationCenter: client.eventNotificationCenter),
+                didReceiveEvent: event
+            )
+
+            // Then
+            XCTAssertEqual(
+                controller.channel?.memberCount,
+                updatedMemberCount,
+                "\(description) should update channel from data store"
+            )
+        }
+    }
+
     func test_didReceiveEvent_differentChannelEvent_isIgnored() {
         let otherChannelId = ChannelId.unique
         let messageFromOtherChannel = ChatMessage.mock(id: "other", cid: otherChannelId, text: "Other message")


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1066/livestream-controller-member-and-truncation-events

### 🎯 Goal

Handle member related events and channel truncated event in`LivestreamChannelController`.

### 🛠 Implementation

For now, these events will still go through the DB to make sure it does not break the Channel List updates, but we make sure the data is updated inside the livestream controller as well.

### 🧪 Manual Testing Notes

Members:
1. Open the Channel List
2. Swipe
3. Tap on "..."
4. Show as livestream controller
5. Add a member / Remove a member
6. It should update the header subtitle text with the number of members, and online members

Truncation:
1. Open the Channel List
2. Swipe
3. Tap on "..."
4. Show as livestream controller
5. Truncate a channel with and without a message
6. It should update the messages of the channel accordingly

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Demo Livestream chat now shows a two-line navigation title with channel name, member count, and online watcher count, with proper pluralization.

- Improvements
  - Livestream channels now update in real time for member changes and channel truncation. Messages are reset appropriately when a channel is truncated.

- Documentation
  - Changelog updated to note new event-handling capabilities.

- Tests
  - Expanded test coverage for member events, channel truncation, cross-channel event filtering, and paused-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->