### PR TITLE
Handle user banned events in livestream controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Handle member-related events in `LivestreamChannelController` [#3775](https://github.com/GetStream/stream-chat-swift/pull/3775)
 - Handle channel truncation events in `LivestreamChannelController` [#3775](https://github.com/GetStream/stream-chat-swift/pull/3775)
+- Handle user banned events in `LivestreamChannelController` [#3777](https://github.com/GetStream/stream-chat-swift/pull/3777)
 - Add a completion block to `LivestreamChannelController.resume()` to observe possible errors [#3774](https://github.com/GetStream/stream-chat-swift/pull/3774)
 ### 🐞 Fixed
 - Fix pending message being added to `LivestreamChannelController.messages` when in paused state [#3774](https://github.com/GetStream/stream-chat-swift/pull/3774)

--- a/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
+++ b/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
@@ -355,6 +355,7 @@ class DemoLivestreamChatChannelVC: _ViewController,
     ) {
         channelAvatarView.content = (livestreamChannelController.channel, client.currentUserId)
         updateNavigationTitle()
+        messageComposerVC.updateContent()
     }
 
     func livestreamChannelController(
@@ -504,6 +505,13 @@ class DemoLivestreamComposerVC: ComposerVC {
 
     override var isCommandsEnabled: Bool {
         false
+    }
+
+    override var isSendMessageEnabled: Bool {
+        if livestreamChannelController?.channel?.membership?.isBannedFromChannel == true {
+            return false
+        }
+        return super.isSendMessageEnabled
     }
 }
 

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -914,6 +914,10 @@ public class LivestreamChannelController: DataStoreProvider, EventsControllerDel
              is NotificationInviteRejectedEvent:
             updateChannelFromDataStore()
 
+        case is UserBannedEvent,
+             is UserUnbannedEvent:
+            updateChannelFromDataStore()
+
         case let channelTruncatedEvent as ChannelTruncatedEvent:
             channel = channelTruncatedEvent.channel
             if let message = channelTruncatedEvent.message {

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -1432,19 +1432,15 @@ extension LivestreamChannelController_Tests {
         waitForExpectations(timeout: defaultTimeout)
         XCTAssertEqual(controller.channel?.membership?.isBannedFromChannel, true)
 
-        // Ban member
+        // Unban member
         try! client.databaseContainer.writeSynchronously { session in
             try session.saveMember(payload: .dummy(user: .dummy(userId: userId), isMemberBanned: false), channelId: cid)
         }
 
-        let event = UserBannedEvent(
+        let event = UserUnbannedEvent(
             cid: cid,
             user: .mock(id: userId),
-            ownerId: .unique,
-            createdAt: .unique,
-            reason: nil,
-            expiredAt: nil,
-            isShadowBan: nil
+            createdAt: .unique
         )
 
         // When


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1069/handle-user-banned-events-in-livestream-controlloer

### 🎯 Goal

Handle user-banned events in the livestream controller

### 🧪 Manual Testing Notes

1. Open Channel List with Leia Organa
2. Open Channel "LiveX Controller" with Han Solo and with "Show as Livestream Controller"
3. With Leia Organa, Ban Han Solo
4. Han Solo device should see "Can't send message" in Composer
5. With Leia Organa, Unban Han Solo
6. Han Solo should be able to send messages again

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Composer now refreshes automatically when the livestream channel updates.
- Bug Fixes
  - Livestream chat refreshes channel state on ban/unban events so membership status is current.
  - Message sending is disabled for users banned from a channel.
- Documentation
  - Added changelog entry noting handling of user banned events in livestream channels.
- Tests
  - Added tests verifying membership reflects ban/unban after related events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->