### PR TITLE
[V4] Fix clearing unread messages on channel open when the first unread message is not visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ Dependencies/
 # VSCode
 .vscode
 buildServer.json
+
+# Claude
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Fix clearing unread messages on channel open when the first unread message is not visible [#4013](https://github.com/GetStream/stream-chat-swift/pull/4013)
 
 # [4.99.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.99.0)
 _March 16, 2026_

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -91,6 +91,7 @@ open class ChatChannelVC: _ViewController,
         guard isLastMessageVisibleOrSeen else { return false }
         guard isFirstPageLoaded else { return false }
         guard !hasMarkedMessageAsUnread else { return false }
+        guard hasSeenFirstUnreadMessage else { return false }
         
         guard let channel = channelController.channel, let currentUserId = client.currentUserId else { return false }
         guard let read = channel.read(for: currentUserId), let lastMessage = messages.first else {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -917,9 +917,14 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.markedAsUnread_mock = false
         try XCTUnwrap(channelControllerMock.client as? ChatClient_Mock).currentUserId_mock = currentUserId
 
-        // Simulate display to update hasSeenLastMessage && hasSeenFirstUnreadMessage
-        vc.chatMessageListVC(ChatMessageListVC_Mock(), willDisplayMessageAt: IndexPath(item: 0, section: 0))
+        // Simulate didUpdateMessages to update hasSeenFirstUnreadMessage (unreadCount == 0, firstUnreadMessageId == nil)
+        vc.channelController(channelControllerMock, didUpdateMessages: [])
+        mockedListView.updateMessagesCompletion?()
+        channelControllerMock.markReadCallCount = 0
+
+        // Simulate scroll to update hasSeenLastMessage
         vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
+        channelControllerMock.markReadCallCount = 0
 
         XCTAssertTrue(vc.shouldMarkChannelRead)
     }
@@ -937,9 +942,14 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.markedAsUnread_mock = false
         try XCTUnwrap(channelControllerMock.client as? ChatClient_Mock).currentUserId_mock = currentUserId
 
-        // Simulate display to update hasSeenLastMessage && hasSeenFirstUnreadMessage
-        vc.chatMessageListVC(ChatMessageListVC_Mock(), willDisplayMessageAt: IndexPath(item: 0, section: 0))
+        // Simulate didUpdateMessages to update hasSeenFirstUnreadMessage (unreadCount == 0, firstUnreadMessageId == nil)
+        vc.channelController(channelControllerMock, didUpdateMessages: [])
+        mockedListView.updateMessagesCompletion?()
+        channelControllerMock.markReadCallCount = 0
+
+        // Simulate scroll to update hasSeenLastMessage
         vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
+        channelControllerMock.markReadCallCount = 0
 
         XCTAssertTrue(vc.shouldMarkChannelRead)
     }
@@ -957,8 +967,11 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.markedAsUnread_mock = false
         try XCTUnwrap(channelControllerMock.client as? ChatClient_Mock).currentUserId_mock = currentUserId
 
-        // Simulate display to update hasSeenLastMessage && hasSeenFirstUnreadMessage
-        vc.chatMessageListVC(ChatMessageListVC_Mock(), willDisplayMessageAt: IndexPath(item: 0, section: 0))
+        // Simulate didUpdateMessages to update hasSeenFirstUnreadMessage (unreadCount == 0, firstUnreadMessageId == nil)
+        vc.channelController(channelControllerMock, didUpdateMessages: [])
+        mockedListView.updateMessagesCompletion?()
+
+        // Simulate scroll to update hasSeenLastMessage
         vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
 
         XCTAssertFalse(vc.shouldMarkChannelRead)
@@ -972,6 +985,26 @@ final class ChatChannelVC_Tests: XCTestCase {
         mockedListView.mockIsLastCellFullyVisible = true
         channelControllerMock.hasLoadedAllNextMessages_mock = true
         channelControllerMock.markedAsUnread_mock = false
+
+        XCTAssertFalse(vc.shouldMarkChannelRead)
+    }
+
+    func test_shouldMarkChannelRead_jumpToUnreadEnabled_whenSeenLastMessage_whenNotSeenFirstUnreadMessage_shouldReturnFalse() throws {
+        let mockedListView = makeMockMessageListView()
+        let currentUserId = UserId.unique
+        vc.mockIsViewVisible(true)
+        vc.components.isJumpToUnreadEnabled = true
+        vc.messages = [.mock()]
+        channelControllerMock.state_mock = .remoteDataFetched
+        channelControllerMock.channel_mock = .mock(cid: .unique, reads: [.mock(lastReadAt: .distantPast, lastReadMessageId: .unique, unreadMessagesCount: 0, user: .mock(id: currentUserId))])
+        mockedListView.mockIsLastCellFullyVisible = true
+        channelControllerMock.hasLoadedAllNextMessages_mock = true
+        channelControllerMock.markedAsUnread_mock = false
+        try XCTUnwrap(channelControllerMock.client as? ChatClient_Mock).currentUserId_mock = currentUserId
+
+        // Simulate scroll to update hasSeenLastMessage, but NOT hasSeenFirstUnreadMessage
+        vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
+        channelControllerMock.markReadCallCount = 0
 
         XCTAssertFalse(vc.shouldMarkChannelRead)
     }


### PR DESCRIPTION
### 🔗 Issue Links

Fixes [IOS-1529](https://linear.app/stream/issue/IOS-1529/unread-count-pill-disappears-on-channel-reentry)

### 🎯 Goal

Fix an issue where on channel open existing unread count is cleared

### 📝 Summary

- #3896 introduced regression where checking if the first unread is visible, was accidentally left out

### 🛠 Implementation

Check if first unread message has been seen by the user before marking the channel as read.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  <img src="https://github.com/user-attachments/assets/9b2e6bcc-13da-4ef8-94d4-1a200cd83a67" style="max-height:600px;display:block;">   |  <img src="https://github.com/user-attachments/assets/5a9557c3-3068-4b78-adb7-796f99a27fae" style="max-height:600px;display:block;">  |

### 🧪 Manual Testing Notes

Case 1: Unread issue verification
1. GIVEN open a channel
2. WHEN scroll the message list up (a couple of pages)
3. AND mark some participant's message as unread
4. THEN the unread messages label appears
5. WHEN scroll down
6. THEN the unread count pill appears
7. WHEN reenter the channel
8. THEN the unread count pill still visible
9. WHEN scroll up to unread message
10. THEN unread messages label is present
11. AND the unread count pill disappears

Case 2: Message from muted user is marked as delivered
1. User A mutes user B
2. User B sends a message
3. User A reads this message
Result: User B sees that the message status is read and delivered

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
