### PR TITLE
[CI] Get the correct target branch on public interface validation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -847,12 +847,15 @@ end
 lane :validate_public_interface do
   next unless is_check_required(sources: sources_matrix[:public_interface], force_check: @force_check)
 
-  # Run the analysis on the current branch
+  # Get branch names
   original_branch = current_branch
+  target_branch = ENV['GITHUB_BASE_REF'] || (original_branch.include?('release/') ? 'main' : 'develop')
+  UI.important("Target branch: #{target_branch} 🕊️")
+
+  # Run the analysis on the current branch
   sh('interface-analyser analysis ../Sources/ public_interface_current.json')
 
   # Checkout the target branch
-  target_branch = original_branch.include?('release/') ? 'main' : 'develop'
   sh("git fetch origin #{target_branch}")
   sh("git checkout #{target_branch}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI now automatically determines the appropriate target branch for public interface validation.
  - Runs interface analysis on both the current branch and the target branch to produce a comparison report.
  - Posts the diff report as a comment on pull requests when running in CI.
  - Ensures the original branch is restored after checks.
  - No user-facing changes to product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->