### PR TITLE
Limit synced channels count to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `ChannelController.hasLoadedAllPreviousMessages` not correct for newly created channels [#3855](https://github.com/GetStream/stream-chat-swift/pull/3855)
 - Fix duplicated watch channel requests when a channel is created and it belongs to multiple queries [#3857](https://github.com/GetStream/stream-chat-swift/pull/3857)
 - Fix calling watch channel request when a channel is updated and it already belongs to another query [#3857](https://github.com/GetStream/stream-chat-swift/pull/3857)
+- Fix syncing error when trying to sync too many channels [#3863](https://github.com/GetStream/stream-chat-swift/pull/3863)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -122,7 +122,7 @@ final class SyncEventsOperation: AsyncOperation, @unchecked Sendable {
             }
             
             syncRepository?.syncChannelsEvents(
-                channelIds: Array(channelIds),
+                channelIds: Array(channelIds.prefix(100)),
                 lastSyncAt: context.lastSyncAt,
                 isRecovery: recovery
             ) { result in

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
@@ -12,6 +12,7 @@ final class SyncRepository_Mock: SyncRepository, Spy {
 
     let spyState = SpyState()
     var syncMissingEventsResult: Result<[ChannelId], SyncError>?
+    var syncMissingEvents_syncChannels: [ChannelId]?
 
     convenience init() {
         let apiClient = APIClient_Spy()
@@ -59,6 +60,7 @@ final class SyncRepository_Mock: SyncRepository, Spy {
         completion: @escaping (Result<[ChannelId], SyncError>) -> Void
     ) {
         record()
+        syncMissingEvents_syncChannels = channelIds
         syncMissingEventsResult.map(completion)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Fixes: [IOS-1219](https://linear.app/stream/issue/IOS-1219)

### 🎯 Goal

Set hard limit of 100 when calling /sync endpoint

### 📝 Summary

### 🛠 Implementation

### 🎨 Showcase

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed a syncing error that occurred when attempting to synchronize a large number of channels simultaneously. The system now implements proper handling for bulk channel synchronization operations, ensuring stable and reliable performance while preventing failures with extensive channel lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->