### PR TITLE
Update gallery and scroll-to-bottom SF Symbol icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChatCommonUI
 ### 🔄 Changed
+- Update gallery and scroll-to-bottom SF Symbol icons [#4059](https://github.com/GetStream/stream-chat-swift/pull/4059)
 - Use MainActor for Appearance and its subtypes [#4052](https://github.com/GetStream/stream-chat-swift/pull/4052)
 ### ❌ Removed
 - Remove existing color tokens in favor of the new palette in `Appearance.ColorPalette` [#4025](https://github.com/GetStream/stream-chat-swift/pull/4025)

--- a/Sources/StreamChatCommonUI/Appearance+Images.swift
+++ b/Sources/StreamChatCommonUI/Appearance+Images.swift
@@ -449,11 +449,8 @@ public extension Appearance {
         public var checkmarkFilled: UIImage = loadSafely(systemName: "checkmark.circle.fill")
         public var closeFill: UIImage = loadSafely(systemName: "xmark.circle.fill")
         public var videoIndicator: UIImage = loadSafely(systemName: "video.fill")
-        public var gallery: UIImage = loadSafely(
-            systemName: "square.grid.3x3.fill",
-            systemNameFallback: "square.grid.2x2.fill"
-        )
-        
+        public var gallery: UIImage = loadSafely(systemName: "square.grid.2x2")
+
         // MARK: - No Content Icons
         
         public var noContent: UIImage = UIImage(

--- a/Sources/StreamChatCommonUI/Appearance+Images.swift
+++ b/Sources/StreamChatCommonUI/Appearance+Images.swift
@@ -495,7 +495,7 @@ public extension Appearance {
         public var scrollDownArrow: UIImage = loadSafely(
             systemName: "arrow.down",
             config: UIImage.SymbolConfiguration(
-                weight: .medium
+                weight: .regular
             )
         )
 


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1602](https://linear.app/stream/issue/IOS-1602/v5-qa-mediar-viewer-selection-bug-and-sf-symbol-grid-icon): v5 QA: Media Viewer Selection bug and SF Symbol grid icon
- [IOS-1603](https://linear.app/stream/issue/IOS-1603/v5-qa-scroll-to-bottom-button-icon-weight): v5 QA: Scroll to bottom button icon weight

### 🎯 Goal

Fix icon inconsistencies found during v5 QA.

### 📝 Summary

- Change gallery icon from `square.grid.3x3.fill` to `square.grid.2x2`
- Change scroll-down arrow weight from `.medium` to `.regular`

### 🛠 Implementation

Updated the default SF Symbol names and weights in `Appearance+Images.swift`.

### 🧪 Manual Testing Notes

- Open the media viewer and verify the grid icon matches the design
- Verify the scroll-to-bottom button arrow looks thinner

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated gallery and scroll-down arrow icons for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->