### PR TITLE
Fix build errors when building with Xcode 26.4

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1361,7 +1361,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// - Parameters:
     ///   - timestamp: The timestamp used to find the first message to mark as unread. All messages created after this timestamp will be marked as unread.
     ///   - completion: The completion handler to be called after marking messages as unread. Called with a `Result` containing the updated `ChatChannel` on success, or an `Error` on failure.
-    public func markUnread(from timestamp: Date, completion: (@Sendable (Result<ChatChannel, Error>) -> Void)? = nil) {
+    public func markUnread(from timestamp: Date, completion: (@MainActor (Result<ChatChannel, Error>) -> Void)? = nil) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let channel = channel else {
             let error = ClientError.ChannelNotCreatedYet()

--- a/Sources/StreamChatUI/StreamNuke/Nuke/Prefetching/ImagePrefetcher.swift
+++ b/Sources/StreamChatUI/StreamNuke/Nuke/Prefetching/ImagePrefetcher.swift
@@ -50,7 +50,7 @@ final class ImagePrefetcher: @unchecked Sendable {
     /// regardless of whether the requests succeed or some fail.
     ///
     /// - note: The closure is called on the main queue.
-    var didComplete: (@MainActor() -> Void)?
+    var didComplete: (@MainActor () -> Void)?
 
     private let pipeline: ImagePipeline
     private var tasks = [TaskLoadImageKey: Task]()


### PR DESCRIPTION
### 🔗 Issue Links

Fixes [IOS-1545](https://linear.app/stream/issue/IOS-1545/xcode-264-compatibility)

### 🎯 Goal

Build error when building with Xcode 26.4 (Xcode 26.3 is OK)

### 📝 Summary

### 🛠 Implementation

### 🎨 Showcase

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal threading annotations for improved concurrency handling.
  * Minor code formatting adjustments.

This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->