### PR TITLE
Added channelRole to ChatMessage model

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -56,6 +56,7 @@ enum MessagePayloadsCodingKeys: String, CodingKey, CaseIterable {
     case draft
     case location = "shared_location"
     case reminder
+    case member
 }
 
 extension MessagePayload {
@@ -117,6 +118,7 @@ class MessagePayload: Decodable {
     var draft: DraftPayload?
     var location: SharedLocationPayload?
     var reminder: ReminderPayload?
+    var member: MemberInfoPayload?
 
     /// Only message payload from `getMessage` endpoint contains channel data. It's a convenience workaround for having to
     /// make an extra call do get channel details.
@@ -186,6 +188,7 @@ class MessagePayload: Decodable {
         draft = try container.decodeIfPresent(DraftPayload.self, forKey: .draft)
         location = try container.decodeIfPresent(SharedLocationPayload.self, forKey: .location)
         reminder = try container.decodeIfPresent(ReminderPayload.self, forKey: .reminder)
+        member = try container.decodeIfPresent(MemberInfoPayload.self, forKey: .member)
     }
 
     init(
@@ -229,7 +232,8 @@ class MessagePayload: Decodable {
         poll: PollPayload? = nil,
         draft: DraftPayload? = nil,
         reminder: ReminderPayload? = nil,
-        location: SharedLocationPayload? = nil
+        location: SharedLocationPayload? = nil,
+        member: MemberInfoPayload? = nil
     ) {
         self.id = id
         self.cid = cid
@@ -272,6 +276,7 @@ class MessagePayload: Decodable {
         self.draft = draft
         self.location = location
         self.reminder = reminder
+        self.member = member
     }
 }
 
@@ -397,5 +402,13 @@ public struct Command: Codable, Hashable {
         self.description = description
         self.set = set
         self.args = args
+    }
+}
+
+public struct MemberInfoPayload: Codable, Hashable {
+    public let channelRole: MemberRole?
+    
+    enum CodingKeys: String, CodingKey {
+        case channelRole = "channel_role"
     }
 }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -116,6 +116,8 @@ class MessageDTO: NSManagedObject {
     // We use `Date!` to replicate a required value. The value must be marked as optional in the CoreData model, because we change
     // it in the `willSave` phase, which happens after the validation.
     @NSManaged var defaultSortingKey: DBDate!
+    
+    @NSManaged var channelRole: String?
 
     override func willSave() {
         super.willSave()
@@ -972,6 +974,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         dto.parentMessageId = payload.parentId
         dto.showReplyInChannel = payload.showReplyInChannel
         dto.replyCount = Int32(payload.replyCount)
+        dto.channelRole = payload.member?.channelRole?.rawValue
 
         do {
             dto.extraData = try JSONEncoder.default.encode(payload.extraData)
@@ -1860,6 +1863,11 @@ private extension ChatMessage {
         let draftReply = try? dto.draftReply?.relationshipAsModel(depth: depth)
 
         let readBy = Set(dto.reads.compactMap { try? $0.user.asModel() })
+        
+        var channelRole: MemberRole?
+        if let role = dto.channelRole {
+            channelRole = MemberRole(rawValue: role)
+        }
 
         let message = ChatMessage(
             id: id,
@@ -1906,7 +1914,8 @@ private extension ChatMessage {
                 createdAt: $0.createdAt.bridgeDate,
                 updatedAt: $0.updatedAt.bridgeDate
             ) },
-            sharedLocation: location
+            sharedLocation: location,
+            channelRole: channelRole
         )
 
         if let transformer = chatClientConfig?.modelsTransformer {

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -211,6 +211,7 @@
     </entity>
     <entity name="MessageDTO" representedClassName="MessageDTO" syncable="YES">
         <attribute name="args" optional="YES" attributeType="String"/>
+        <attribute name="channelRole" optional="YES" attributeType="String"/>
         <attribute name="cid" optional="YES" attributeType="String"/>
         <attribute name="command" optional="YES" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -183,6 +183,9 @@ public struct ChatMessage {
 
     /// The location information of the message.
     public let sharedLocation: SharedLocation?
+    
+    /// The role of the member in the channel.
+    public let channelRole: MemberRole?
 
     init(
         id: MessageId,
@@ -225,7 +228,8 @@ public struct ChatMessage {
         textUpdatedAt: Date?,
         draftReply: DraftMessage?,
         reminder: MessageReminderInfo?,
-        sharedLocation: SharedLocation?
+        sharedLocation: SharedLocation?,
+        channelRole: MemberRole?
     ) {
         self.id = id
         self.cid = cid
@@ -269,6 +273,7 @@ public struct ChatMessage {
         self.draftReply = draftReply
         self.sharedLocation = sharedLocation
         self.reminder = reminder
+        self.channelRole = channelRole
     }
 
     /// Returns a new `ChatMessage` with the provided data changed.
@@ -329,7 +334,8 @@ public struct ChatMessage {
             textUpdatedAt: textUpdatedAt,
             draftReply: draftReply,
             reminder: reminder,
-            sharedLocation: sharedLocation
+            sharedLocation: sharedLocation,
+            channelRole: channelRole
         )
     }
 
@@ -443,7 +449,8 @@ public struct ChatMessage {
             textUpdatedAt: textUpdatedAt,
             draftReply: draftReply,
             reminder: reminder,
-            sharedLocation: sharedLocation
+            sharedLocation: sharedLocation,
+            channelRole: channelRole
         )
     }
 }

--- a/Sources/StreamChat/Models/DraftMessage.swift
+++ b/Sources/StreamChat/Models/DraftMessage.swift
@@ -164,5 +164,6 @@ extension ChatMessage {
         draftReply = nil
         reminder = nil
         sharedLocation = nil
+        channelRole = nil
     }
 }

--- a/Sources/StreamChat/Models/Payload+asModel/MessagePayload+asModel.swift
+++ b/Sources/StreamChat/Models/Payload+asModel/MessagePayload+asModel.swift
@@ -136,7 +136,8 @@ extension MessagePayload {
                     createdAt: $0.createdAt,
                     endAt: $0.endAt
                 )
-            }
+            },
+            channelRole: member?.channelRole
         )
     }
 }

--- a/TestTools/StreamChatTestTools/Extensions/Unique/ChatMessage+Unique.swift
+++ b/TestTools/StreamChatTestTools/Extensions/Unique/ChatMessage+Unique.swift
@@ -55,7 +55,8 @@ extension ChatMessage {
             textUpdatedAt: nil,
             draftReply: nil,
             reminder: nil,
-            sharedLocation: nil
+            sharedLocation: nil,
+            channelRole: nil
         )
     }
 }

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Message.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Message.json
@@ -58,6 +58,9 @@
         "text" : "No, I am your father!",
         "show_in_channel": true,
         "parent_id": "3294-4c0c-9a62-c9d0928bf733",
+        "member": {
+            "channel_role": "moderator"
+        },
         "channel" : {
             "id" : "channel-ex7-63",
             "created_at" : "2019-12-17T17:11:26.131888Z",

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessage_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessage_Mock.swift
@@ -52,7 +52,8 @@ public extension ChatMessage {
         poll: Poll? = nil,
         draftReply: DraftMessage? = nil,
         reminder: MessageReminderInfo? = nil,
-        sharedLocation: SharedLocation? = nil
+        sharedLocation: SharedLocation? = nil,
+        channelRole: MemberRole? = nil
     ) -> Self {
         .init(
             id: id,
@@ -95,7 +96,8 @@ public extension ChatMessage {
             textUpdatedAt: textUpdatedAt,
             draftReply: draftReply,
             reminder: reminder,
-            sharedLocation: sharedLocation
+            sharedLocation: sharedLocation,
+            channelRole: channelRole
         )
     }
 }

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -63,6 +63,7 @@ final class MessagePayload_Tests: XCTestCase {
         XCTAssertEqual(payload.moderation?.blocklistMatched, "profanity_2021_01")
         XCTAssertEqual(payload.moderation?.semanticFilterMatched, "bad_phrases")
         XCTAssertEqual(payload.moderation?.platformCircumvented, false)
+        XCTAssertEqual(payload.member?.channelRole, .moderator)
     }
 
     func test_messagePayload_isSerialized_withDefaultExtraData_withBrokenAttachmentPayload() throws {

--- a/Tests/StreamChatTests/Models/ChatMessage_Tests.swift
+++ b/Tests/StreamChatTests/Models/ChatMessage_Tests.swift
@@ -532,7 +532,8 @@ final class ChatMessage_Tests: XCTestCase {
             moderationsDetails: nil,
             attachments: [
                 .dummy(id: .init(cid: .unique, messageId: .unique, index: 0))
-            ]
+            ],
+            channelRole: .moderator
         )
 
         // Test changing only some fields
@@ -553,6 +554,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertEqual(partiallyChangedMessage.allAttachments, originalMessage.allAttachments)
         XCTAssertEqual(partiallyChangedMessage.translations, originalMessage.translations)
         XCTAssertEqual(partiallyChangedMessage.originalLanguage, originalMessage.originalLanguage)
+        XCTAssertEqual(partiallyChangedMessage.channelRole, .moderator)
         XCTAssertNil(partiallyChangedMessage.moderationDetails)
 
         // Test changing all available fields


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1114/patreonllc-add-channel-role-parsing-to-message.

### 🎯 Goal

Expose channel role from the message.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
