### PR TITLE
[CI] Add E2E tests for draft messages

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -607,6 +607,8 @@
 		829CD5C72848C71B003C3877 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5C62848C71B003C3877 /* Settings.swift */; };
 		829CD5CC2848C8D6003C3877 /* BackendRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5CB2848C8D6003C3877 /* BackendRobot.swift */; };
 		82A6F5C027E2031000F4A2F6 /* Reactions_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A6F5BF27E2031000F4A2F6 /* Reactions_Tests.swift */; };
+		82AA15092F211F9100555893 /* StreamSwiftTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 8274181E2ACDE85E004A23DA /* StreamSwiftTestHelpers */; };
+		82AA150B2F2234EA00555893 /* DraftMessages_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AA150A2F2234D700555893 /* DraftMessages_Tests.swift */; };
 		82BA52EF27E1EF7B00951B87 /* MessageList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BA52EE27E1EF7B00951B87 /* MessageList_Tests.swift */; };
 		82BE0ACD2C009A17008DA9DC /* BlockedUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BE0ACC2C009A17008DA9DC /* BlockedUserDetails.swift */; };
 		82BE0ACE2C009A17008DA9DC /* BlockedUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BE0ACC2C009A17008DA9DC /* BlockedUserDetails.swift */; };
@@ -3615,6 +3617,7 @@
 		829CD5C62848C71B003C3877 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		829CD5CB2848C8D6003C3877 /* BackendRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendRobot.swift; sourceTree = "<group>"; };
 		82A6F5BF27E2031000F4A2F6 /* Reactions_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reactions_Tests.swift; sourceTree = "<group>"; };
+		82AA150A2F2234D700555893 /* DraftMessages_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftMessages_Tests.swift; sourceTree = "<group>"; };
 		82AA16CF28A400F8009816CD /* StreamChatFlakyTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StreamChatFlakyTests.xctestplan; sourceTree = "<group>"; };
 		82AD02BC27D8E44B000611B7 /* StreamTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamTestCase.swift; sourceTree = "<group>"; };
 		82BA52EE27E1EF7B00951B87 /* MessageList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageList_Tests.swift; sourceTree = "<group>"; };
@@ -5095,8 +5098,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82AA15092F211F9100555893 /* StreamSwiftTestHelpers in Frameworks */,
 				E74DB0C82656631700508D22 /* StreamChatUI.framework in Frameworks */,
-				8274181F2ACDE85E004A23DA /* StreamSwiftTestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6241,6 +6244,7 @@
 				829762DF28C7587500B953E8 /* PushNotification_Tests.swift */,
 				826EF2B0291C01C1005A9EEF /* Authentication_Tests.swift */,
 				8292D6DA29B78476007A17D1 /* QuotedReply_Tests.swift */,
+				82AA150A2F2234D700555893 /* DraftMessages_Tests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -12320,6 +12324,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				829CD5CC2848C8D6003C3877 /* BackendRobot.swift in Sources */,
+				82AA150B2F2234EA00555893 /* DraftMessages_Tests.swift in Sources */,
 				82CED1C827DF492F006E967A /* ThreadPage.swift in Sources */,
 				8292D6DB29B78476007A17D1 /* QuotedReply_Tests.swift in Sources */,
 				8232B84F28635C4A0032C7DB /* Attachments_Tests.swift in Sources */,

--- a/StreamChatUITestsApp/StreamChat/StreamChatWrapper+TestApp.swift
+++ b/StreamChatUITestsApp/StreamChat/StreamChatWrapper+TestApp.swift
@@ -39,5 +39,6 @@ extension StreamChatWrapper {
         Components.default.threadVC = ThreadVC.self
         Components.default.messageActionsVC = MessageActionsVC.self
         Components.default.messageSwipeToReplyEnabled = true
+        Components.default.isDraftMessagesEnabled = true
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -670,6 +670,22 @@ extension UserRobot {
         XCTAssertEqual(expectedCount, actualCount, file: file, line: line)
         return self
     }
+    
+    @discardableResult
+    func assertComposerText(
+        _ text: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let composerTextView = MessageListPage.Composer.textView.wait()
+        XCTAssertEqual(
+            composerTextView.text,
+            text,
+            file: file,
+            line: line
+        )
+        return self
+    }
 
     @discardableResult
     func assertComposerLeftButtons(

--- a/StreamChatUITestsAppUITests/Tests/DraftMessages_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/DraftMessages_Tests.swift
@@ -1,0 +1,112 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+final class DraftMessages_Tests: StreamTestCase {
+    let firstMessage = "message"
+    let draftMessage = "alright"
+    
+    func test_updateChannelDraftMessage() {
+        linkToScenario(withId: 7120)
+
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        AND("user sends a message") {
+            userRobot.sendMessage(firstMessage)
+        }
+        WHEN("user inputs some text in the composer") {
+            userRobot.typeText(draftMessage)
+        }
+        AND("user leaves the Channel") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("the draft message is in preview") {
+            userRobot.assertLastMessageInChannelPreview("Draft: \(draftMessage)")
+        }
+        WHEN("user comes back to the channel") {
+            userRobot.openChannel()
+        }
+        THEN("the draft message is in the composer") {
+            userRobot.assertComposerText(draftMessage)
+        }
+        WHEN("user deletes the draft message") {
+            userRobot.clearComposer()
+        }
+        AND("user leaves the Channel") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("there is no draft message in preview") {
+            userRobot.assertLastMessageInChannelPreview("You: \(firstMessage)")
+        }
+        WHEN("user comes back to the channel") {
+            userRobot.openChannel()
+        }
+        THEN("there is no draft message in the composer") {
+            userRobot.assertComposerText("")
+        }
+    }
+    
+    func test_updateThreadDraftMessage() {
+        linkToScenario(withId: 7121)
+
+        GIVEN("user opens a thread") {
+            backendRobot.generateChannels(
+                channelsCount: 1,
+                messagesCount: 1,
+                repliesCount: 1,
+                repliesText: firstMessage
+            )
+            userRobot
+                .login()
+                .openChannel()
+                .openThread()
+        }
+        WHEN("user inputs some text in the composer") {
+            userRobot.typeText(draftMessage)
+        }
+        AND("user leaves the Thread and comes back to the Thread") {
+            userRobot.tapOnBackButton().openThread()
+        }
+        THEN("the draft message is in the composer") {
+            userRobot.assertComposerText(draftMessage)
+        }
+        WHEN("user deletes the draft message") {
+            userRobot.clearComposer()
+        }
+        AND("user leaves the Thread and comes back to the Thread") {
+            userRobot.tapOnBackButton().openThread()
+        }
+        THEN("there is no draft message in the composer") {
+            userRobot.assertComposerText("")
+        }
+    }
+    
+    func test_updateDraftMessageBeingOffline() {
+        linkToScenario(withId: 7122)
+
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        AND("user becomes offline") {
+            userRobot.setConnectivity(to: .off)
+        }
+        WHEN("user inputs some text in the composer") {
+            userRobot.typeText(draftMessage)
+        }
+        AND("user leaves the Channel") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("the draft message is in preview") {
+            userRobot.assertLastMessageInChannelPreview("Draft: \(draftMessage)")
+        }
+        WHEN("user comes back to the channel") {
+            userRobot.openChannel()
+        }
+        THEN("the draft message is in the composer") {
+            userRobot.assertComposerText(draftMessage)
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-930

### 🎯 Goal

Add E2E tests for draft messages

### 🧪 Manual Testing Notes

Run new tests locally from Xcode or CLI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Draft messages functionality is now enabled for testing across channels, threads, and offline scenarios.

* **Tests**
  * Added comprehensive test coverage for draft message preservation and restoration across various user workflows.
  * Added assertion utilities to validate draft message content during testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->