### PR TITLE
[CI] Revert -Osize flag implementation

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,6 +3,9 @@ name: "Publish new release"
 on:
   workflow_dispatch:
 
+env:
+  XCODE_VERSION: "16.4"
+
 jobs:
   release:
     name: Publish new release

--- a/.github/workflows/sdk-performance-metrics.yml
+++ b/.github/workflows/sdk-performance-metrics.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+  XCODE_VERSION: "16.4"
 
 jobs:
   performance:

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+  XCODE_VERSION: "16.4"
 
 jobs:
   sdk_size:

--- a/Package.swift
+++ b/Package.swift
@@ -31,10 +31,7 @@ let package = Package(
         .target(
             name: "StreamChat",
             exclude: ["Info.plist"],
-            resources: [.copy("Database/StreamChatModel.xcdatamodeld")],
-            swiftSettings: [
-                .unsafeFlags(["-Osize"], .when(configuration: .release))
-            ]
+            resources: [.copy("Database/StreamChatModel.xcdatamodeld")]
         ),
         .target(
             name: "StreamChatUI",

--- a/StreamChat-XCFramework.podspec
+++ b/StreamChat-XCFramework.podspec
@@ -22,6 +22,4 @@ Pod::Spec.new do |spec|
   spec.preserve_paths = "#{spec.module_name}.xcframework/*"
 
   spec.cocoapods_version = '>= 1.11.0'
-
-  spec.pod_target_xcconfig = { 'SWIFT_OPTIMIZATION_LEVEL' => '-Osize' }
 end

--- a/StreamChat.podspec
+++ b/StreamChat.podspec
@@ -21,6 +21,4 @@ Pod::Spec.new do |spec|
   spec.source = { git: 'https://github.com/GetStream/stream-chat-swift.git', tag: spec.version.to_s }
   spec.source_files = ['Sources/StreamChat/**/*.swift']
   spec.resource_bundles = { 'StreamChat' => ['Sources/StreamChat/**/*.xcdatamodeld'] }
-
-  spec.pod_target_xcconfig = { 'SWIFT_OPTIMIZATION_LEVEL' => '-Osize' }
 end

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -14366,7 +14366,6 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Osize";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
### 🎯 Goal

Resolve:

> .unsafeFlags are not allowed for dependencies specified with a version. The workaround is to specify the version with a commit hash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to explicitly specify Xcode version 16.4
  * Modified release build configurations to use default optimization settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->