### PR TITLE
Fix audio recorder init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Fix audio recorder init method [#3783](https://github.com/GetStream/stream-chat-swift/pull/3783)
+- Fix `StreamAudioRecorder` not overridable because of init method [#3783](https://github.com/GetStream/stream-chat-swift/pull/3783)
 
 # [4.85.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.85.0)
 _August 13, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix audio recorder init method [#3783](https://github.com/GetStream/stream-chat-swift/pull/3783)
 
 # [4.85.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.85.0)
 _August 13, 2025_

--- a/Sources/StreamChat/Audio/AudioRecorder/AudioRecording.swift
+++ b/Sources/StreamChat/Audio/AudioRecorder/AudioRecording.swift
@@ -145,25 +145,34 @@ open class StreamAudioRecorder: NSObject, AudioRecording, AVAudioRecorderDelegat
         self.init(configuration: .default)
     }
 
-    /// Initialises a new instance of StreamAudioRecorder
+    /// Initializes a new `StreamAudioRecorder`.
+    ///
     /// - Parameters:
-    ///   - audioSessionConfigurator: The configurator to use to interact with `AVAudioSession`
-    ///   - audioRecorderSettings: The settings that will be used any time a new `AVAudioRecorder` is instantiated
-    ///   - audioFileName: The name of the file that will be used by every `AVAudioRecorder` instance to store in progress recordings.
-    ///   - audioRecorderBaseStorageURL: The path in where we would like to store temporary and finalised recording files.
-    ///   - audioRecorderMeterNormaliser: The normaliser that will be used to transform `AVAudioRecorder's` updated meter values.
-    public convenience init(
-        configuration: Configuration
+    ///   - configuration: Configuration for the recorder.
+    ///   - audioSessionConfigurator: The object used to interact with `AVAudioSession`. Defaults to `StreamAudioSessionConfigurator()`.
+    public init(
+        configuration: Configuration,
+        audioSessionConfigurator: AudioSessionConfiguring = StreamAudioSessionConfigurator()
     ) {
-        self.init(
-            configuration: configuration,
-            audioSessionConfigurator: StreamAudioSessionConfigurator(),
-            audioRecorderMeterNormaliser: AudioValuePercentageNormaliser(),
-            appStateObserver: StreamAppStateObserver(),
-            audioRecorderAVProvider: AVAudioRecorder.init
-        )
+        self.audioSessionConfigurator = audioSessionConfigurator
+        self.configuration = configuration
+        self.audioRecorderMeterNormaliser = AudioValuePercentageNormaliser()
+        self.appStateObserver = StreamAppStateObserver()
+        self.audioRecorderAVProvider = AVAudioRecorder.init
+        multicastDelegate = .init()
+
+        super.init()
+
+        setUp()
     }
 
+    /// Initialises a new instance of StreamAudioRecorder
+    /// - Parameters:
+    ///   - configuration: Configuration for the recorder.
+    ///   - audioSessionConfigurator: The object used to interact with `AVAudioSession`.
+    ///   - audioRecorderMeterNormaliser: Transforms meter values emitted by `AVAudioRecorder` into a normalised range for UI/logic.
+    ///   - appStateObserver: Observes application lifecycle events that the recorder reacts to.
+    ///   - audioRecorderAVProvider: Factory closure used to construct `AVAudioRecorder` instances for a given file URL and settings dictionary.
     internal init(
         configuration: Configuration,
         audioSessionConfigurator: AudioSessionConfiguring,

--- a/Sources/StreamChat/Audio/AudioRecorder/AudioRecording.swift
+++ b/Sources/StreamChat/Audio/AudioRecorder/AudioRecording.swift
@@ -156,9 +156,9 @@ open class StreamAudioRecorder: NSObject, AudioRecording, AVAudioRecorderDelegat
     ) {
         self.audioSessionConfigurator = audioSessionConfigurator
         self.configuration = configuration
-        self.audioRecorderMeterNormaliser = AudioValuePercentageNormaliser()
-        self.appStateObserver = StreamAppStateObserver()
-        self.audioRecorderAVProvider = AVAudioRecorder.init
+        audioRecorderMeterNormaliser = AudioValuePercentageNormaliser()
+        appStateObserver = StreamAppStateObserver()
+        audioRecorderAVProvider = AVAudioRecorder.init
         multicastDelegate = .init()
 
         super.init()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1076/openwav-fix-initializers-in-streamaudiorecorder.

### 🎯 Goal

Allow customers to override the audio recorder.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed an audio recorder override/initialization issue to improve extensibility and reliability.

- Changed
  - Audio recorder initialization now uses explicit dependency configuration; integration may need minor initialization updates.

- Documentation
  - Reorganized CHANGELOG under a StreamChat section and documented the audio recorder fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->