### PR TITLE
Add channelRole filter key for ChannelListQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### ✅ Added
+- Add `FilterKey.channelRole` for `ChannelListQuery` [3802](https://github.com/GetStream/stream-chat-swift/pull/3802)
 
 # [4.87.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.87.0)
 _August 29, 2025_

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -58,6 +58,13 @@ final class DemoChatChannelListVC: ChatChannelListVC {
             ])
         ])
     )
+    
+    lazy var channelModeratorChannelsQuery: ChannelListQuery = .init(
+        filter: .and([
+            .containMembers(userIds: [currentUserId]),
+            .equal(.channelRole, to: "channel_moderator")
+        ])
+    )
 
     lazy var unreadCountChannelsQuery: ChannelListQuery = .init(
         filter: .and([
@@ -180,6 +187,15 @@ final class DemoChatChannelListVC: ChatChannelListVC {
                 self?.setBlockedUnblockedWithHiddenChannelsQuery()
             }
         )
+        
+        let channelRoleChannelsAction = UIAlertAction(
+            title: "Moderator Channels",
+            style: .default,
+            handler: { [weak self] _ in
+                self?.title = "Moderator Channels"
+                self?.setChannelModeratorChannelsQuery()
+            }
+        )
 
         let unreadCountChannelsAction = UIAlertAction(
             title: "Unread Count Channels",
@@ -254,7 +270,8 @@ final class DemoChatChannelListVC: ChatChannelListVC {
                 coolChannelsAction,
                 pinnedChannelsAction,
                 archivedChannelsAction,
-                equalMembersAction
+                equalMembersAction,
+                channelRoleChannelsAction
             ].sorted(by: { $0.title ?? "" < $1.title ?? "" }),
             preferredStyle: .actionSheet,
             sourceView: filterChannelsButton
@@ -271,6 +288,10 @@ final class DemoChatChannelListVC: ChatChannelListVC {
     
     func setBlockedUnblockedWithHiddenChannelsQuery() {
         replaceQuery(blockedUnblockedWithHiddenChannelsQuery)
+    }
+    
+    func setChannelModeratorChannelsQuery() {
+        replaceQuery(channelModeratorChannelsQuery)
     }
 
     func setUnreadCountChannelsQuery() {

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -122,7 +122,7 @@ extension NSManagedObjectContext {
 
         // Save member specific data
         if let role = payload.role {
-            dto.channelRoleRaw = role.rawValue
+            dto.channelRoleRaw = role.rawChannelValue
         }
 
         dto.memberCreatedAt = payload.createdAt.bridgeDate
@@ -213,7 +213,7 @@ extension ChatChannelMember {
             memberExtraData = [:]
         }
 
-        let role = dto.channelRoleRaw.flatMap { MemberRole(rawValue: $0) } ?? .member
+        let role = dto.channelRoleRaw.flatMap { MemberRole(rawChannelValue: $0) } ?? .member
         let language: TranslationLanguage? = dto.user.language.map(TranslationLanguage.init)
 
         var member = ChatChannelMember(

--- a/Sources/StreamChat/Models/Member.swift
+++ b/Sources/StreamChat/Models/Member.swift
@@ -172,11 +172,26 @@ public struct MemberRole: RawRepresentable, Codable, Hashable, ExpressibleByStri
 
     public init(rawValue: String) {
         self.rawValue = rawValue
+        rawChannelValue = rawValue
     }
 
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }
+    
+    init(rawChannelValue: String) {
+        // Historically these have been mapped when decoding JSON
+        switch rawChannelValue {
+        case "channel_member":
+            self.init(rawValue: Self.member.rawValue)
+        case "channel_moderator":
+            self.init(rawValue: Self.moderator.rawValue)
+        default:
+            self.init(rawValue: rawChannelValue)
+        }
+    }
+    
+    var rawChannelValue: String
 }
 
 public extension MemberRole {
@@ -207,6 +222,8 @@ public extension MemberRole {
         default:
             self = MemberRole(rawValue: value)
         }
+        // Store the original raw value from the backend for local filtering
+        rawChannelValue = value
     }
     
     func encode(to encoder: any Encoder) throws {

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -287,6 +287,10 @@ public extension FilterKey where Scope == ChannelListFilterScope {
     /// Filter for the time of the last message in the channel. If the channel has no messages, then the time the channel was created.
     /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`
     static var lastUpdatedAt: FilterKey<Scope, Date> { .init(rawValue: "last_updated", keyPathString: #keyPath(ChannelDTO.defaultSortingAt)) }
+    
+    /// Filter for checking if the current user has a specific channel role set.
+    /// Supported operatios: `equal`, `in`
+    static var channelRole: FilterKey<Scope, String> { .init(rawValue: "channel_role", keyPathString: #keyPath(ChannelDTO.membership.channelRoleRaw)) }
 }
 
 /// Internal filter queries for the channel list.


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1112](https://linear.app/stream/issue/IOS-1112)

### 🎯 Goal

New `channel_role` filter key was added which needs to be exposed with local DB filtering support

### 📝 Summary

* Add `FilterKey.channelRole` for `ChannelListQuery`
* Store original unmapped role value in the local DB for local filtering (note that MemberRole struct maps `channel_member` to `member`)

### 🛠 Implementation

It is unfortunate that `MemberRole` maps `member` and `channel_member` to `member` which means that having a filter like:
```
filter: .and([
            .containMembers(userIds: [currentUserId]),
            .equal(.channelRole, to: "channel_moderator")
        ])
```
would fail because CoreData DB stores "member". This PR changes it so that now we store whatever backend returns.

### 🎨 Showcase

### 🧪 Manual Testing Notes

1. Log in with r2-d2
2. Change channel list filter to Moderator Channels
Result: one channel appears

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Moderator Channels” filter in the demo app to quickly view channels where you are a moderator.
  - Introduced a new channel list filter option that lets you filter channels by your role.
- Documentation
  - CHANGELOG updated with details about the new role-based channel filtering capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->