### PR TITLE
Keep hidden state unchanged when receiving campaign message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix logout not clearing token when current user had no device registered [#3838](https://github.com/GetStream/stream-chat-swift/pull/3838)
 - Fix `PollVoteListController` not updating votes on the vote cast event [#3849](https://github.com/GetStream/stream-chat-swift/pull/3849)
+- Fix showing channel when receiving a campaign message with `show_channels` false [#3851](https://github.com/GetStream/stream-chat-swift/pull/3851)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -58,6 +58,7 @@ enum MessagePayloadsCodingKeys: String, CodingKey, CaseIterable {
     case reminder
     case member
     case deletedForMe = "deleted_for_me"
+    case campaignId = "created_by_campaign_id"
 }
 
 extension MessagePayload {
@@ -121,6 +122,8 @@ class MessagePayload: Decodable {
     var reminder: ReminderPayload?
     var member: MemberInfoPayload?
     let deletedForMe: Bool?
+    
+    let campaignId: String?
 
     /// Only message payload from `getMessage` endpoint contains channel data. It's a convenience workaround for having to
     /// make an extra call do get channel details.
@@ -192,6 +195,7 @@ class MessagePayload: Decodable {
         reminder = try container.decodeIfPresent(ReminderPayload.self, forKey: .reminder)
         member = try container.decodeIfPresent(MemberInfoPayload.self, forKey: .member)
         deletedForMe = try container.decodeIfPresent(Bool.self, forKey: .deletedForMe)
+        campaignId = try container.decodeIfPresent(String.self, forKey: .campaignId)
     }
 
     init(
@@ -237,7 +241,8 @@ class MessagePayload: Decodable {
         reminder: ReminderPayload? = nil,
         location: SharedLocationPayload? = nil,
         member: MemberInfoPayload? = nil,
-        deletedForMe: Bool? = nil
+        deletedForMe: Bool? = nil,
+        campaignId: String? = nil
     ) {
         self.id = id
         self.cid = cid
@@ -282,6 +287,7 @@ class MessagePayload: Decodable {
         self.reminder = reminder
         self.member = member
         self.deletedForMe = deletedForMe
+        self.campaignId = campaignId
     }
 }
 

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware.swift
@@ -34,7 +34,7 @@ struct ChannelVisibilityEventMiddleware: EventMiddleware {
                     throw ClientError.ChannelDoesNotExist(cid: event.cid)
                 }
                 
-                if !event.message.isShadowed && !channelDTO.isBlocked {
+                if !event.message.isShadowed && event.message.campaignId == nil && !channelDTO.isBlocked {
                     channelDTO.isHidden = false
                 }
 
@@ -45,7 +45,7 @@ struct ChannelVisibilityEventMiddleware: EventMiddleware {
                     throw ClientError.ChannelDoesNotExist(cid: event.channel.cid)
                 }
 
-                if !event.message.isShadowed && !channelDTO.isBlocked {
+                if !event.message.isShadowed && event.message.campaignId == nil && !channelDTO.isBlocked {
                     channelDTO.isHidden = false
                 }
 

--- a/TestTools/StreamChatTestTools/TestData/DummyData/MessagePayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/MessagePayload.swift
@@ -54,7 +54,8 @@ extension MessagePayload {
         draft: DraftPayload? = nil,
         sharedLocation: SharedLocationPayload? = nil,
         member: MemberInfoPayload? = nil,
-        deletedForMe: Bool? = nil
+        deletedForMe: Bool? = nil,
+        campaignId: String? = nil
     ) -> MessagePayload {
         .init(
             id: messageId,
@@ -99,7 +100,8 @@ extension MessagePayload {
             draft: draft,
             location: sharedLocation,
             member: member,
-            deletedForMe: deletedForMe
+            deletedForMe: deletedForMe,
+            campaignId: campaignId
         )
     }
 

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware_Tests.swift
@@ -236,7 +236,36 @@ final class ChannelVisibilityEventMiddleware_Tests: XCTestCase {
         // Assert the `isHidden` value is still true
         XCTAssertTrue(channelDTO.isHidden)
     }
+    
+    func test_messageNewEvent_whenCampaignMessage_doesNotResetIsHidden() throws {
+        let cid: ChannelId = .unique
 
+        // Create the event
+        let event = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: cid,
+                user: .dummy(userId: .unique),
+                message: .dummy(messageId: .unique, authorUserId: .unique, campaignId: "campaign_123"),
+                createdAt: .unique
+            ) as EventPayload
+        )
+
+        // Create a channel in the DB with `isHidden` set to true
+        try database.writeSynchronously { session in
+            let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+            dto.isHidden = true
+        }
+
+        // Simulate incoming event
+        _ = middleware.handle(event: event, session: database.viewContext)
+
+        let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
+
+        // Assert the `isHidden` value is still true
+        XCTAssertTrue(channelDTO.isHidden)
+    }
+    
     func test_notificationMessageNewEvent_resetsHiddenAtValue() throws {
         let cid: ChannelId = .unique
 
@@ -278,6 +307,36 @@ final class ChannelVisibilityEventMiddleware_Tests: XCTestCase {
                 user: .dummy(userId: .unique),
                 channel: .dummy(cid: cid),
                 message: .dummy(messageId: .unique, authorUserId: .unique, isShadowed: true),
+                createdAt: .unique
+            )
+        )
+
+        // Create a channel in the DB with `isHidden` set to true
+        try database.writeSynchronously { session in
+            let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+            dto.isHidden = true
+        }
+
+        // Simulate incoming event
+        _ = middleware.handle(event: event, session: database.viewContext)
+
+        let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
+
+        // Assert the `isHidden` value is still true
+        XCTAssertTrue(channelDTO.isHidden)
+    }
+    
+    func test_notificationMessageNewEvent_whenCampaignMessage_doesNotResetIsHidden() throws {
+        let cid: ChannelId = .unique
+
+        // Create the event
+        let event = try NotificationMessageNewEventDTO(
+            from: .init(
+                eventType: .notificationMessageNew,
+                cid: cid,
+                user: .dummy(userId: .unique),
+                channel: .dummy(cid: cid),
+                message: .dummy(messageId: .unique, authorUserId: .unique, campaignId: "campaign_123"),
                 createdAt: .unique
             )
         )


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1194](https://linear.app/stream/issue/IOS-1194)

### 🎯 Goal

Keep channel hidden state unchanged wen receiving campaign message

### 📝 Summary

* If new message is from campaign, do not change hidden status because campaign API does that automatically through `show_channels: true/false` configuration

### 🛠 Implementation

[Campaign API](https://getstream.io/chat/docs/ios-swift/campaign_api/) has a setting called `show_channels`. If it is true, channels are automatically shown, if false, hidden state is not changed. On the other hand SDKs support "Hiding a channel will remove it from query channel requests for that user until a new message is added." ([docs](https://getstream.io/chat/docs/ios/muting_channels/#hiding-a-channel)). Only way for supporting both is opting out of showing channels on the SDK side when receiving a new message if the message is from campaign API.

### 🎨 Showcase

### 🧪 Manual Testing Notes

Download the [script](https://www.notion.so/stream-wiki/Testing-Campaign-API-2946a5d7f9f6809b8d8bce97d6a22d27)
1. Log in with anakin (hide the existing campaign channel if it is visible from previous testing)
2. Send a message with campaign API script when `show_channels: false` - channel does not appear in the channel list
3. Send a message with campaign API script when `show_channels: true` - channel appears in the channel list

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where channels were incorrectly displayed when receiving campaign messages with visibility settings set to false. Channels now properly maintain their hidden state when handling campaign-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->