### PR TITLE
Fix channel list query filtering by both blocked and non-blocked channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix LivestreamChannelController not reconnecting when connection is dropped [#3782](https://github.com/GetStream/stream-chat-swift/pull/3782)
 - Fix `StreamAudioRecorder` not overridable because of init method [#3783](https://github.com/GetStream/stream-chat-swift/pull/3783)
+- Fix channel list query filtering by both blocked and non-blocked channels [#3785](https://github.com/GetStream/stream-chat-swift/pull/3785)
 
 # [4.85.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.85.0)
 _August 13, 2025_

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -41,6 +41,14 @@ final class DemoChatChannelListVC: ChatChannelListVC {
         .equal(.hidden, to: true)
     ]))
 
+    lazy var allBlockedChannelsQuery: ChannelListQuery = .init(filter: .and([
+        .containMembers(userIds: [currentUserId]),
+        .or([
+            .equal(.blocked, to: false),
+            .equal(.blocked, to: true)
+        ])
+    ]))
+
     lazy var unreadCountChannelsQuery: ChannelListQuery = .init(
         filter: .and([
             .containMembers(userIds: [currentUserId]),
@@ -145,6 +153,15 @@ final class DemoChatChannelListVC: ChatChannelListVC {
             }
         )
 
+        let allBlockedChannelsAction = UIAlertAction(
+            title: "Blocked and Non-Blocked Channels",
+            style: .default,
+            handler: { [weak self] _ in
+                self?.title = "All Blocked Channels"
+                self?.setAllBlockedChannelsQuery()
+            }
+        )
+
         let unreadCountChannelsAction = UIAlertAction(
             title: "Unread Count Channels",
             style: .default,
@@ -212,6 +229,7 @@ final class DemoChatChannelListVC: ChatChannelListVC {
                 unreadCountChannelsAction,
                 hasUnreadChannelsAction,
                 hiddenChannelsAction,
+                allBlockedChannelsAction,
                 mutedChannelsAction,
                 coolChannelsAction,
                 pinnedChannelsAction,
@@ -225,6 +243,10 @@ final class DemoChatChannelListVC: ChatChannelListVC {
 
     func setHiddenChannelsQuery() {
         replaceQuery(hiddenChannelsQuery)
+    }
+
+    func setAllBlockedChannelsQuery() {
+        replaceQuery(allBlockedChannelsQuery)
     }
 
     func setUnreadCountChannelsQuery() {

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -458,7 +458,9 @@ extension ChannelDTO {
 
         // If a hidden filter is not provided, we add a default hidden filter == 0.
         // The backend appends a `hidden: false` filter when it's not specified, so we need to do the same.
-        if query.filter.hiddenFilterValue == nil {
+        // Additionally we also check for blocked filter. Only if blocked or hidden filters are not provider,
+        // we add default hidden filter.
+        if query.filter.hiddenFilterValue == nil && query.filter.blockedFilterValue == nil {
             subpredicates.append(NSPredicate(format: "\(#keyPath(ChannelDTO.isHidden)) == 0"))
         }
 

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -113,6 +113,17 @@ extension Filter where Scope == ChannelListFilterScope {
             return nil
         }
     }
+
+    var blockedFilterValue: Bool? {
+        if `operator`.isGroupOperator {
+            let filters = value as? [Filter] ?? []
+            return filters.compactMap(\.blockedFilterValue).first
+        } else if `operator` == FilterOperator.equal.rawValue {
+            return key == FilterKey<Scope, Bool>.blocked.rawValue ? (value as? Bool) : nil
+        } else {
+            return nil
+        }
+    }
 }
 
 /// Filter values to be used with `.invite` FilterKey.

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1373,6 +1373,80 @@ final class ChannelListController_Tests: XCTestCase {
         )
     }
 
+    func test_filterPredicate_whenBlockedTrueOrFalse_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .or([
+                .equal(.blocked, to: true),
+                .equal(.blocked, to: false)
+            ]),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isBlocked: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isBlocked: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isBlocked: false))
+            ],
+            expectedResult: [cid1, cid2, cid3]
+        )
+    }
+
+    func test_filterPredicate_whenBlockedTrue_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .equal(.blocked, to: true),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isBlocked: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isBlocked: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isBlocked: false))
+            ],
+            expectedResult: [cid1, cid2]
+        )
+    }
+
+    func test_filterPredicate_whenBlockedFalse_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .equal(.blocked, to: false),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isBlocked: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isBlocked: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isBlocked: false))
+            ],
+            expectedResult: [cid3]
+        )
+    }
+
+    func test_filterPredicate_whenQueryingBothBlockedAndNonBlocked_containsExpectedItems() throws {
+        let currentUserId = UserId.unique
+        let cid1 = ChannelId.unique
+        let cid2 = ChannelId.unique
+        let cid3 = ChannelId.unique
+
+        try assertFilterPredicate(
+            .and([
+                .containMembers(userIds: [currentUserId]),
+                .or([
+                    .equal(.blocked, to: false),
+                    .equal(.blocked, to: true)
+                ])
+            ]),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, isBlocked: true), members: [.dummy(user: .dummy(userId: currentUserId))]),
+                .dummy(channel: .dummy(cid: cid2, isBlocked: false), members: [.dummy(user: .dummy(userId: currentUserId))]),
+                .dummy(channel: .dummy(cid: cid3, isBlocked: false), members: [.dummy(user: .dummy(userId: .unique))])
+            ],
+            expectedResult: [cid1, cid2]
+        )
+    }
+
     func test_filterPredicate_nor_containsExpectedItems() throws {
         let memberId1 = UserId.unique
         let memberId2 = UserId.unique


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1081/add-support-for-querying-both-blocked-and-non-blocked-channels

### 🎯 Goal

Fix channel list query filtering by both blocked and non-blocked channels.

### 🛠 Implementation

We need to remove the default hidden query, for when a blocked filter is provided.

### 🧪 Manual Testing Notes

1. Open the Demo App with Han Solo
2. Tap on the filters icon on right top corner
3. Select "Blocked and Non-Blocked Channels"
4. Channels with "Block" in the name should appear

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a filter option to view all channels (both blocked and non-blocked) the current user is in.

- Bug Fixes
  - Channel list filtering now correctly handles requests that include both blocked and non-blocked channels.

- Documentation
  - Updated changelog to reflect the fix for channel list filtering with blocked/non-blocked channels.

- Tests
  - Added unit tests to verify filtering behavior for blocked = true, blocked = false, and combined scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->