### PR TITLE
[CI] Do not run PR checks on png changes

### DIFF
--- a/.github/workflows/sdk-performance-metrics.yml
+++ b/.github/workflows/sdk-performance-metrics.yml
@@ -9,6 +9,10 @@ on:
     types:
       - opened
       - ready_for_review
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '**/*.png'
 
   workflow_dispatch:
 

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -2,6 +2,10 @@ name: SDK Size
 
 on:
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '**/*.png'
 
   workflow_dispatch:
 

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
+      - '**/*.png'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflows to skip unnecessary runs when only documentation or image files are modified, reducing CI/CD overhead and improving efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->