### PR TITLE
[CI][v5] Enable offline E2E test

### DIFF
--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -259,8 +259,6 @@ final class MessageList_Tests: StreamTestCase {
 
     func test_addMessageWhileOffline() throws {
         linkToScenario(withId: 36)
-        
-        throw XCTSkip("https://linear.app/stream/issue/IOS-1345")
 
         let message = "test message"
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1345

### 🎯 Goal

Enable offline E2E test

### 📝 Summary

After implementing new mock server, this test fails on v4 and passes on v5.
On v4 this test will be run manually, on v5 it will be run automatically.

