### PR TITLE
V5: Add configurable emoji reactions for design refresh

### DIFF
--- a/Sources/StreamChatCommonUI/Appearance+Images.swift
+++ b/Sources/StreamChatCommonUI/Appearance+Images.swift
@@ -408,5 +408,22 @@ public extension Appearance {
                 weight: .regular
             )
         )
+        
+        /// The reactions emoji unicode rendered in the message list.
+        public var availableMessagesReactionEmojis: [MessageReactionType: String] {
+            get {
+                _availableMessagesReactionEmojis ??
+                    [
+                        "love": "❤️",
+                        "haha": "😂",
+                        "like": "👍",
+                        "sad": "👎",
+                        "wow": "😮"
+                    ]
+            }
+            set { _availableMessagesReactionEmojis = newValue }
+        }
+
+        private var _availableMessagesReactionEmojis: [MessageReactionType: String]?
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1379](https://linear.app/stream/issue/IOS-1379/v5-message-list-text-only-messages-with-reactions)

### 🎯 Goal

Different set of reactions for design refresh (emoji based, rather than vector images)

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
