### PR TITLE
Prevent adding back deleted reactions in case of client errors

### DIFF
--- a/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
@@ -41,6 +41,13 @@ extension Error {
         return false
     }
 
+    var isClientError: Bool {
+        if let error = (self as? ClientError)?.underlyingError as? ErrorPayload {
+            return error.isClientError
+        }
+        return false
+    }
+
     var isRateLimitError: Bool {
         if let error = (self as? ClientError)?.underlyingError as? ErrorPayload,
            error.statusCode == 429 {

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -652,6 +652,7 @@ class MessageUpdater: Worker {
                 guard let error = result.error else { return }
 
                 if self?.canKeepReactionState(for: error) == true { return }
+                if error.isClientError { return }
 
                 repository?.undoReactionDeletion(on: messageId, type: type, score: reactionScore ?? 1)
             }

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1911,6 +1911,110 @@ final class MessageUpdater_Tests: XCTestCase {
         XCTAssertEqual(reactionReloaded.localState, .deletingFailed)
     }
 
+    func test_deleteReaction_clientError_localStorageEnabled_doesNotUndoDeletion() throws {
+        let userId: UserId = .unique
+        let messageId: MessageId = try setupReactionData(userId: userId)
+        let reactionType: MessageReactionType = .init(rawValue: .unique)
+
+        try database.writeSynchronously { _ in
+            try self.database.writableContext
+                .saveReaction(payload: .dummy(
+                    type: reactionType,
+                    messageId: messageId,
+                    user: .dummy(userId: userId),
+                    extraData: [:]
+                ), query: nil, cache: nil)
+        }
+
+        recreateUpdater(isLocalStorageEnabled: true)
+
+        // Simulate `deleteReaction` call.
+        let dbCall = XCTestExpectation(description: "database call")
+        messageUpdater.deleteReaction(reactionType, messageId: messageId) { error in
+            XCTAssertNil(error)
+            dbCall.fulfill()
+        }
+
+        // wait for the db call to be done
+        wait(for: [dbCall], timeout: defaultTimeout)
+
+        guard let reaction = database.viewContext.reaction(messageId: messageId, userId: userId, type: reactionType) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(reaction.localState, .pendingDelete)
+
+        // Simulate API response with a 4xx client error.
+        let clientError = ClientError(with: ErrorPayload(code: 0, message: "Bad request", statusCode: 400))
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(clientError))
+        apiClient.waitForRequest()
+
+        try database.writeSynchronously { _ in
+            try self.database.writableContext.save()
+        }
+
+        guard let reactionReloaded = database.viewContext.reaction(messageId: messageId, userId: userId, type: reactionType) else {
+            XCTFail()
+            return
+        }
+
+        // Should keep pendingDelete, not undo to deletingFailed
+        XCTAssertEqual(reactionReloaded.localState, .pendingDelete)
+    }
+
+    func test_deleteReaction_clientError_localStorageDisabled_doesNotUndoDeletion() throws {
+        let userId: UserId = .unique
+        let messageId: MessageId = try setupReactionData(userId: userId)
+        let reactionType: MessageReactionType = .init(rawValue: .unique)
+
+        try database.writeSynchronously { _ in
+            try self.database.writableContext
+                .saveReaction(payload: .dummy(
+                    type: reactionType,
+                    messageId: messageId,
+                    user: .dummy(userId: userId),
+                    extraData: [:]
+                ), query: nil, cache: nil)
+        }
+
+        recreateUpdater(isLocalStorageEnabled: false)
+
+        // Simulate `deleteReaction` call.
+        let dbCall = XCTestExpectation(description: "database call")
+        messageUpdater.deleteReaction(reactionType, messageId: messageId) { error in
+            XCTAssertNil(error)
+            dbCall.fulfill()
+        }
+
+        // wait for the db call to be done
+        wait(for: [dbCall], timeout: defaultTimeout)
+
+        guard let reaction = database.viewContext.reaction(messageId: messageId, userId: userId, type: reactionType) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(reaction.localState, .pendingDelete)
+
+        // Simulate API response with a 4xx client error.
+        let clientError = ClientError(with: ErrorPayload(code: 0, message: "Not found", statusCode: 404))
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(clientError))
+        apiClient.waitForRequest()
+
+        try database.writeSynchronously { _ in
+            try self.database.writableContext.save()
+        }
+
+        guard let reactionReloaded = database.viewContext.reaction(messageId: messageId, userId: userId, type: reactionType) else {
+            XCTFail()
+            return
+        }
+
+        // Should keep pendingDelete even with local storage disabled
+        XCTAssertEqual(reactionReloaded.localState, .pendingDelete)
+    }
+
     // MARK: - Pinning message
 
     func test_pinMessage_propagates_MessageDoesNotExist_Error() throws {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1411/prevent-adding-back-deleted-reactions-in-case-of-client-errors.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reaction deletion error handling to no longer revert deletions when encountering client-side API errors.

* **Tests**
  * Added test coverage for reaction deletion behavior when client-side API errors occur, including scenarios with different storage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->