### PR TITLE
Fix querying threads by disabled channels crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix querying threads by disabled channels crashing [#3813](https://github.com/GetStream/stream-chat-swift/pull/3813)
 
 # [4.88.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.88.0)
 _September 09, 2025_

--- a/Sources/StreamChat/Query/ThreadListQuery.swift
+++ b/Sources/StreamChat/Query/ThreadListQuery.swift
@@ -120,7 +120,7 @@ public extension FilterKey where Scope == ThreadListFilterScope {
     static var channelDisabled: FilterKey<Scope, Bool> {
         .init(
             rawValue: "channel.disabled",
-            keyPathString: #keyPath(ChannelDTO.isDisabled)
+            keyPathString: #keyPath(ThreadDTO.channel.isDisabled)
         )
     }
 }

--- a/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ThreadListController/ChatThreadListController_Tests.swift
@@ -208,6 +208,64 @@ final class ChatThreadListController_Tests: XCTestCase {
         XCTAssertEqual(controller.threads.count, 3)
         XCTAssertEqual(delegate.threads.map(\.title), ["1", "2", "3"])
     }
+
+    // MARK: - Filter Predicate Tests
+
+    func test_filterPredicate_channelDisabled_returnsExpectedResults() throws {
+        let threadId1 = MessageId.unique
+        let threadId2 = MessageId.unique
+        let threadId3 = MessageId.unique
+
+        try assertThreadFilterPredicate(
+            .equal(.channelDisabled, to: true),
+            threadsInDB: [
+                .dummy(
+                    parentMessageId: threadId1,
+                    channel: .dummy(cid: .unique, isDisabled: true),
+                    title: "Disabled Channel Thread 1"
+                ),
+                .dummy(
+                    parentMessageId: threadId2,
+                    channel: .dummy(cid: .unique, isDisabled: false),
+                    title: "Enabled Channel Thread 1"
+                ),
+                .dummy(
+                    parentMessageId: threadId3,
+                    channel: .dummy(cid: .unique, isDisabled: true),
+                    title: "Disabled Channel Thread 2"
+                )
+            ],
+            expectedResult: [threadId1, threadId3]
+        )
+    }
+
+    func test_filterPredicate_channelEnabled_returnsExpectedResults() throws {
+        let threadId1 = MessageId.unique
+        let threadId2 = MessageId.unique
+        let threadId3 = MessageId.unique
+
+        try assertThreadFilterPredicate(
+            .equal(.channelDisabled, to: false),
+            threadsInDB: [
+                .dummy(
+                    parentMessageId: threadId1,
+                    channel: .dummy(cid: .unique, isDisabled: true),
+                    title: "Disabled Channel Thread 1"
+                ),
+                .dummy(
+                    parentMessageId: threadId2,
+                    channel: .dummy(cid: .unique, isDisabled: false),
+                    title: "Enabled Channel Thread 1"
+                ),
+                .dummy(
+                    parentMessageId: threadId3,
+                    channel: .dummy(cid: .unique, isDisabled: false),
+                    title: "Enabled Channel Thread 2"
+                )
+            ],
+            expectedResult: [threadId2, threadId3]
+        )
+    }
 }
 
 // MARK: - Helpers
@@ -235,5 +293,76 @@ extension ChatThreadListController_Tests {
                 }
             )
         )
+    }
+
+    private func assertThreadFilterPredicate(
+        _ filter: @autoclosure () -> Filter<ThreadListFilterScope>,
+        sort: [Sorting<ThreadListSortingKey>] = [],
+        threadsInDB: @escaping @autoclosure () -> [ThreadPayload],
+        expectedResult: @autoclosure () -> [MessageId],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let query = ThreadListQuery(
+            watch: true,
+            filter: filter(),
+            sort: sort
+        )
+        controller = makeController(query: query)
+        
+        // Simulate `synchronize` call
+        controller.synchronize()
+        
+        // Wait for initial threads update
+        waitForInitialThreadsUpdate()
+        
+        XCTAssertEqual(controller.threads.map(\.parentMessageId), [], file: file, line: line)
+        
+        // Simulate changes in the DB:
+        _ = try waitFor {
+            client.databaseContainer.write({ session in
+                session.saveThreadList(payload: .init(
+                    threads: threadsInDB(),
+                    next: nil
+                ))
+            }, completion: $0)
+        }
+        
+        // Assert the resulting value is updated
+        XCTAssertEqual(
+            controller.threads.map(\.parentMessageId).sorted(),
+            expectedResult().sorted(),
+            file: file,
+            line: line
+        )
+    }
+
+    private func waitForInitialThreadsUpdate(file: StaticString = #file, line: UInt = #line) {
+        waitForThreadsUpdate(file: file, line: line) {}
+    }
+
+    private func waitForThreadsUpdate(file: StaticString = #file, line: UInt = #line, block: () -> Void) {
+        let threadsExpectation = expectation(description: "Threads update")
+        let delegate = ThreadsUpdateWaiter(threadsExpectation: threadsExpectation)
+        controller.delegate = delegate
+        block()
+        wait(for: [threadsExpectation], timeout: defaultTimeout)
+    }
+}
+
+private class ThreadsUpdateWaiter: ChatThreadListControllerDelegate {
+    weak var threadsExpectation: XCTestExpectation?
+
+    var didChangeThreadsCount: Int?
+
+    init(threadsExpectation: XCTestExpectation?) {
+        self.threadsExpectation = threadsExpectation
+    }
+
+    func controller(_ controller: ChatThreadListController, didChangeThreads changes: [ListChange<ChatThread>]) {
+        DispatchQueue.main.async {
+            self.didChangeThreadsCount = controller.threads.count
+            self.threadsExpectation?.fulfill()
+        }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1133/llc-crash-when-using-channeldisabled-filter-key-for-thread-list

### 🎯 Goal

Fix querying threads by disabled channels crashing.

### 🧪 Manual Testing Notes

N/A. Covered by tests. (Also tested manually)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash when querying or filtering threads in disabled channels. Filtering now correctly respects channel-disabled state, improving stability during thread browsing and moderation.

- **Documentation**
  - Reorganized the Upcoming section of the changelog under a new StreamChat section.
  - Added an entry detailing the fix for crashes when querying threads by disabled channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->