### PR TITLE
Fix pin/unpin updates not propagated in LivestreamChannelController for old messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix pin/unpin updates not propagated in `LivestreamChannelController` when the message is not in the local messages list [#4029](https://github.com/GetStream/stream-chat-swift/pull/4029)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix clearing unread messages on channel open when the first unread message is not visible [#4013](https://github.com/GetStream/stream-chat-swift/pull/4013)

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1116,15 +1116,23 @@ public class LivestreamChannelController: DataStoreProvider, EventsControllerDel
             messages[index] = updatedMessage
 
             if existingMessage.isPinned != updatedMessage.isPinned {
-                var pinnedMessages = channel?.pinnedMessages ?? []
-                if updatedMessage.isPinned {
-                    pinnedMessages.append(updatedMessage)
-                } else {
-                    pinnedMessages.removeAll(where: { $0.id == existingMessage.id })
-                }
-                channel = channel?.changing(pinnedMessages: pinnedMessages)
+                updatePinnedMessages(for: updatedMessage)
             }
+        } else if updatedMessage.isPinned || channel?.pinnedMessages.contains(where: { $0.id == updatedMessage.id }) == true {
+            updatePinnedMessages(for: updatedMessage)
         }
+    }
+
+    private func updatePinnedMessages(for message: ChatMessage) {
+        var pinnedMessages = channel?.pinnedMessages ?? []
+        if message.isPinned {
+            if !pinnedMessages.contains(where: { $0.id == message.id }) {
+                pinnedMessages.append(message)
+            }
+        } else {
+            pinnedMessages.removeAll(where: { $0.id == message.id })
+        }
+        channel = channel?.changing(pinnedMessages: pinnedMessages)
     }
 
     private func handleDeletedMessage(_ deletedMessage: ChatMessage) {

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -1318,7 +1318,124 @@ extension LivestreamChannelController_Tests {
         XCTAssertEqual(controller.channel?.pinnedMessages.count, 1)
         XCTAssertEqual(controller.channel?.pinnedMessages.first?.id, messageId)
     }
-    
+
+    func test_didReceiveEvent_messageUpdatedEvent_messageNotInLocalList_pinAdded_updatesPinnedMessages() {
+        let cid = controller.cid!
+        let messageId = "old-pin-me"
+
+        let exp = expectation(description: "sync completes")
+        controller.synchronize { _ in
+            exp.fulfill()
+        }
+        let channelPayload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid),
+            pinnedMessages: []
+        )
+        client.mockAPIClient.test_simulateResponse(.success(channelPayload))
+        waitForExpectations(timeout: defaultTimeout)
+
+        XCTAssertEqual(controller.messages.count, 0)
+        XCTAssertEqual(controller.channel?.pinnedMessages.count, 0)
+
+        let pinnedMessage = ChatMessage.mock(
+            id: messageId,
+            cid: cid,
+            text: "Old message now pinned",
+            pinDetails: .init(pinnedAt: .unique, pinnedBy: .unique, expiresAt: nil)
+        )
+        let event = MessageUpdatedEvent(
+            user: .mock(id: .unique),
+            channel: .mock(cid: cid),
+            message: pinnedMessage,
+            createdAt: .unique
+        )
+        controller.eventsController(
+            EventsController(notificationCenter: client.eventNotificationCenter),
+            didReceiveEvent: event
+        )
+
+        XCTAssertEqual(controller.messages.count, 0)
+        XCTAssertEqual(controller.channel?.pinnedMessages.count, 1)
+        XCTAssertEqual(controller.channel?.pinnedMessages.first?.id, messageId)
+    }
+
+    func test_didReceiveEvent_messageUpdatedEvent_messageNotInLocalList_pinRemoved_updatesPinnedMessages() {
+        let cid = controller.cid!
+        let messageId = "old-unpin-me"
+
+        let exp = expectation(description: "sync completes")
+        controller.synchronize { _ in
+            exp.fulfill()
+        }
+        let channelPayload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid),
+            pinnedMessages: [.dummy(messageId: messageId)]
+        )
+        client.mockAPIClient.test_simulateResponse(.success(channelPayload))
+        waitForExpectations(timeout: defaultTimeout)
+
+        XCTAssertEqual(controller.messages.count, 0)
+        XCTAssertEqual(controller.channel?.pinnedMessages.count, 1)
+
+        let unpinnedMessage = ChatMessage.mock(
+            id: messageId,
+            cid: cid,
+            text: "Old message now unpinned",
+            pinDetails: nil
+        )
+        let event = MessageUpdatedEvent(
+            user: .mock(id: .unique),
+            channel: .mock(cid: cid),
+            message: unpinnedMessage,
+            createdAt: .unique
+        )
+        controller.eventsController(
+            EventsController(notificationCenter: client.eventNotificationCenter),
+            didReceiveEvent: event
+        )
+
+        XCTAssertEqual(controller.messages.count, 0)
+        XCTAssertEqual(controller.channel?.pinnedMessages.count, 0)
+    }
+
+    func test_didReceiveEvent_messageUpdatedEvent_messageNotInLocalList_notPinned_doesNotUpdatePinnedMessages() {
+        let cid = controller.cid!
+
+        let exp = expectation(description: "sync completes")
+        controller.synchronize { _ in
+            exp.fulfill()
+        }
+        let channelPayload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid),
+            pinnedMessages: [.dummy(messageId: "existing-pin")]
+        )
+        client.mockAPIClient.test_simulateResponse(.success(channelPayload))
+        waitForExpectations(timeout: defaultTimeout)
+
+        XCTAssertEqual(controller.channel?.pinnedMessages.count, 1)
+
+        let regularMessage = ChatMessage.mock(
+            id: "not-pinned",
+            cid: cid,
+            text: "Updated text",
+            pinDetails: nil
+        )
+        let event = MessageUpdatedEvent(
+            user: .mock(id: .unique),
+            channel: .mock(cid: cid),
+            message: regularMessage,
+            createdAt: .unique
+        )
+        controller.eventsController(
+            EventsController(notificationCenter: client.eventNotificationCenter),
+            didReceiveEvent: event
+        )
+
+        XCTAssertEqual(controller.messages.count, 0)
+        XCTAssertEqual(controller.channel?.pinnedMessages.count, 1)
+        XCTAssertEqual(controller.channel?.pinnedMessages.first?.id, "existing-pin")
+    }
+
     func test_didReceiveEvent_messageDeletedEvent_hardDelete_removesMessage() {
         // Add a message
         controller.eventsController(


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1553](https://linear.app/stream/issue/IOS-1553/patreonllc-no-channel-update-received-for-old-pinned-messages-in)

### 🎯 Goal

Fix pin/unpin updates not being propagated through `channelChangePublisher` in `LivestreamChannelController` when the pinned message is not in the local messages list (e.g., old messages that haven't been paginated to).

### 📝 Summary

- Update `handleUpdatedMessage` in `LivestreamChannelController` to also update `channel.pinnedMessages` when the message is not in the local messages array
- Extract shared pin/unpin logic into a reusable `updatePinnedMessages(for:)` method

### 🛠 Implementation

Previously, `handleUpdatedMessage` only updated `channel.pinnedMessages` if the message existed in the local `messages` array. For old messages that haven't been paginated into the list, pin/unpin events were silently ignored, so the channel's `pinnedMessages` was never updated and `channelChangePublisher` never fired.

The fix adds an `else` branch that checks whether the updated message is newly pinned or was previously in `pinnedMessages` (now unpinned), and updates accordingly. The pin/unpin logic is extracted into `updatePinnedMessages(for:)` to avoid duplication.

### 🧪 Manual Testing Notes

1. Open a livestream channel with `LivestreamChannelController`
2. Pin an old message that is not currently in the paginated messages list
3. Verify that `channel.pinnedMessages` is updated in the Channel Info debugger
4. Unpin the same message and verify the update propagates

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo