### PR TITLE
Remove timestamp from demo app message reads info view

### DIFF
--- a/DemoApp/StreamChat/Components/DeliveredMessages/DemoMessageReadsInfoView.swift
+++ b/DemoApp/StreamChat/Components/DeliveredMessages/DemoMessageReadsInfoView.swift
@@ -29,8 +29,7 @@ struct DemoMessageReadsInfoView: View {
                         ForEach(deliveredUsers, id: \.id) { user in
                             UserReadInfoRow(
                                 user: user,
-                                status: .delivered,
-                                timestamp: getDeliveredTimestamp(for: user)
+                                status: .delivered
                             )
                         }
                     }
@@ -41,8 +40,7 @@ struct DemoMessageReadsInfoView: View {
                         ForEach(readUsers, id: \.id) { user in
                             UserReadInfoRow(
                                 user: user,
-                                status: .read,
-                                timestamp: getReadTimestamp(for: user)
+                                status: .read
                             )
                         }
                     }
@@ -135,7 +133,6 @@ struct DemoMessageReadsInfoView: View {
 struct UserReadInfoRow: View {
     let user: ChatUser
     let status: ReadStatus
-    let timestamp: Date?
     
     enum ReadStatus {
         case delivered
@@ -184,12 +181,6 @@ struct UserReadInfoRow: View {
                 Text(user.name ?? user.id)
                     .font(.headline)
                     .foregroundColor(.primary)
-                
-                if let timestamp = timestamp {
-                    Text(formatTimestamp(timestamp))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
             }
             
             Spacer()
@@ -200,21 +191,5 @@ struct UserReadInfoRow: View {
                 .font(.title3)
         }
         .padding(.vertical, 4)
-    }
-    
-    private func formatTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        
-        let calendar = Calendar.current
-        if calendar.isDateInToday(date) {
-            return "Today at \(formatter.string(from: date))"
-        } else if calendar.isDateInYesterday(date) {
-            return "Yesterday at \(formatter.string(from: date))"
-        } else {
-            formatter.dateStyle = .short
-            return formatter.string(from: date)
-        }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: https://github.com/GetStream/docs-content/pull/746

### 🎯 Goal

Remove timestamps from the demo app message reads info view, as per the documentation. Rendering the timestamp is useless since it is always the same for every message.

### 🧪 Manual Testing Notes

N/A.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed timestamp information from message delivery and read status indicators. Message status displays (delivered/read) remain fully functional and continue to show as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->