### PR TITLE
[CI] Delete excess arg on backend test run

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -544,7 +544,6 @@ lane :test_e2e do |options|
     cloned_source_packages_path: source_packages_path,
     clean: is_localhost,
     test_without_building: options[:test_without_building],
-    xcargs: buildcache_xcargs,
     devices: options[:device],
     prelaunch_simulator: is_ci,
     number_of_retries: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a build cache configuration setting from the end-to-end testing pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->