### PR TITLE
[CI] Comment out iOS 16.4 configuration on Cron Checks due to XCTest issues

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -30,9 +30,9 @@ jobs:
           - ios: "17.5"
             device: "iPhone 15 Pro"
             setup_runtime: true
-          - ios: "16.4"
-            device: "iPhone 14 Pro"
-            setup_runtime: true
+          # - ios: "16.4" # XCTest runner hangs most of the time on iOS 16
+          #   device: "iPhone 14 Pro"
+          #   setup_runtime: true
           - ios: "15.5"
             device: "iPhone 13 Pro"
             setup_runtime: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted testing matrix configuration by disabling a specific device and OS version combination from automated test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->