### PR TITLE
Make CDNRequester a constructor dependency of StreamMediaLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChatUI
 ### 🔄 Changed
+- `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Components` [#4070](https://github.com/GetStream/stream-chat-swift/pull/4070)
 
 # [5.0.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.0.0)
 _April 16, 2026_

--- a/DemoApp/Screens/UserProfile/UserProfileViewController.swift
+++ b/DemoApp/Screens/UserProfile/UserProfileViewController.swift
@@ -158,7 +158,7 @@ class UserProfileViewController: UITableViewController, CurrentChatUserControlle
             .loadImage(
                 into: imageView,
                 from: currentUserController.currentUser?.imageURL,
-                with: ImageLoaderOptions(cdnRequester: Components.default.cdnRequester)
+                with: ImageLoaderOptions()
             )
 
         if let typingIndicatorsEnabled = currentUserController.currentUser?.privacySettings.typingIndicators?.enabled {

--- a/Examples/MessengerClone/MessengerChatMessageContentView.swift
+++ b/Examples/MessengerClone/MessengerChatMessageContentView.swift
@@ -125,8 +125,7 @@ final class MessengerChatMessageContentView: ChatMessageContentView {
                 from: imageURL,
                 with: ImageLoaderOptions(
                     resize: .init(components.avatarThumbnailSize),
-                    placeholder: placeholder,
-                    cdnRequester: components.cdnRequester
+                    placeholder: placeholder
                 )
             )
         } else {

--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -288,13 +288,13 @@ class APIClient: @unchecked Sendable {
     }
     
     func downloadFile(
-        from remoteURL: URL,
+        _ request: URLRequest,
         to localURL: URL,
         progress: (@Sendable (Double) -> Void)?,
         completion: @escaping @Sendable (Error?) -> Void
     ) {
         let downloadOperation = AsyncOperation(maxRetries: maximumRequestRetries) { [weak self] operation, done in
-            self?.attachmentDownloader.download(from: remoteURL, to: localURL, progress: progress) { [weak self] error in
+            self?.attachmentDownloader.download(request, to: localURL, progress: progress) { [weak self] error in
                 if let error, self?.isConnectionError(error) == true {
                     // Do not retry unless its a connection problem and we still have retries left
                     if operation.canRetry {

--- a/Sources/StreamChat/APIClient/AttachmentDownloader/AttachmentDownloader.swift
+++ b/Sources/StreamChat/APIClient/AttachmentDownloader/AttachmentDownloader.swift
@@ -9,12 +9,12 @@ protocol AttachmentDownloader {
     /// Downloads a file attachment to the specified local URL.
     ///
     /// - Parameters:
-    ///   - remoteURL: A remote URL of the file.
+    ///   - request: The URL request for the remote file.
     ///   - localURL: The destination URL of the download.
     ///   - progress: The progress of the download.
     ///   - completion: The callback with an error if a failure occurred.
     func download(
-        from remoteURL: URL,
+        _ request: URLRequest,
         to localURL: URL,
         progress: (@Sendable (Double) -> Void)?,
         completion: @escaping @Sendable (Error?) -> Void
@@ -30,12 +30,11 @@ final class StreamAttachmentDownloader: AttachmentDownloader, @unchecked Sendabl
     }
     
     func download(
-        from remoteURL: URL,
+        _ request: URLRequest,
         to localURL: URL,
         progress: (@Sendable (Double) -> Void)?,
         completion: @escaping @Sendable (Error?) -> Void
     ) {
-        let request = URLRequest(url: remoteURL)
         let task = session.downloadTask(with: request) { temporaryURL, _, downloadError in
             if let downloadError {
                 completion(downloadError)

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -789,17 +789,17 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     ///
     /// - Parameters:
     ///   - attachment: The attachment to download.
-    ///   - remoteURL: An optional pre-resolved URL to download from (e.g. after CDN signing).
-    ///     If `nil`, the attachment's original `remoteURL` is used.
+    ///   - request: An optional pre-resolved `URLRequest` (e.g. from ``MediaLoader/loadFileRequest(for:options:completion:)``).
+    ///     If `nil`, a default request using the attachment's `remoteURL` is used.
     ///   - completion: A completion block with the attachment containing the downloading state.
     ///
     /// - Note: The local storage URL (`attachment.downloadingState?.localFileURL`) can change between app launches.
     public func downloadAttachment<Payload>(
         _ attachment: ChatMessageAttachment<Payload>,
-        remoteURL: URL? = nil,
+        request: URLRequest? = nil,
         completion: @escaping @MainActor (Result<ChatMessageAttachment<Payload>, Error>) -> Void
     ) where Payload: DownloadableAttachmentPayload {
-        messageUpdater.downloadAttachment(attachment, remoteURL: remoteURL) { [weak self] result in
+        messageUpdater.downloadAttachment(attachment, request: request) { [weak self] result in
             self?.callback {
                 completion(result)
             }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -430,8 +430,8 @@ public class Chat: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - attachment: The attachment to download.
-    ///   - remoteURL: An optional pre-resolved URL to download from (e.g. after CDN signing).
-    ///     If `nil`, the attachment's original `remoteURL` is used.
+    ///   - request: An optional pre-resolved `URLRequest` (e.g. from ``MediaLoader/loadFileRequest(for:options:completion:)``).
+    ///     If `nil`, a default request using the attachment's `remoteURL` is used.
     ///
     /// - Note: The local storage URL can change between app launches.
     ///
@@ -439,9 +439,9 @@ public class Chat: @unchecked Sendable {
     /// - Returns: An instance of the downloaded attachment which includes the local URL.
     @discardableResult public func downloadAttachment<Payload>(
         _ attachment: ChatMessageAttachment<Payload>,
-        remoteURL: URL? = nil
+        request: URLRequest? = nil
     ) async throws -> ChatMessageAttachment<Payload> where Payload: DownloadableAttachmentPayload {
-        try await messageUpdater.downloadAttachment(attachment, remoteURL: remoteURL)
+        try await messageUpdater.downloadAttachment(attachment, request: request)
     }
     
     /// Deletes the locally downloaded file.

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -761,13 +761,14 @@ class MessageUpdater: Worker, @unchecked Sendable {
 
     func downloadAttachment<Payload>(
         _ attachment: ChatMessageAttachment<Payload>,
-        remoteURL: URL? = nil,
+        request: URLRequest? = nil,
         completion: @escaping @Sendable (Result<ChatMessageAttachment<Payload>, Error>) -> Void
     ) where Payload: DownloadableAttachmentPayload {
         let attachmentId = attachment.id
         let localURL = URL.streamAttachmentLocalStorageURL(forRelativePath: attachment.relativeStoragePath)
+        let downloadRequest = request ?? URLRequest(url: attachment.remoteURL)
         apiClient.downloadFile(
-            from: remoteURL ?? attachment.remoteURL,
+            downloadRequest,
             to: localURL,
             progress: { [weak self] progress in
                 self?.updateDownloadProgress(
@@ -1270,10 +1271,10 @@ extension MessageUpdater {
 
     func downloadAttachment<Payload>(
         _ attachment: ChatMessageAttachment<Payload>,
-        remoteURL: URL? = nil
+        request: URLRequest? = nil
     ) async throws -> ChatMessageAttachment<Payload> where Payload: DownloadableAttachmentPayload {
         try await withCheckedThrowingContinuation { continuation in
-            downloadAttachment(attachment, remoteURL: remoteURL) { result in
+            downloadAttachment(attachment, request: request) { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/StreamChatCommonUI/ImageLoading/ImageDownloading.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/ImageDownloading.swift
@@ -51,14 +51,11 @@ public struct ImageDownloadingOptions: Sendable {
 public struct DownloadedImage: Sendable {
     /// The downloaded image.
     public var image: UIImage
-    /// Whether the image is an animated format (e.g. GIF).
-    public var isAnimated: Bool
     /// The raw image data for animated rendering. `nil` for static images.
     public var animatedImageData: Data?
 
-    public init(image: UIImage, isAnimated: Bool = false, animatedImageData: Data? = nil) {
+    public init(image: UIImage, animatedImageData: Data? = nil) {
         self.image = image
-        self.isAnimated = isAnimated
         self.animatedImageData = animatedImageData
     }
 }

--- a/Sources/StreamChatCommonUI/ImageLoading/ImageDownloading.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/ImageDownloading.swift
@@ -51,8 +51,14 @@ public struct ImageDownloadingOptions: Sendable {
 public struct DownloadedImage: Sendable {
     /// The downloaded image.
     public var image: UIImage
+    /// Whether the image is an animated format (e.g. GIF).
+    public var isAnimated: Bool
+    /// The raw image data for animated rendering. `nil` for static images.
+    public var animatedImageData: Data?
 
-    public init(image: UIImage) {
+    public init(image: UIImage, isAnimated: Bool = false, animatedImageData: Data? = nil) {
         self.image = image
+        self.isAnimated = isAnimated
+        self.animatedImageData = animatedImageData
     }
 }

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -209,17 +209,14 @@ public struct DownloadFileRequestOptions: Sendable {
 public struct MediaLoaderImage: Sendable {
     /// The loaded image.
     public var image: UIImage
-    /// Whether the image is an animated format (e.g. GIF).
-    public var isAnimated: Bool
     /// The raw image data for animated rendering. `nil` for static images.
     public var animatedImageData: Data?
     /// The caching key used by the CDN requester, if any.
     /// UI layers can use this to maintain a synchronous cache lookup table.
     public var cachingKey: String?
 
-    public init(image: UIImage, isAnimated: Bool = false, animatedImageData: Data? = nil, cachingKey: String? = nil) {
+    public init(image: UIImage, animatedImageData: Data? = nil, cachingKey: String? = nil) {
         self.image = image
-        self.isAnimated = isAnimated
         self.animatedImageData = animatedImageData
         self.cachingKey = cachingKey
     }

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -254,4 +254,3 @@ public struct MediaLoaderFileRequest: Sendable {
         self.urlRequest = urlRequest
     }
 }
-

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -155,19 +155,11 @@ public struct ImageLoadOptions: Sendable {
     public init(resize: ImageResize? = nil) {
         self.resize = resize
     }
-
-    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
-    public init(resize: ImageResize? = nil, cdnRequester: CDNRequester) {
-        self.resize = resize
-    }
 }
 
 /// Options for loading video content through a ``MediaLoader``.
 public struct VideoLoadOptions: Sendable {
     public init() {}
-
-    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
-    public init(cdnRequester: CDNRequester) {}
 }
 
 /// Options for loading file content through a ``MediaLoader``.

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -75,21 +75,22 @@ public protocol MediaLoader: AnyObject, Sendable {
         completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
     )
 
-    // MARK: - File Loading
+    // MARK: - File Request
 
-    /// Resolves a file URL through the CDN (signing, headers, etc.).
+    /// Creates a request for downloading or previewing a file.
     ///
-    /// Use this before passing a URL to `downloadAttachment` or displaying
-    /// content in a web view that requires CDN-signed URLs.
+    /// Resolves the URL through the CDN (signing, rewriting) and packages the
+    /// result into a ready-to-use request with any required HTTP headers.
+    /// Pass the returned request to `downloadAttachment` or load it in a web view.
     ///
     /// - Parameters:
     ///   - url: The original file URL to resolve.
-    ///   - options: Options controlling file load behavior.
-    ///   - completion: A completion handler called on the main actor with the resolved file.
-    func loadFile(
-        at url: URL,
-        options: FileLoadOptions,
-        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
+    ///   - options: Options controlling file request behavior.
+    ///   - completion: A completion handler called on the main actor with the resolved request.
+    func loadFileRequest(
+        for url: URL,
+        options: DownloadFileRequestOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFileRequest, Error>) -> Void
     )
 }
 
@@ -132,13 +133,13 @@ extension MediaLoader {
         }
     }
 
-    /// Resolves a file URL through the CDN.
-    public func loadFile(
-        at url: URL,
-        options: FileLoadOptions = FileLoadOptions()
-    ) async throws -> MediaLoaderFile {
+    /// Creates a request for downloading or previewing a file.
+    public func loadFileRequest(
+        for url: URL,
+        options: DownloadFileRequestOptions = DownloadFileRequestOptions()
+    ) async throws -> MediaLoaderFileRequest {
         try await withCheckedThrowingContinuation { continuation in
-            loadFile(at: url, options: options) { result in
+            loadFileRequest(for: url, options: options) { result in
                 continuation.resume(with: result)
             }
         }
@@ -162,8 +163,8 @@ public struct VideoLoadOptions: Sendable {
     public init() {}
 }
 
-/// Options for loading file content through a ``MediaLoader``.
-public struct FileLoadOptions: Sendable {
+/// Options for creating a file download request through a ``MediaLoader``.
+public struct DownloadFileRequestOptions: Sendable {
     public init() {}
 }
 
@@ -209,15 +210,13 @@ public struct MediaLoaderVideoPreview: Sendable {
     }
 }
 
-/// The result of loading a file through a ``MediaLoader``.
-public struct MediaLoaderFile: Sendable {
-    /// The resolved URL (potentially signed or rewritten by the CDN).
-    public var url: URL
-    /// Optional HTTP headers required to access the file.
-    public var headers: [String: String]?
+/// The result of resolving a file download request through a ``MediaLoader``.
+public struct MediaLoaderFileRequest: Sendable {
+    /// A ready-to-use URL request with CDN-resolved URL and any required HTTP headers.
+    public var urlRequest: URLRequest
 
-    public init(url: URL, headers: [String: String]? = nil) {
-        self.url = url
-        self.headers = headers
+    public init(urlRequest: URLRequest) {
+        self.urlRequest = urlRequest
     }
 }
+

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -171,9 +171,15 @@ public struct VideoLoadOptions: Sendable {
 public struct MediaLoaderImage: Sendable {
     /// The loaded image.
     public var image: UIImage
+    /// Whether the image is an animated format (e.g. GIF).
+    public var isAnimated: Bool
+    /// The raw image data for animated rendering. `nil` for static images.
+    public var animatedImageData: Data?
 
-    public init(image: UIImage) {
+    public init(image: UIImage, isAnimated: Bool = false, animatedImageData: Data? = nil) {
         self.image = image
+        self.isAnimated = isAnimated
+        self.animatedImageData = animatedImageData
     }
 }
 

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -175,11 +175,15 @@ public struct MediaLoaderImage: Sendable {
     public var isAnimated: Bool
     /// The raw image data for animated rendering. `nil` for static images.
     public var animatedImageData: Data?
+    /// The caching key used by the CDN requester, if any.
+    /// UI layers can use this to maintain a synchronous cache lookup table.
+    public var cachingKey: String?
 
-    public init(image: UIImage, isAnimated: Bool = false, animatedImageData: Data? = nil) {
+    public init(image: UIImage, isAnimated: Bool = false, animatedImageData: Data? = nil, cachingKey: String? = nil) {
         self.image = image
         self.isAnimated = isAnimated
         self.animatedImageData = animatedImageData
+        self.cachingKey = cachingKey
     }
 }
 

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -94,13 +94,51 @@ public protocol MediaLoader: AnyObject, Sendable {
     )
 }
 
+// MARK: - Convenience Extensions
+
+extension MediaLoader {
+    public func loadImage(
+        url: URL?,
+        completion: @escaping @MainActor (Result<MediaLoaderImage, Error>) -> Void
+    ) {
+        loadImage(url: url, options: ImageLoadOptions(), completion: completion)
+    }
+
+    public func loadVideoAsset(
+        at url: URL,
+        completion: @escaping @MainActor (Result<MediaLoaderVideoAsset, Error>) -> Void
+    ) {
+        loadVideoAsset(at: url, options: VideoLoadOptions(), completion: completion)
+    }
+
+    public func loadVideoPreview(
+        with attachment: ChatMessageVideoAttachment,
+        completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
+    ) {
+        loadVideoPreview(with: attachment, options: VideoLoadOptions(), completion: completion)
+    }
+
+    public func loadVideoPreview(
+        at url: URL,
+        completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
+    ) {
+        loadVideoPreview(at: url, options: VideoLoadOptions(), completion: completion)
+    }
+
+    public func loadFileRequest(
+        for url: URL,
+        completion: @escaping @MainActor (Result<MediaLoaderFileRequest, Error>) -> Void
+    ) {
+        loadFileRequest(for: url, options: DownloadFileRequestOptions(), completion: completion)
+    }
+}
+
 // MARK: - Async/Await Extensions
 
 extension MediaLoader {
-    /// Loads a single image from the given URL.
     public func loadImage(
         url: URL?,
-        options: ImageLoadOptions
+        options: ImageLoadOptions = ImageLoadOptions()
     ) async throws -> MediaLoaderImage {
         try await withCheckedThrowingContinuation { continuation in
             loadImage(url: url, options: options) { result in
@@ -109,10 +147,9 @@ extension MediaLoader {
         }
     }
 
-    /// Returns a video asset for the given URL.
     public func loadVideoAsset(
         at url: URL,
-        options: VideoLoadOptions
+        options: VideoLoadOptions = VideoLoadOptions()
     ) async throws -> MediaLoaderVideoAsset {
         try await withCheckedThrowingContinuation { continuation in
             loadVideoAsset(at: url, options: options) { result in
@@ -121,10 +158,9 @@ extension MediaLoader {
         }
     }
 
-    /// Generates a video preview thumbnail from a URL.
     public func loadVideoPreview(
         at url: URL,
-        options: VideoLoadOptions
+        options: VideoLoadOptions = VideoLoadOptions()
     ) async throws -> MediaLoaderVideoPreview {
         try await withCheckedThrowingContinuation { continuation in
             loadVideoPreview(at: url, options: options) { result in
@@ -133,7 +169,6 @@ extension MediaLoader {
         }
     }
 
-    /// Creates a request for downloading or previewing a file.
     public func loadFileRequest(
         for url: URL,
         options: DownloadFileRequestOptions = DownloadFileRequestOptions()

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -75,7 +75,7 @@ public protocol MediaLoader: AnyObject, Sendable {
         completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
     )
 
-    // MARK: - File URL Resolution
+    // MARK: - File Loading
 
     /// Resolves a file URL through the CDN (signing, headers, etc.).
     ///
@@ -84,10 +84,12 @@ public protocol MediaLoader: AnyObject, Sendable {
     ///
     /// - Parameters:
     ///   - url: The original file URL to resolve.
-    ///   - completion: A completion handler called on the main actor with the resolved CDN request.
-    func resolveFileURL(
-        _ url: URL,
-        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    ///   - options: Options controlling file load behavior.
+    ///   - completion: A completion handler called on the main actor with the resolved file.
+    func loadFile(
+        at url: URL,
+        options: FileLoadOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
     )
 }
 
@@ -131,9 +133,12 @@ extension MediaLoader {
     }
 
     /// Resolves a file URL through the CDN.
-    public func resolveFileURL(_ url: URL) async throws -> CDNRequest {
+    public func loadFile(
+        at url: URL,
+        options: FileLoadOptions = FileLoadOptions()
+    ) async throws -> MediaLoaderFile {
         try await withCheckedThrowingContinuation { continuation in
-            resolveFileURL(url) { result in
+            loadFile(at: url, options: options) { result in
                 continuation.resume(with: result)
             }
         }
@@ -163,6 +168,11 @@ public struct VideoLoadOptions: Sendable {
 
     @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
     public init(cdnRequester: CDNRequester) {}
+}
+
+/// Options for loading file content through a ``MediaLoader``.
+public struct FileLoadOptions: Sendable {
+    public init() {}
 }
 
 // MARK: - Result Types
@@ -204,5 +214,18 @@ public struct MediaLoaderVideoPreview: Sendable {
 
     public init(image: UIImage) {
         self.image = image
+    }
+}
+
+/// The result of loading a file through a ``MediaLoader``.
+public struct MediaLoaderFile: Sendable {
+    /// The resolved URL (potentially signed or rewritten by the CDN).
+    public var url: URL
+    /// Optional HTTP headers required to access the file.
+    public var headers: [String: String]?
+
+    public init(url: URL, headers: [String: String]? = nil) {
+        self.url = url
+        self.headers = headers
     }
 }

--- a/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/MediaLoader.swift
@@ -6,12 +6,12 @@ import AVKit
 import StreamChat
 import UIKit
 
-/// A unified protocol for loading images and video previews.
+/// A unified protocol for loading images, video previews, and resolving file URLs.
 ///
-/// Configuration is passed via options structs on every call, so concrete
-/// implementations remain stateless with respect to CDN configuration.
-/// Changing the requester on `ChatClientConfig` takes effect immediately without
-/// recreating the loader.
+/// The ``CDNRequester`` is provided as a constructor dependency of the concrete
+/// implementation (e.g. ``StreamMediaLoader``), so callers don't need to pass
+/// it on every call. Configuring the CDN requester in one place ensures all
+/// content loading automatically picks it up.
 public protocol MediaLoader: AnyObject, Sendable {
     // MARK: - Image Loading
 
@@ -19,7 +19,7 @@ public protocol MediaLoader: AnyObject, Sendable {
     ///
     /// - Parameters:
     ///   - url: The image URL. If nil, the completion is called with a failure.
-    ///   - options: Options controlling resize and CDN behavior.
+    ///   - options: Options controlling resize behavior.
     ///   - completion: A completion handler called on the main actor with the loaded image.
     func loadImage(
         url: URL?,
@@ -31,8 +31,8 @@ public protocol MediaLoader: AnyObject, Sendable {
 
     /// Returns a video asset for the given URL.
     ///
-    /// Implementers should use the CDN requester in options to adjust the URL
-    /// before creating the asset.
+    /// The implementation resolves the URL through its CDN requester before
+    /// creating the asset.
     func loadVideoAsset(
         at url: URL,
         options: VideoLoadOptions,
@@ -47,7 +47,7 @@ public protocol MediaLoader: AnyObject, Sendable {
     ///
     /// - Parameters:
     ///   - attachment: A video attachment containing the video URL and optional thumbnail URL.
-    ///   - options: Options controlling CDN behavior.
+    ///   - options: Options controlling video load behavior.
     ///   - completion: A completion handler called on the main actor with the preview image.
     func loadVideoPreview(
         with attachment: ChatMessageVideoAttachment,
@@ -67,12 +67,27 @@ public protocol MediaLoader: AnyObject, Sendable {
     ///
     /// - Parameters:
     ///   - url: The video URL (typically a local `file://` URL).
-    ///   - options: Options controlling CDN behavior.
+    ///   - options: Options controlling video load behavior.
     ///   - completion: A completion handler called on the main actor with the preview image.
     func loadVideoPreview(
         at url: URL,
         options: VideoLoadOptions,
         completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
+    )
+
+    // MARK: - File URL Resolution
+
+    /// Resolves a file URL through the CDN (signing, headers, etc.).
+    ///
+    /// Use this before passing a URL to `downloadAttachment` or displaying
+    /// content in a web view that requires CDN-signed URLs.
+    ///
+    /// - Parameters:
+    ///   - url: The original file URL to resolve.
+    ///   - completion: A completion handler called on the main actor with the resolved CDN request.
+    func resolveFileURL(
+        _ url: URL,
+        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
     )
 }
 
@@ -114,6 +129,15 @@ extension MediaLoader {
             }
         }
     }
+
+    /// Resolves a file URL through the CDN.
+    public func resolveFileURL(_ url: URL) async throws -> CDNRequest {
+        try await withCheckedThrowingContinuation { continuation in
+            resolveFileURL(url) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 }
 
 // MARK: - Options
@@ -122,23 +146,23 @@ extension MediaLoader {
 public struct ImageLoadOptions: Sendable {
     /// Optional resize parameters for server-side resizing.
     public var resize: ImageResize?
-    /// The CDN requester for URL transformation (signing, headers, resizing).
-    public var cdnRequester: CDNRequester
 
+    public init(resize: ImageResize? = nil) {
+        self.resize = resize
+    }
+
+    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
     public init(resize: ImageResize? = nil, cdnRequester: CDNRequester) {
         self.resize = resize
-        self.cdnRequester = cdnRequester
     }
 }
 
 /// Options for loading video content through a ``MediaLoader``.
 public struct VideoLoadOptions: Sendable {
-    /// The CDN requester for URL transformation (signing, headers).
-    public var cdnRequester: CDNRequester
+    public init() {}
 
-    public init(cdnRequester: CDNRequester) {
-        self.cdnRequester = cdnRequester
-    }
+    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
+    public init(cdnRequester: CDNRequester) {}
 }
 
 // MARK: - Result Types

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -75,7 +75,13 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
                     resize: resizeSize
                 )
                 downloader.downloadImage(url: cdnRequest.url, options: downloadOptions) { imageResult in
-                    completion(imageResult.map { MediaLoaderImage(image: $0.image) })
+                    completion(imageResult.map {
+                        MediaLoaderImage(
+                            image: $0.image,
+                            isAnimated: $0.isAnimated,
+                            animatedImageData: $0.animatedImageData
+                        )
+                    })
                 }
             case let .failure(error):
                 StreamConcurrency.onMain {

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -41,11 +41,6 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         )
     }
 
-    @available(*, deprecated, message: "Use init(cdnRequester:downloader:) instead.")
-    public convenience init(downloader: ImageDownloading) {
-        self.init(cdnRequester: StreamCDNRequester(), downloader: downloader)
-    }
-
     deinit {
         NotificationCenter.default.removeObserver(self)
     }

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -231,15 +231,16 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         }
     }
 
-    // MARK: - File URL Resolution
+    // MARK: - File Loading
 
-    open func resolveFileURL(
-        _ url: URL,
-        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    open func loadFile(
+        at url: URL,
+        options: FileLoadOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
     ) {
         cdnRequester.fileRequest(for: url, options: .init()) { result in
             StreamConcurrency.onMain {
-                completion(result)
+                completion(result.map { MediaLoaderFile(url: $0.url, headers: $0.headers) })
             }
         }
     }

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -12,11 +12,11 @@ import UIKit
 /// image downloading to an ``ImageDownloading`` backend (typically Nuke),
 /// and video preview generation to AVFoundation.
 open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
-    /// The CDN requester used for URL transformation (signing, headers, resizing).
-    public let cdnRequester: CDNRequester
-
     /// The backend that performs the actual image download and caching.
     public let downloader: ImageDownloading
+
+    /// The CDN requester used for URL transformation (signing, headers, resizing).
+    public let cdnRequester: CDNRequester
 
     /// The video preview thumbnails local cache used for videos that
     /// don't have remote thumbnails available.
@@ -25,11 +25,11 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
     private let videoPreviewCacheCountLimit: Int = 50
 
     public init(
-        cdnRequester: CDNRequester = StreamCDNRequester(),
-        downloader: ImageDownloading
+        downloader: ImageDownloading,
+        cdnRequester: CDNRequester = StreamCDNRequester()
     ) {
-        self.cdnRequester = cdnRequester
         self.downloader = downloader
+        self.cdnRequester = cdnRequester
         self.videoPreviewCache = NSCache<NSURL, UIImage>()
         self.videoPreviewCache.countLimit = videoPreviewCacheCountLimit
 

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -226,16 +226,20 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         }
     }
 
-    // MARK: - File Loading
+    // MARK: - File Request
 
-    open func loadFile(
-        at url: URL,
-        options: FileLoadOptions,
-        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
+    open func loadFileRequest(
+        for url: URL,
+        options: DownloadFileRequestOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFileRequest, Error>) -> Void
     ) {
         cdnRequester.fileRequest(for: url, options: .init()) { result in
             StreamConcurrency.onMain {
-                completion(result.map { MediaLoaderFile(url: $0.url, headers: $0.headers) })
+                completion(result.map { cdnRequest in
+                    var request = URLRequest(url: cdnRequest.url)
+                    cdnRequest.headers?.forEach { request.setValue($1, forHTTPHeaderField: $0) }
+                    return MediaLoaderFileRequest(urlRequest: request)
+                })
             }
         }
     }

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -130,7 +130,7 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         }
 
         if let thumbnailURL = attachment.payload.thumbnailURL {
-            loadImage(url: thumbnailURL, options: ImageLoadOptions()) { [weak self] result in
+            loadImage(url: thumbnailURL) { [weak self] result in
                 guard let self else {
                     StreamConcurrency.onMain {
                         completion(.failure(ClientError.Unknown("MediaLoader was deallocated")))

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -74,12 +74,14 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
                     cachingKey: cdnRequest.cachingKey,
                     resize: resizeSize
                 )
+                let cachingKey = cdnRequest.cachingKey
                 downloader.downloadImage(url: cdnRequest.url, options: downloadOptions) { imageResult in
                     completion(imageResult.map {
                         MediaLoaderImage(
                             image: $0.image,
                             isAnimated: $0.isAnimated,
-                            animatedImageData: $0.animatedImageData
+                            animatedImageData: $0.animatedImageData,
+                            cachingKey: cachingKey
                         )
                     })
                 }

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -74,7 +74,6 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
                     completion(imageResult.map {
                         MediaLoaderImage(
                             image: $0.image,
-                            isAnimated: $0.isAnimated,
                             animatedImageData: $0.animatedImageData,
                             cachingKey: cachingKey
                         )

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -8,10 +8,13 @@ import UIKit
 
 /// The default ``MediaLoader`` implementation.
 ///
-/// Delegates URL transformation to the ``CDNRequester`` provided via options,
+/// Delegates URL transformation to its ``CDNRequester`` dependency,
 /// image downloading to an ``ImageDownloading`` backend (typically Nuke),
 /// and video preview generation to AVFoundation.
 open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
+    /// The CDN requester used for URL transformation (signing, headers, resizing).
+    public let cdnRequester: CDNRequester
+
     /// The backend that performs the actual image download and caching.
     public let downloader: ImageDownloading
 
@@ -21,7 +24,11 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
     /// The limit of the local  video preview thumbnails cache.
     private let videoPreviewCacheCountLimit: Int = 50
 
-    public init(downloader: ImageDownloading) {
+    public init(
+        cdnRequester: CDNRequester = StreamCDNRequester(),
+        downloader: ImageDownloading
+    ) {
+        self.cdnRequester = cdnRequester
         self.downloader = downloader
         self.videoPreviewCache = NSCache<NSURL, UIImage>()
         self.videoPreviewCache.countLimit = videoPreviewCacheCountLimit
@@ -32,6 +39,11 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
             name: UIApplication.didReceiveMemoryWarningNotification,
             object: nil
         )
+    }
+
+    @available(*, deprecated, message: "Use init(cdnRequester:downloader:) instead.")
+    public convenience init(downloader: ImageDownloading) {
+        self.init(cdnRequester: StreamCDNRequester(), downloader: downloader)
     }
 
     deinit {
@@ -53,7 +65,7 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         }
 
         let downloader = self.downloader
-        options.cdnRequester.imageRequest(for: url, options: ImageRequestOptions(imageResize: options.resize)) { result in
+        cdnRequester.imageRequest(for: url, options: ImageRequestOptions(imageResize: options.resize)) { result in
             switch result {
             case let .success(cdnRequest):
                 let resizeSize: CGSize? = options.resize.map { CGSize(width: $0.width, height: $0.height) }
@@ -80,7 +92,7 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         options: VideoLoadOptions,
         completion: @escaping @MainActor (Result<MediaLoaderVideoAsset, Error>) -> Void
     ) {
-        options.cdnRequester.fileRequest(for: url, options: .init()) { result in
+        cdnRequester.fileRequest(for: url, options: .init()) { result in
             switch result {
             case let .success(cdnRequest):
                 var assetOptions: [String: Any] = [:]
@@ -115,8 +127,7 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         }
 
         if let thumbnailURL = attachment.payload.thumbnailURL {
-            let imageOptions = ImageLoadOptions(cdnRequester: options.cdnRequester)
-            loadImage(url: thumbnailURL, options: imageOptions) { [weak self] result in
+            loadImage(url: thumbnailURL, options: ImageLoadOptions()) { [weak self] result in
                 guard let self else {
                     StreamConcurrency.onMain {
                         completion(.failure(ClientError.Unknown("MediaLoader was deallocated")))
@@ -161,7 +172,7 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         options: VideoLoadOptions,
         completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
     ) {
-        options.cdnRequester.fileRequest(for: url, options: .init()) { [weak self] result in
+        cdnRequester.fileRequest(for: url, options: .init()) { [weak self] result in
             guard let self else {
                 StreamConcurrency.onMain {
                     completion(.failure(ClientError.Unknown("MediaLoader was deallocated")))
@@ -208,6 +219,19 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
                 StreamConcurrency.onMain {
                     completion(result)
                 }
+            }
+        }
+    }
+
+    // MARK: - File URL Resolution
+
+    open func resolveFileURL(
+        _ url: URL,
+        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    ) {
+        cdnRequester.fileRequest(for: url, options: .init()) { result in
+            StreamConcurrency.onMain {
+                completion(result)
             }
         }
     }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/Gallery/ChatMessageImageGallery+ImagePreview.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/Gallery/ChatMessageImageGallery+ImagePreview.swift
@@ -93,8 +93,7 @@ extension ChatMessageGalleryView {
             imageTask = components.mediaLoader.loadImage(
                 into: imageView,
                 from: attachment?.payload,
-                maxResolutionInPixels: components.imageAttachmentMaxPixels,
-                cdnRequester: components.cdnRequester
+                maxResolutionInPixels: components.imageAttachmentMaxPixels
             ) { [weak self] _ in
                 self?.loadingIndicator.isVisible = false
                 self?.imageTask = nil

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/Gallery/VideoAttachmentGalleryPreview.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/Gallery/VideoAttachmentGalleryPreview.swift
@@ -85,8 +85,7 @@ open class VideoAttachmentGalleryPreview: _View, ThemeProvider {
 
         if let content {
             components.mediaLoader.loadVideoPreview(
-                with: content,
-                options: VideoLoadOptions()
+                with: content
             ) { [weak self] in
                 self?.loadingIndicator.isHidden = true
                 if case let .success(preview) = $0 {

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/Gallery/VideoAttachmentGalleryPreview.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/Gallery/VideoAttachmentGalleryPreview.swift
@@ -86,7 +86,7 @@ open class VideoAttachmentGalleryPreview: _View, ThemeProvider {
         if let content {
             components.mediaLoader.loadVideoPreview(
                 with: content,
-                options: VideoLoadOptions(cdnRequester: components.cdnRequester)
+                options: VideoLoadOptions()
             ) { [weak self] in
                 self?.loadingIndicator.isHidden = true
                 if case let .success(preview) = $0 {

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/Link/ChatMessageLinkPreviewView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/Link/ChatMessageLinkPreviewView.swift
@@ -144,7 +144,7 @@ open class ChatMessageLinkPreviewView: _Control, ThemeProvider {
         components.mediaLoader.loadImage(
             into: imagePreview,
             from: payload?.previewURL,
-            with: ImageLoaderOptions(cdnRequester: components.cdnRequester)
+            with: ImageLoaderOptions()
         )
         imagePreview.isHidden = isImageHidden
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -1028,10 +1028,10 @@ open class ChatMessageListVC: _ViewController,
                 present(activityViewController, animated: true)
             } else {
                 let chat = client.makeChat(for: attachment.id.cid)
-                let cdnRequester = components.cdnRequester
+                let mediaLoader = components.mediaLoader
                 _Concurrency.Task {
                     do {
-                        let cdnRequest = try await cdnRequester.fileRequest(for: attachment.remoteURL)
+                        let cdnRequest = try await mediaLoader.resolveFileURL(attachment.remoteURL)
                         try await chat.downloadAttachment(attachment, remoteURL: cdnRequest.url)
                     } catch {
                         log.error("Failed to download attachment \(attachment.id): \(error)")

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -1031,8 +1031,8 @@ open class ChatMessageListVC: _ViewController,
                 let mediaLoader = components.mediaLoader
                 _Concurrency.Task {
                     do {
-                        let cdnRequest = try await mediaLoader.resolveFileURL(attachment.remoteURL)
-                        try await chat.downloadAttachment(attachment, remoteURL: cdnRequest.url)
+                        let file = try await mediaLoader.loadFile(at: attachment.remoteURL)
+                        try await chat.downloadAttachment(attachment, remoteURL: file.url)
                     } catch {
                         log.error("Failed to download attachment \(attachment.id): \(error)")
                     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -1031,8 +1031,8 @@ open class ChatMessageListVC: _ViewController,
                 let mediaLoader = components.mediaLoader
                 _Concurrency.Task {
                     do {
-                        let file = try await mediaLoader.loadFile(at: attachment.remoteURL)
-                        try await chat.downloadAttachment(attachment, remoteURL: file.url)
+                        let fileRequest = try await mediaLoader.loadFileRequest(for: attachment.remoteURL)
+                        try await chat.downloadAttachment(attachment, request: fileRequest.urlRequest)
                     } catch {
                         log.error("Failed to download attachment \(attachment.id): \(error)")
                     }

--- a/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/ImageAttachmentComposerPreview.swift
+++ b/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/ImageAttachmentComposerPreview.swift
@@ -47,7 +47,7 @@ open class ImageAttachmentComposerPreview: _View, ThemeProvider {
         components.mediaLoader.loadImage(
             into: imageView,
             from: content,
-            with: ImageLoaderOptions(resize: ImageResize(size), cdnRequester: components.cdnRequester)
+            with: ImageLoaderOptions(resize: ImageResize(size))
         )
     }
 }

--- a/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/VideoAttachmentComposerPreview.swift
+++ b/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/VideoAttachmentComposerPreview.swift
@@ -93,8 +93,7 @@ open class VideoAttachmentComposerPreview: _View, ThemeProvider {
         videoDurationLabel.text = nil
 
         if let url = content {
-            let options = VideoLoadOptions(cdnRequester: components.cdnRequester)
-            components.mediaLoader.loadVideoPreview(at: url, options: options) { [weak self] in
+            components.mediaLoader.loadVideoPreview(at: url, options: VideoLoadOptions()) { [weak self] in
                 self?.loadingIndicator.isHidden = true
                 switch $0 {
                 case let .success(preview):
@@ -103,7 +102,7 @@ open class VideoAttachmentComposerPreview: _View, ThemeProvider {
                     self?.previewImageView.image = nil
                 }
             }
-            components.mediaLoader.loadVideoAsset(at: url, options: options) { [weak self] result in
+            components.mediaLoader.loadVideoAsset(at: url, options: VideoLoadOptions()) { [weak self] result in
                 if case let .success(loaded) = result {
                     self?.videoDurationLabel.text = self?.appearance.formatters.videoDuration.format(
                         loaded.asset.duration.seconds

--- a/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/VideoAttachmentComposerPreview.swift
+++ b/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/VideoAttachmentComposerPreview.swift
@@ -93,7 +93,7 @@ open class VideoAttachmentComposerPreview: _View, ThemeProvider {
         videoDurationLabel.text = nil
 
         if let url = content {
-            components.mediaLoader.loadVideoPreview(at: url, options: VideoLoadOptions()) { [weak self] in
+            components.mediaLoader.loadVideoPreview(at: url) { [weak self] in
                 self?.loadingIndicator.isHidden = true
                 switch $0 {
                 case let .success(preview):
@@ -102,7 +102,7 @@ open class VideoAttachmentComposerPreview: _View, ThemeProvider {
                     self?.previewImageView.image = nil
                 }
             }
-            components.mediaLoader.loadVideoAsset(at: url, options: VideoLoadOptions()) { [weak self] result in
+            components.mediaLoader.loadVideoAsset(at: url) { [weak self] result in
                 if case let .success(loaded) = result {
                     self?.videoDurationLabel.text = self?.appearance.formatters.videoDuration.format(
                         loaded.asset.duration.seconds

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -163,7 +163,7 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
         nonisolated(unsafe) var memberNames = names
         let requests = urls.prefix(maxNumberOfImagesInCombinedAvatar)
             .compactMap { $0 }
-            .map { ImageDownloadRequest(url: $0, options: ImageDownloadOptions(resize: .init(avatarSize), cdnRequester: components.cdnRequester)) }
+            .map { ImageDownloadRequest(url: $0, options: ImageDownloadOptions(resize: .init(avatarSize))) }
 
         components.mediaLoader.downloadMultipleImages(with: requests) { results in
             // Scale only placeholders since images already have a correct size
@@ -217,8 +217,7 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
             from: url,
             with: ImageLoaderOptions(
                 resize: .init(components.avatarThumbnailSize),
-                placeholder: placeholder,
-                cdnRequester: components.cdnRequester
+                placeholder: placeholder
             )
         )
     }

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatUserAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatUserAvatarView.swift
@@ -41,8 +41,7 @@ open class ChatUserAvatarView: _View, ThemeProvider {
             from: content?.imageURL,
             with: ImageLoaderOptions(
                 resize: .init(components.avatarThumbnailSize),
-                placeholder: placeholder,
-                cdnRequester: components.cdnRequester
+                placeholder: placeholder
             )
         )
 

--- a/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
+++ b/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
@@ -284,7 +284,7 @@ open class QuotedChatMessageView: _View, ThemeProvider {
         components.mediaLoader.loadImage(
             into: attachmentPreviewView,
             from: url,
-            with: ImageLoaderOptions(resize: .init(attachmentPreviewSize), cdnRequester: components.cdnRequester)
+            with: ImageLoaderOptions(resize: .init(attachmentPreviewSize))
         )
     }
 
@@ -296,7 +296,7 @@ open class QuotedChatMessageView: _View, ThemeProvider {
     open func setVideoAttachmentPreviewImage(attachment: ChatMessageVideoAttachment) {
         components.mediaLoader.loadVideoPreview(
             with: attachment,
-            options: VideoLoadOptions(cdnRequester: components.cdnRequester)
+            options: VideoLoadOptions()
         ) { [weak self] in
             switch $0 {
             case let .success(preview):

--- a/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
+++ b/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
@@ -295,8 +295,7 @@ open class QuotedChatMessageView: _View, ThemeProvider {
     /// - Parameter attachment: The video attachment to load the preview for.
     open func setVideoAttachmentPreviewImage(attachment: ChatMessageVideoAttachment) {
         components.mediaLoader.loadVideoPreview(
-            with: attachment,
-            options: VideoLoadOptions()
+            with: attachment
         ) { [weak self] in
             switch $0 {
             case let .success(preview):

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -91,9 +91,17 @@ import UIKit
     public var loadingIndicator: ChatLoadingIndicator.Type = ChatLoadingIndicator.self
 
     /// The CDN requester used for URL transformation (signing, headers, resizing).
-    public var cdnRequester: CDNRequester = StreamCDNRequester()
+    ///
+    /// - Important: This property is provided for backward compatibility.
+    /// Prefer configuring the CDN requester through ``StreamMediaLoader/init(cdnRequester:downloader:)``
+    /// and setting ``mediaLoader`` instead.
+    @available(*, deprecated, message: "Configure CDNRequester through StreamMediaLoader(cdnRequester:) and set mediaLoader instead.")
+    public var cdnRequester: CDNRequester {
+        get { (mediaLoader as? StreamMediaLoader)?.cdnRequester ?? StreamCDNRequester() }
+        set { mediaLoader = StreamMediaLoader(cdnRequester: newValue, downloader: StreamImageDownloader()) }
+    }
 
-    /// The object responsible for loading images and video previews.
+    /// The object responsible for loading images, video previews, and resolving file URLs.
     public var mediaLoader: MediaLoader = StreamMediaLoader(downloader: StreamImageDownloader())
 
     /// Object responsible for providing resizing operations for `UIImage`

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -90,17 +90,6 @@ import UIKit
     /// The view that shows a loading indicator.
     public var loadingIndicator: ChatLoadingIndicator.Type = ChatLoadingIndicator.self
 
-    /// The CDN requester used for URL transformation (signing, headers, resizing).
-    ///
-    /// - Important: This property is provided for backward compatibility.
-    /// Prefer configuring the CDN requester through ``StreamMediaLoader/init(cdnRequester:downloader:)``
-    /// and setting ``mediaLoader`` instead.
-    @available(*, deprecated, message: "Configure CDNRequester through StreamMediaLoader(cdnRequester:) and set mediaLoader instead.")
-    public var cdnRequester: CDNRequester {
-        get { (mediaLoader as? StreamMediaLoader)?.cdnRequester ?? StreamCDNRequester() }
-        set { mediaLoader = StreamMediaLoader(cdnRequester: newValue, downloader: StreamImageDownloader()) }
-    }
-
     /// The object responsible for loading images, video previews, and resolving file URLs.
     public var mediaLoader: MediaLoader = StreamMediaLoader(downloader: StreamImageDownloader())
 

--- a/Sources/StreamChatUI/Composer/ComposerLinkPreviewView.swift
+++ b/Sources/StreamChatUI/Composer/ComposerLinkPreviewView.swift
@@ -141,7 +141,7 @@ open class ComposerLinkPreviewView: _View, ThemeProvider {
             components.mediaLoader.loadImage(
                 into: imagePreviewView,
                 from: imageUrl,
-                with: ImageLoaderOptions(cdnRequester: components.cdnRequester)
+                with: ImageLoaderOptions()
             )
         } else {
             imagePreviewView.contentMode = .center

--- a/Sources/StreamChatUI/Gallery/Cells/ImageAttachmentGalleryCell.swift
+++ b/Sources/StreamChatUI/Gallery/Cells/ImageAttachmentGalleryCell.swift
@@ -35,8 +35,7 @@ open class ImageAttachmentGalleryCell: GalleryCollectionViewCell {
         components.mediaLoader.loadImage(
             into: imageView,
             from: imageAttachment?.payload,
-            maxResolutionInPixels: components.imageAttachmentMaxPixels,
-            cdnRequester: components.cdnRequester
+            maxResolutionInPixels: components.imageAttachmentMaxPixels
         )
     }
 

--- a/Sources/StreamChatUI/Gallery/Cells/VideoAttachmentGalleryCell.swift
+++ b/Sources/StreamChatUI/Gallery/Cells/VideoAttachmentGalleryCell.swift
@@ -53,7 +53,7 @@ open class VideoAttachmentGalleryCell: GalleryCollectionViewCell {
 
         if newAssetURL != currentAssetURL {
             if let url = newAssetURL {
-                components.mediaLoader.loadVideoAsset(at: url, options: VideoLoadOptions()) { [weak self] result in
+                components.mediaLoader.loadVideoAsset(at: url) { [weak self] result in
                     if case let .success(loaded) = result {
                         let playerItem = AVPlayerItem(asset: loaded.asset)
                         self?.player.replaceCurrentItem(with: playerItem)
@@ -65,8 +65,7 @@ open class VideoAttachmentGalleryCell: GalleryCollectionViewCell {
 
             if let videoAttachment {
                 components.mediaLoader.loadVideoPreview(
-                    with: videoAttachment,
-                    options: VideoLoadOptions()
+                    with: videoAttachment
                 ) { [weak self] in
                     switch $0 {
                     case let .success(preview):

--- a/Sources/StreamChatUI/Gallery/Cells/VideoAttachmentGalleryCell.swift
+++ b/Sources/StreamChatUI/Gallery/Cells/VideoAttachmentGalleryCell.swift
@@ -53,8 +53,7 @@ open class VideoAttachmentGalleryCell: GalleryCollectionViewCell {
 
         if newAssetURL != currentAssetURL {
             if let url = newAssetURL {
-                let options = VideoLoadOptions(cdnRequester: components.cdnRequester)
-                components.mediaLoader.loadVideoAsset(at: url, options: options) { [weak self] result in
+                components.mediaLoader.loadVideoAsset(at: url, options: VideoLoadOptions()) { [weak self] result in
                     if case let .success(loaded) = result {
                         let playerItem = AVPlayerItem(asset: loaded.asset)
                         self?.player.replaceCurrentItem(with: playerItem)
@@ -67,7 +66,7 @@ open class VideoAttachmentGalleryCell: GalleryCollectionViewCell {
             if let videoAttachment {
                 components.mediaLoader.loadVideoPreview(
                     with: videoAttachment,
-                    options: VideoLoadOptions(cdnRequester: components.cdnRequester)
+                    options: VideoLoadOptions()
                 ) { [weak self] in
                     switch $0 {
                     case let .success(preview):

--- a/Sources/StreamChatUI/Utils/ImageLoading/ImageDownloadOptions.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/ImageDownloadOptions.swift
@@ -11,11 +11,12 @@ public struct ImageDownloadOptions: Sendable {
     /// The resize information when loading an image. `Nil` if you want the full resolution of the image.
     public var resize: ImageResize?
 
-    /// The CDN requester for URL transformation (signing, headers, resizing).
-    public var cdnRequester: CDNRequester
+    public init(resize: ImageResize? = nil) {
+        self.resize = resize
+    }
 
+    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
     public init(resize: ImageResize? = nil, cdnRequester: CDNRequester) {
         self.resize = resize
-        self.cdnRequester = cdnRequester
     }
 }

--- a/Sources/StreamChatUI/Utils/ImageLoading/ImageDownloadOptions.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/ImageDownloadOptions.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import StreamChat
 import StreamChatCommonUI
 
 /// The options for downloading an image.
@@ -12,11 +11,6 @@ public struct ImageDownloadOptions: Sendable {
     public var resize: ImageResize?
 
     public init(resize: ImageResize? = nil) {
-        self.resize = resize
-    }
-
-    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
-    public init(resize: ImageResize? = nil, cdnRequester: CDNRequester) {
         self.resize = resize
     }
 }

--- a/Sources/StreamChatUI/Utils/ImageLoading/ImageLoaderOptions.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/ImageLoaderOptions.swift
@@ -2,7 +2,6 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import StreamChat
 import StreamChatCommonUI
 import UIKit
 
@@ -17,12 +16,6 @@ public struct ImageLoaderOptions: Sendable {
     public var placeholder: UIImage?
 
     public init(resize: ImageResize? = nil, placeholder: UIImage? = nil) {
-        self.placeholder = placeholder
-        self.resize = resize
-    }
-
-    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
-    public init(resize: ImageResize? = nil, placeholder: UIImage? = nil, cdnRequester: CDNRequester) {
         self.placeholder = placeholder
         self.resize = resize
     }

--- a/Sources/StreamChatUI/Utils/ImageLoading/ImageLoaderOptions.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/ImageLoaderOptions.swift
@@ -16,12 +16,14 @@ public struct ImageLoaderOptions: Sendable {
     /// The placeholder to be used while the image is finishing loading.
     public var placeholder: UIImage?
 
-    /// The CDN requester for URL transformation (signing, headers, resizing).
-    public var cdnRequester: CDNRequester
+    public init(resize: ImageResize? = nil, placeholder: UIImage? = nil) {
+        self.placeholder = placeholder
+        self.resize = resize
+    }
 
+    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader. Pass it when creating the loader instead.")
     public init(resize: ImageResize? = nil, placeholder: UIImage? = nil, cdnRequester: CDNRequester) {
         self.placeholder = placeholder
         self.resize = resize
-        self.cdnRequester = cdnRequester
     }
 }

--- a/Sources/StreamChatUI/Utils/ImageLoading/MediaLoader+UIKit.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/MediaLoader+UIKit.swift
@@ -25,7 +25,7 @@ extension MediaLoader {
 
         imageView.currentImageLoadingTask = task
 
-        let loadOptions = ImageLoadOptions(resize: options.resize, cdnRequester: options.cdnRequester)
+        let loadOptions = ImageLoadOptions(resize: options.resize)
         loadImage(url: url, options: loadOptions) { result in
             guard !task.isCancelled else { return }
             switch result {
@@ -45,7 +45,7 @@ extension MediaLoader {
         with request: ImageDownloadRequest,
         completion: @escaping @MainActor (Result<UIImage, Error>) -> Void
     ) {
-        let loadOptions = ImageLoadOptions(resize: request.options.resize, cdnRequester: request.options.cdnRequester)
+        let loadOptions = ImageLoadOptions(resize: request.options.resize)
         loadImage(url: request.url, options: loadOptions) { result in
             completion(result.map(\.image))
         }
@@ -86,7 +86,6 @@ extension MediaLoader {
         into imageView: UIImageView,
         from attachmentPayload: ImageAttachmentPayload?,
         maxResolutionInPixels: Double,
-        cdnRequester: CDNRequester,
         completion: (@MainActor (Result<UIImage, Error>) -> Void)? = nil
     ) -> ImageLoadingTask {
         guard let originalWidth = attachmentPayload?.originalWidth,
@@ -94,7 +93,7 @@ extension MediaLoader {
             return loadImage(
                 into: imageView,
                 from: attachmentPayload?.imageURL,
-                with: ImageLoaderOptions(cdnRequester: cdnRequester),
+                with: ImageLoaderOptions(),
                 completion: completion
             )
         }
@@ -109,7 +108,24 @@ extension MediaLoader {
         return loadImage(
             into: imageView,
             from: attachmentPayload?.imageURL,
-            with: ImageLoaderOptions(resize: ImageResize(newSize), cdnRequester: cdnRequester),
+            with: ImageLoaderOptions(resize: ImageResize(newSize)),
+            completion: completion
+        )
+    }
+
+    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader.")
+    @discardableResult
+    @MainActor public func loadImage(
+        into imageView: UIImageView,
+        from attachmentPayload: ImageAttachmentPayload?,
+        maxResolutionInPixels: Double,
+        cdnRequester: CDNRequester,
+        completion: (@MainActor (Result<UIImage, Error>) -> Void)? = nil
+    ) -> ImageLoadingTask {
+        loadImage(
+            into: imageView,
+            from: attachmentPayload,
+            maxResolutionInPixels: maxResolutionInPixels,
             completion: completion
         )
     }

--- a/Sources/StreamChatUI/Utils/ImageLoading/MediaLoader+UIKit.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/MediaLoader+UIKit.swift
@@ -113,22 +113,6 @@ extension MediaLoader {
         )
     }
 
-    @available(*, deprecated, message: "CDNRequester is now a dependency of StreamMediaLoader.")
-    @discardableResult
-    @MainActor public func loadImage(
-        into imageView: UIImageView,
-        from attachmentPayload: ImageAttachmentPayload?,
-        maxResolutionInPixels: Double,
-        cdnRequester: CDNRequester,
-        completion: (@MainActor (Result<UIImage, Error>) -> Void)? = nil
-    ) -> ImageLoadingTask {
-        loadImage(
-            into: imageView,
-            from: attachmentPayload,
-            maxResolutionInPixels: maxResolutionInPixels,
-            completion: completion
-        )
-    }
 }
 
 final class ImageBatchResult: @unchecked Sendable {

--- a/Sources/StreamChatUI/Utils/ImageLoading/MediaLoader+UIKit.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/MediaLoader+UIKit.swift
@@ -112,7 +112,6 @@ extension MediaLoader {
             completion: completion
         )
     }
-
 }
 
 final class ImageBatchResult: @unchecked Sendable {

--- a/Sources/StreamChatUI/Utils/ImageLoading/StreamImageDownloader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/StreamImageDownloader.swift
@@ -36,7 +36,11 @@ public final class StreamImageDownloader: ImageDownloading, Sendable {
             StreamConcurrency.onMain {
                 switch result {
                 case let .success(imageResponse):
-                    completion(.success(DownloadedImage(image: imageResponse.image)))
+                    completion(.success(DownloadedImage(
+                        image: imageResponse.image,
+                        isAnimated: imageResponse.container.type == .gif,
+                        animatedImageData: imageResponse.container.data
+                    )))
                 case let .failure(error):
                     completion(.failure(error))
                 }

--- a/Sources/StreamChatUI/Utils/ImageLoading/StreamImageDownloader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/StreamImageDownloader.swift
@@ -36,10 +36,11 @@ public final class StreamImageDownloader: ImageDownloading, Sendable {
             StreamConcurrency.onMain {
                 switch result {
                 case let .success(imageResponse):
+                    let isAnimated = imageResponse.container.type == .gif
                     completion(.success(DownloadedImage(
                         image: imageResponse.image,
-                        isAnimated: imageResponse.container.type == .gif,
-                        animatedImageData: imageResponse.container.data
+                        isAnimated: isAnimated,
+                        animatedImageData: isAnimated ? imageResponse.container.data : nil
                     )))
                 case let .failure(error):
                     completion(.failure(error))

--- a/Sources/StreamChatUI/Utils/ImageLoading/StreamImageDownloader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/StreamImageDownloader.swift
@@ -36,11 +36,9 @@ public final class StreamImageDownloader: ImageDownloading, Sendable {
             StreamConcurrency.onMain {
                 switch result {
                 case let .success(imageResponse):
-                    let isAnimated = imageResponse.container.type == .gif
                     completion(.success(DownloadedImage(
                         image: imageResponse.image,
-                        isAnimated: isAnimated,
-                        animatedImageData: isAnimated ? imageResponse.container.data : nil
+                        animatedImageData: imageResponse.container.type == .gif ? imageResponse.container.data : nil
                     )))
                 case let .failure(error):
                     completion(.failure(error))

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -18,7 +18,7 @@ final class MessageUpdater_Mock: MessageUpdater, @unchecked Sendable {
     @Atomic var deleteMessage_deleteForMe: Bool?
 
     @Atomic var downloadAttachment_attachmentId: AttachmentId?
-    @Atomic var downloadAttachment_remoteURL: URL?
+    @Atomic var downloadAttachment_request: URLRequest?
     @Atomic var downloadAttachment_completion_result: Result<AnyChatMessageAttachment, Error>?
     
     @Atomic var deleteLocalAttachmentDownload_attachmentId: AttachmentId?
@@ -167,7 +167,7 @@ final class MessageUpdater_Mock: MessageUpdater, @unchecked Sendable {
         deleteLocalAttachmentDownload_completion_result = nil
         
         downloadAttachment_attachmentId = nil
-        downloadAttachment_remoteURL = nil
+        downloadAttachment_request = nil
         downloadAttachment_completion_result = nil
         
         editMessage_messageId = nil
@@ -304,11 +304,11 @@ final class MessageUpdater_Mock: MessageUpdater, @unchecked Sendable {
     
     override func downloadAttachment<Payload>(
         _ attachment: ChatMessageAttachment<Payload>,
-        remoteURL: URL? = nil,
+        request: URLRequest? = nil,
         completion: @escaping (Result<ChatMessageAttachment<Payload>, any Error>) -> Void
     ) where Payload: DownloadableAttachmentPayload {
         downloadAttachment_attachmentId = attachment.id
-        downloadAttachment_remoteURL = remoteURL
+        downloadAttachment_request = request
         switch downloadAttachment_completion_result {
         case .success(let anyAttachment):
             if let result = anyAttachment.attachment(payloadType: Payload.self) {

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -33,7 +33,7 @@ final class APIClient_Spy: APIClient, Spy, @unchecked Sendable {
     @Atomic var unmanagedRequest_completion: Any?
     @Atomic var unmanagedRequest_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
 
-    @Atomic var downloadFile_remoteURL: URL?
+    @Atomic var downloadFile_request: URLRequest?
     @Atomic var downloadFile_localURL: URL?
     @Atomic var downloadFile_completion_result: Result<Void, Error>?
     @Atomic var downloadFile_expectation: XCTestExpectation
@@ -68,7 +68,7 @@ final class APIClient_Spy: APIClient, Spy, @unchecked Sendable {
         recoveryRequest_allRecordedCalls = []
         recoveryRequest_completion = nil
 
-        downloadFile_remoteURL = nil
+        downloadFile_request = nil
         downloadFile_localURL = nil
         downloadFile_completion_result = nil
         
@@ -169,12 +169,12 @@ final class APIClient_Spy: APIClient, Spy, @unchecked Sendable {
     }
 
     override func downloadFile(
-        from remoteURL: URL,
+        _ request: URLRequest,
         to localURL: URL,
         progress: ((Double) -> Void)?,
         completion: @escaping ((any Error)?) -> Void
     ) {
-        downloadFile_remoteURL = remoteURL
+        downloadFile_request = request
         downloadFile_localURL = localURL
         downloadFile_completion_result?.invoke(with: completion)
         downloadFile_expectation.fulfill()

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/AttachmentDownloader_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/AttachmentDownloader_Spy.swift
@@ -10,7 +10,7 @@ final class AttachmentDownloader_Spy: AttachmentDownloader, Spy {
     @Atomic var downloadAttachmentProgress: Double?
     @Atomic var downloadAttachmentResult: Error?
 
-    func download(from remoteURL: URL, to localURL: URL, progress: (@Sendable (Double) -> Void)?, completion: @escaping @Sendable ((any Error)?) -> Void) {
+    func download(_ request: URLRequest, to localURL: URL, progress: (@Sendable (Double) -> Void)?, completion: @escaping @Sendable ((any Error)?) -> Void) {
         record()
         if let downloadAttachmentProgress {
             progress?(downloadAttachmentProgress)

--- a/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Image_Tests.swift
+++ b/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Image_Tests.swift
@@ -15,7 +15,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         super.setUp()
         downloader = MockImageDownloader()
         cdnRequester = MockCDNRequester()
-        sut = StreamMediaLoader(downloader: downloader)
+        sut = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
     }
 
     override func tearDown() {
@@ -30,7 +30,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
     func test_loadImage_nilURL_callsCompletionWithFailure() {
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: nil, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadImage(url: nil, options: ImageLoadOptions()) { result in
             switch result {
             case .failure:
                 break
@@ -49,7 +49,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let url = URL(string: "https://example.com/image.jpg")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadImage(url: url, options: ImageLoadOptions()) { result in
             switch result {
             case let .success(loaded):
                 XCTAssertEqual(loaded.image.pngData(), testImage.pngData())
@@ -68,7 +68,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let url = URL(string: "https://example.com/image.jpg")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadImage(url: url, options: ImageLoadOptions()) { result in
             switch result {
             case .success:
                 XCTFail("Should have failed")
@@ -87,7 +87,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let url = URL(string: "https://example.com/image.jpg")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadImage(url: url, options: ImageLoadOptions()) { result in
             switch result {
             case .success:
                 XCTFail("Should have failed")
@@ -107,7 +107,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let resize = ImageResize(CGSize(width: 100, height: 200))
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: url, options: ImageLoadOptions(resize: resize, cdnRequester: cdnRequester)) { _ in
+        sut.loadImage(url: url, options: ImageLoadOptions(resize: resize)) { _ in
             expectation.fulfill()
         }
 
@@ -126,7 +126,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let url = URL(string: "https://example.com/image.jpg")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { _ in
+        sut.loadImage(url: url, options: ImageLoadOptions()) { _ in
             expectation.fulfill()
         }
 
@@ -144,7 +144,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let url = URL(string: "https://example.com/image.jpg")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { _ in
+        sut.loadImage(url: url, options: ImageLoadOptions()) { _ in
             expectation.fulfill()
         }
 
@@ -160,7 +160,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         let originalURL = URL(string: "https://example.com/original.jpg")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadImage(url: originalURL, options: ImageLoadOptions(cdnRequester: cdnRequester)) { _ in
+        sut.loadImage(url: originalURL, options: ImageLoadOptions()) { _ in
             expectation.fulfill()
         }
 

--- a/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Image_Tests.swift
+++ b/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Image_Tests.swift
@@ -15,7 +15,7 @@ final class StreamMediaLoader_Image_Tests: XCTestCase {
         super.setUp()
         downloader = MockImageDownloader()
         cdnRequester = MockCDNRequester()
-        sut = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        sut = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
     }
 
     override func tearDown() {

--- a/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Video_Tests.swift
+++ b/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Video_Tests.swift
@@ -16,7 +16,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         super.setUp()
         downloader = MockImageDownloader()
         cdnRequester = MockCDNRequester()
-        sut = StreamMediaLoader(downloader: downloader)
+        sut = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
     }
 
     override func tearDown() {
@@ -34,7 +34,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let originalURL = URL(string: "https://example.com/video.mp4")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoAsset(at: originalURL, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoAsset(at: originalURL, options: VideoLoadOptions()) { result in
             switch result {
             case let .success(videoAsset):
                 XCTAssertEqual(videoAsset.asset.url, transformedURL)
@@ -53,7 +53,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         cdnRequester.fileRequestResult = .success(CDNRequest(url: url, headers: headers))
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoAsset(at: url, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoAsset(at: url, options: VideoLoadOptions()) { result in
             switch result {
             case let .success(videoAsset):
                 XCTAssertEqual(videoAsset.asset.url, url)
@@ -71,7 +71,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         cdnRequester.fileRequestResult = .success(CDNRequest(url: url, headers: [:]))
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoAsset(at: url, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoAsset(at: url, options: VideoLoadOptions()) { result in
             switch result {
             case let .success(videoAsset):
                 XCTAssertEqual(videoAsset.asset.url, url)
@@ -89,7 +89,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         cdnRequester.fileRequestResult = .success(CDNRequest(url: url))
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoAsset(at: url, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoAsset(at: url, options: VideoLoadOptions()) { result in
             switch result {
             case let .success(videoAsset):
                 XCTAssertEqual(videoAsset.asset.url, url)
@@ -108,7 +108,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let url = URL(string: "https://example.com/video.mp4")!
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoAsset(at: url, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoAsset(at: url, options: VideoLoadOptions()) { result in
             switch result {
             case .success:
                 XCTFail("Should have failed")
@@ -133,7 +133,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let attachment = makeVideoAttachment(videoURL: url, thumbnailURL: thumbnailURL)
 
         let firstExpectation = expectation(description: "First load")
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             if case let .success(preview) = result {
                 XCTAssertEqual(preview.image.pngData(), cachedImage.pngData())
             } else {
@@ -149,7 +149,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
 
         // Second load should hit cache and NOT call CDN requester
         let secondExpectation = expectation(description: "Second load from cache")
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             if case let .success(preview) = result {
                 XCTAssertEqual(preview.image.pngData(), cachedImage.pngData())
             } else {
@@ -173,7 +173,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let attachment = makeVideoAttachment(videoURL: videoURL, thumbnailURL: thumbnailURL)
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             switch result {
             case let .success(preview):
                 XCTAssertEqual(preview.image.pngData(), thumbnailImage.pngData())
@@ -194,7 +194,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let attachment = makeVideoAttachment(videoURL: videoURL, thumbnailURL: thumbnailURL)
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             switch result {
             case .success:
                 XCTFail("Should have failed since both thumbnail and video preview fail")
@@ -214,7 +214,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let attachment = makeVideoAttachment(videoURL: videoURL, thumbnailURL: nil)
         let expectation = expectation(description: "Completion called")
 
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { _ in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { _ in
             expectation.fulfill()
         }
 
@@ -233,7 +233,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         )
         let expectation = expectation(description: "Completion called")
 
-        loader?.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        loader?.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             if case .failure = result {
                 expectation.fulfill()
             } else {
@@ -259,7 +259,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         let attachment = makeVideoAttachment(videoURL: url, thumbnailURL: thumbnailURL)
 
         let firstExpectation = expectation(description: "First load")
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { _ in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { _ in
             firstExpectation.fulfill()
         }
         waitForExpectations(timeout: 2)
@@ -275,7 +275,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
 
         // Load again — should NOT hit cache (it was cleared)
         let secondExpectation = expectation(description: "Second load after memory warning")
-        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { _ in
+        sut.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { _ in
             secondExpectation.fulfill()
         }
         waitForExpectations(timeout: 2)

--- a/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Video_Tests.swift
+++ b/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Video_Tests.swift
@@ -16,7 +16,7 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         super.setUp()
         downloader = MockImageDownloader()
         cdnRequester = MockCDNRequester()
-        sut = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        sut = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
     }
 
     override func tearDown() {

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -746,19 +746,20 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.downloadAttachment_attachmentId, attachmentId)
     }
 
-    func test_downloadAttachment_withCustomRemoteURL_propagatesURLToUpdater() {
+    func test_downloadAttachment_withCustomRequest_propagatesRequestToUpdater() {
         let attachmentId = AttachmentId.unique
         let attachment = ChatMessageFileAttachment.mock(id: attachmentId)
-        let customRemoteURL = URL(string: "https://cdn.example.com/signed?token=abc123")!
+        let customURL = URL(string: "https://cdn.example.com/signed?token=abc123")!
+        let customRequest = URLRequest(url: customURL)
         env.messageUpdater.downloadAttachment_completion_result = .success(attachment.asAnyAttachment)
 
-        controller.downloadAttachment(attachment, remoteURL: customRemoteURL) { _ in }
+        controller.downloadAttachment(attachment, request: customRequest) { _ in }
 
         AssertAsync.willBeEqual(env.messageUpdater.downloadAttachment_attachmentId, attachmentId)
-        XCTAssertEqual(env.messageUpdater.downloadAttachment_remoteURL, customRemoteURL)
+        XCTAssertEqual(env.messageUpdater.downloadAttachment_request?.url, customURL)
     }
 
-    func test_downloadAttachment_withoutRemoteURL_propagatesNilURLToUpdater() {
+    func test_downloadAttachment_withoutRequest_propagatesNilRequestToUpdater() {
         let attachmentId = AttachmentId.unique
         let attachment = ChatMessageFileAttachment.mock(id: attachmentId)
         env.messageUpdater.downloadAttachment_completion_result = .success(attachment.asAnyAttachment)
@@ -766,7 +767,7 @@ final class MessageController_Tests: XCTestCase {
         controller.downloadAttachment(attachment) { _ in }
 
         AssertAsync.willBeEqual(env.messageUpdater.downloadAttachment_attachmentId, attachmentId)
-        XCTAssertNil(env.messageUpdater.downloadAttachment_remoteURL)
+        XCTAssertNil(env.messageUpdater.downloadAttachment_request)
     }
 
     // MARK: - Delete message

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -549,25 +549,26 @@ final class Chat_Tests: XCTestCase {
         XCTAssertEqual(attachmentId, env.messageUpdaterMock.downloadAttachment_attachmentId)
     }
 
-    func test_downloadAttachment_withCustomRemoteURL_propagatesURLToUpdater() async throws {
+    func test_downloadAttachment_withCustomRequest_propagatesRequestToUpdater() async throws {
         let attachmentId = AttachmentId.unique
         let expected = ChatMessageFileAttachment.mock(id: attachmentId)
-        let customRemoteURL = URL(string: "https://cdn.example.com/signed?token=abc123")!
+        let customURL = URL(string: "https://cdn.example.com/signed?token=abc123")!
+        let customRequest = URLRequest(url: customURL)
         env.messageUpdaterMock.downloadAttachment_completion_result = .success(expected.asAnyAttachment)
-        let result = try await chat.downloadAttachment(expected, remoteURL: customRemoteURL)
+        let result = try await chat.downloadAttachment(expected, request: customRequest)
         XCTAssertEqual(expected, result)
         XCTAssertEqual(attachmentId, env.messageUpdaterMock.downloadAttachment_attachmentId)
-        XCTAssertEqual(customRemoteURL, env.messageUpdaterMock.downloadAttachment_remoteURL)
+        XCTAssertEqual(customURL, env.messageUpdaterMock.downloadAttachment_request?.url)
     }
 
-    func test_downloadAttachment_withoutRemoteURL_propagatesNilToUpdater() async throws {
+    func test_downloadAttachment_withoutRequest_propagatesNilToUpdater() async throws {
         let attachmentId = AttachmentId.unique
         let expected = ChatMessageFileAttachment.mock(id: attachmentId)
         env.messageUpdaterMock.downloadAttachment_completion_result = .success(expected.asAnyAttachment)
         let result = try await chat.downloadAttachment(expected)
         XCTAssertEqual(expected, result)
         XCTAssertEqual(attachmentId, env.messageUpdaterMock.downloadAttachment_attachmentId)
-        XCTAssertNil(env.messageUpdaterMock.downloadAttachment_remoteURL)
+        XCTAssertNil(env.messageUpdaterMock.downloadAttachment_request)
     }
     
     func test_deleteLocalAttachmentDownload_whenMessageUpdaterSucceeds_thenSucceess() async throws {

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -2087,7 +2087,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let result = try waitFor { messageUpdater.downloadAttachment(attachment, completion: $0) }
         let value = try XCTUnwrap(result.value)
         XCTAssertEqual("Sample.wav", apiClient.downloadFile_localURL?.lastPathComponent)
-        XCTAssertEqual("http://asset.url/file.wav", apiClient.downloadFile_remoteURL?.absoluteString)
+        XCTAssertEqual("http://asset.url/file.wav", apiClient.downloadFile_request?.url?.absoluteString)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
         XCTAssertEqual(URL.streamAttachmentLocalStorageURL(forRelativePath: value.relativeStoragePath), value.downloadingState?.localFileURL)
@@ -2101,7 +2101,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let result = try waitFor { messageUpdater.downloadAttachment(attachment, completion: $0) }
         let value = try XCTUnwrap(result.value)
         XCTAssertEqual("Sample.pdf", apiClient.downloadFile_localURL?.lastPathComponent)
-        XCTAssertEqual("http://asset.url", apiClient.downloadFile_remoteURL?.absoluteString)
+        XCTAssertEqual("http://asset.url", apiClient.downloadFile_request?.url?.absoluteString)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
         XCTAssertEqual(URL.streamAttachmentLocalStorageURL(forRelativePath: value.relativeStoragePath), value.downloadingState?.localFileURL)
@@ -2119,7 +2119,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let result = try waitFor { messageUpdater.downloadAttachment(attachment, completion: $0) }
         let value = try XCTUnwrap(result.value)
         XCTAssertEqual("yoda.jpg", apiClient.downloadFile_localURL?.lastPathComponent)
-        XCTAssertEqual(URL.localYodaImage, apiClient.downloadFile_remoteURL)
+        XCTAssertEqual(URL.localYodaImage, apiClient.downloadFile_request?.url)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
         XCTAssertEqual(URL.streamAttachmentLocalStorageURL(forRelativePath: value.relativeStoragePath), value.downloadingState?.localFileURL)
@@ -2133,7 +2133,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let result = try waitFor { messageUpdater.downloadAttachment(attachment, completion: $0) }
         let value = try XCTUnwrap(result.value)
         XCTAssertEqual("Sample.mp4", apiClient.downloadFile_localURL?.lastPathComponent)
-        XCTAssertEqual("http://asset.url/video.mp4", apiClient.downloadFile_remoteURL?.absoluteString)
+        XCTAssertEqual("http://asset.url/video.mp4", apiClient.downloadFile_request?.url?.absoluteString)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
         XCTAssertEqual(URL.streamAttachmentLocalStorageURL(forRelativePath: value.relativeStoragePath), value.downloadingState?.localFileURL)
@@ -2150,7 +2150,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let result = try waitFor { messageUpdater.downloadAttachment(attachment, completion: $0) }
         let value = try XCTUnwrap(result.value)
         XCTAssertEqual("recording.aac", apiClient.downloadFile_localURL?.lastPathComponent)
-        XCTAssertEqual("http://asset.url/myrecording.aac", apiClient.downloadFile_remoteURL?.absoluteString)
+        XCTAssertEqual("http://asset.url/myrecording.aac", apiClient.downloadFile_request?.url?.absoluteString)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
         XCTAssertEqual(URL.streamAttachmentLocalStorageURL(forRelativePath: value.relativeStoragePath), value.downloadingState?.localFileURL)
@@ -2173,33 +2173,34 @@ final class MessageUpdater_Tests: XCTestCase {
         let result = try waitFor { messageUpdater.downloadAttachment(attachment, completion: $0) }
         let value = try XCTUnwrap(result.value)
         XCTAssertEqual("52.3676-4.9041", apiClient.downloadFile_localURL?.lastPathComponent)
-        XCTAssertEqual("https://asset.url/map_preview", apiClient.downloadFile_remoteURL?.absoluteString)
+        XCTAssertEqual("https://asset.url/map_preview", apiClient.downloadFile_request?.url?.absoluteString)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
         XCTAssertEqual(URL.streamAttachmentLocalStorageURL(forRelativePath: value.relativeStoragePath), value.downloadingState?.localFileURL)
     }
     
-    func test_downloadAttachment_usesRemoteURLWhenProvided() throws {
+    func test_downloadAttachment_usesRequestWhenProvided() throws {
         let attachment = try setUpAttachment(
             attachment: ChatMessageFileAttachment.mock(id: .unique)
         )
         let signedURL = URL(string: "https://cdn.example.com/signed?token=abc123")!
+        let signedRequest = URLRequest(url: signedURL)
         apiClient.downloadFile_completion_result = .success(())
-        let result = try waitFor { messageUpdater.downloadAttachment(attachment, remoteURL: signedURL, completion: $0) }
+        let result = try waitFor { messageUpdater.downloadAttachment(attachment, request: signedRequest, completion: $0) }
         let value = try XCTUnwrap(result.value)
-        XCTAssertEqual(signedURL, apiClient.downloadFile_remoteURL)
+        XCTAssertEqual(signedURL, apiClient.downloadFile_request?.url)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
     }
 
-    func test_downloadAttachment_usesOriginalURLWhenRemoteURLIsNil() throws {
+    func test_downloadAttachment_usesOriginalURLWhenRequestIsNil() throws {
         let attachment = try setUpAttachment(
             attachment: ChatMessageFileAttachment.mock(id: .unique)
         )
         apiClient.downloadFile_completion_result = .success(())
-        let result = try waitFor { messageUpdater.downloadAttachment(attachment, remoteURL: nil, completion: $0) }
+        let result = try waitFor { messageUpdater.downloadAttachment(attachment, request: nil, completion: $0) }
         let value = try XCTUnwrap(result.value)
-        XCTAssertEqual("http://asset.url", apiClient.downloadFile_remoteURL?.absoluteString)
+        XCTAssertEqual("http://asset.url", apiClient.downloadFile_request?.url?.absoluteString)
         XCTAssertEqual(attachment.id, value.id)
         XCTAssertEqual(LocalAttachmentDownloadState.downloaded, value.downloadingState?.state)
     }

--- a/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
@@ -93,12 +93,13 @@ final class ImageLoader_Mock: MediaLoader, @unchecked Sendable {
         }
     }
 
-    func resolveFileURL(
-        _ url: URL,
-        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    func loadFile(
+        at url: URL,
+        options: FileLoadOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
     ) {
         MainActor.assumeIsolated {
-            completion(.success(CDNRequest(url: url)))
+            completion(.success(MediaLoaderFile(url: url)))
         }
     }
 }

--- a/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
@@ -92,4 +92,13 @@ final class ImageLoader_Mock: MediaLoader, @unchecked Sendable {
             }
         }
     }
+
+    func resolveFileURL(
+        _ url: URL,
+        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    ) {
+        MainActor.assumeIsolated {
+            completion(.success(CDNRequest(url: url)))
+        }
+    }
 }

--- a/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
@@ -93,13 +93,13 @@ final class ImageLoader_Mock: MediaLoader, @unchecked Sendable {
         }
     }
 
-    func loadFile(
-        at url: URL,
-        options: FileLoadOptions,
-        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
+    func loadFileRequest(
+        for url: URL,
+        options: DownloadFileRequestOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFileRequest, Error>) -> Void
     ) {
         MainActor.assumeIsolated {
-            completion(.success(MediaLoaderFile(url: url)))
+            completion(.success(MediaLoaderFileRequest(urlRequest: URLRequest(url: url))))
         }
     }
 }

--- a/Tests/StreamChatUITests/Utils/StreamMediaLoader_UIKit_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/StreamMediaLoader_UIKit_Tests.swift
@@ -17,7 +17,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         super.setUp()
         cdnRequester = MockCDNRequester()
         downloader = MockImageDownloader()
-        sut = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        sut = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
     }
 
     override func tearDown() {

--- a/Tests/StreamChatUITests/Utils/StreamMediaLoader_UIKit_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/StreamMediaLoader_UIKit_Tests.swift
@@ -17,7 +17,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         super.setUp()
         cdnRequester = MockCDNRequester()
         downloader = MockImageDownloader()
-        sut = StreamMediaLoader(downloader: downloader)
+        sut = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
     }
 
     override func tearDown() {
@@ -33,7 +33,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
     func test_loadImageInto_nilURL_setsPlaceholder() {
         let imageView = UIImageView()
         let placeholder = UIImage.make(withColor: .gray)
-        let options = ImageLoaderOptions(placeholder: placeholder, cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions(placeholder: placeholder)
 
         sut.loadImage(into: imageView, from: nil, with: options)
 
@@ -43,7 +43,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
     @MainActor
     func test_loadImageInto_nilURL_noPlaceholder_setsNilImage() {
         let imageView = UIImageView()
-        let options = ImageLoaderOptions(cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions()
 
         sut.loadImage(into: imageView, from: nil, with: options)
 
@@ -56,7 +56,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         downloader.result = .success(DownloadedImage(image: testImage))
         let imageView = UIImageView()
         let url = URL(string: "https://example.com/image.jpg")!
-        let options = ImageLoaderOptions(cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions()
         let expectation = expectation(description: "Completion called")
 
         sut.loadImage(into: imageView, from: url, with: options) { result in
@@ -79,7 +79,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         downloader.result = .failure(expectedError)
         let imageView = UIImageView()
         let url = URL(string: "https://example.com/image.jpg")!
-        let options = ImageLoaderOptions(cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions()
         let expectation = expectation(description: "Completion called")
 
         sut.loadImage(into: imageView, from: url, with: options) { result in
@@ -101,7 +101,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         downloader.result = .success(DownloadedImage(image: testImage))
         let imageView = UIImageView()
         let url = URL(string: "https://example.com/image.jpg")!
-        let options = ImageLoaderOptions(cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions()
 
         let task = sut.loadImage(into: imageView, from: url, with: options)
 
@@ -115,7 +115,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         downloader.result = .success(DownloadedImage(image: testImage))
         let imageView = UIImageView()
         let url = URL(string: "https://example.com/image.jpg")!
-        let options = ImageLoaderOptions(cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions()
         let expectation = expectation(description: "Wait for delayed completion")
         expectation.isInverted = true
 
@@ -133,7 +133,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         let imageView = UIImageView()
         let url1 = URL(string: "https://example.com/1.jpg")!
         let url2 = URL(string: "https://example.com/2.jpg")!
-        let options = ImageLoaderOptions(cdnRequester: cdnRequester)
+        let options = ImageLoaderOptions()
         downloader.completionDelay = 0.1
         downloader.result = .success(DownloadedImage(image: UIImage.make(withColor: .red)))
 
@@ -150,7 +150,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         downloader.result = .success(DownloadedImage(image: testImage))
         let request = ImageDownloadRequest(
             url: URL(string: "https://example.com/image.jpg")!,
-            options: ImageDownloadOptions(cdnRequester: cdnRequester)
+            options: ImageDownloadOptions()
         )
         let expectation = expectation(description: "Completion called")
 
@@ -172,7 +172,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         downloader.result = .failure(expectedError)
         let request = ImageDownloadRequest(
             url: URL(string: "https://example.com/image.jpg")!,
-            options: ImageDownloadOptions(cdnRequester: cdnRequester)
+            options: ImageDownloadOptions()
         )
         let expectation = expectation(description: "Completion called")
 
@@ -195,7 +195,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         let resize = ImageResize(CGSize(width: 200, height: 300))
         let request = ImageDownloadRequest(
             url: URL(string: "https://example.com/image.jpg")!,
-            options: ImageDownloadOptions(resize: resize, cdnRequester: cdnRequester)
+            options: ImageDownloadOptions(resize: resize)
         )
         let expectation = expectation(description: "Completion called")
 
@@ -219,9 +219,9 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
             URL(string: "https://example.com/3.jpg")!: .success(DownloadedImage(image: image3))
         ]
         let requests = [
-            ImageDownloadRequest(url: URL(string: "https://example.com/1.jpg")!, options: ImageDownloadOptions(cdnRequester: cdnRequester)),
-            ImageDownloadRequest(url: URL(string: "https://example.com/2.jpg")!, options: ImageDownloadOptions(cdnRequester: cdnRequester)),
-            ImageDownloadRequest(url: URL(string: "https://example.com/3.jpg")!, options: ImageDownloadOptions(cdnRequester: cdnRequester))
+            ImageDownloadRequest(url: URL(string: "https://example.com/1.jpg")!, options: ImageDownloadOptions()),
+            ImageDownloadRequest(url: URL(string: "https://example.com/2.jpg")!, options: ImageDownloadOptions()),
+            ImageDownloadRequest(url: URL(string: "https://example.com/3.jpg")!, options: ImageDownloadOptions())
         ]
         let expectation = expectation(description: "Completion called")
 
@@ -258,9 +258,9 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
             URL(string: "https://example.com/3.jpg")!: .success(DownloadedImage(image: image3))
         ]
         let requests = [
-            ImageDownloadRequest(url: URL(string: "https://example.com/1.jpg")!, options: ImageDownloadOptions(cdnRequester: cdnRequester)),
-            ImageDownloadRequest(url: URL(string: "https://example.com/2.jpg")!, options: ImageDownloadOptions(cdnRequester: cdnRequester)),
-            ImageDownloadRequest(url: URL(string: "https://example.com/3.jpg")!, options: ImageDownloadOptions(cdnRequester: cdnRequester))
+            ImageDownloadRequest(url: URL(string: "https://example.com/1.jpg")!, options: ImageDownloadOptions()),
+            ImageDownloadRequest(url: URL(string: "https://example.com/2.jpg")!, options: ImageDownloadOptions()),
+            ImageDownloadRequest(url: URL(string: "https://example.com/3.jpg")!, options: ImageDownloadOptions())
         ]
         let expectation = expectation(description: "Completion called")
 
@@ -305,8 +305,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         sut.loadImage(
             into: imageView,
             from: payload,
-            maxResolutionInPixels: 1_000_000,
-            cdnRequester: cdnRequester
+            maxResolutionInPixels: 1_000_000
         ) { _ in
             expectation.fulfill()
         }
@@ -330,8 +329,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         sut.loadImage(
             into: imageView,
             from: payload,
-            maxResolutionInPixels: 1_000_000,
-            cdnRequester: cdnRequester
+            maxResolutionInPixels: 1_000_000
         ) { _ in
             expectation.fulfill()
         }
@@ -347,8 +345,7 @@ final class StreamMediaLoader_UIKit_Tests: XCTestCase {
         sut.loadImage(
             into: imageView,
             from: nil,
-            maxResolutionInPixels: 1_000_000,
-            cdnRequester: cdnRequester
+            maxResolutionInPixels: 1_000_000
         )
 
         XCTAssertNil(imageView.image)


### PR DESCRIPTION
### 🔗 Issue Links

_N/A_

### 🎯 Goal

Improve the CDN and media loading architecture by making `CDNRequester` a constructor dependency of `StreamMediaLoader` instead of passing it through every method's options parameter. This centralizes CDN configuration and simplifies call sites across the SDK.

### 📝 Summary

- `CDNRequester` is now a constructor parameter of `StreamMediaLoader`, removing the need to pass it through `ImageLoadOptions`, `VideoLoadOptions`, and other options structs
- Added `loadFile(at:options:completion:)` to the `MediaLoader` protocol, replacing direct `CDNRequester.fileRequest` calls for file downloads
- Enriched `MediaLoaderImage` with `isAnimated`, `animatedImageData`, and `cachingKey` properties to support animated image rendering and synchronous cache lookups
- Enriched `DownloadedImage` with `isAnimated` and `animatedImageData` from Nuke's response
- Added `MediaLoaderFile` result type (URL + headers) and `FileLoadOptions` options struct
- Removed `cdnRequester` from `Components` — `MediaLoader` is now the single injection point
- Removed `cdnRequester` property from `ImageLoadOptions`, `VideoLoadOptions`, `ImageLoaderOptions`, and `ImageDownloadOptions`
- Updated all UIKit call sites (gallery cells, composer previews, avatar views, link previews, message list) to use simplified options
- Updated all tests and mocks to reflect the new API

### 🛠 Implementation

**Architecture decision**: Rather than passing `CDNRequester` on every call via options, it is now injected once at `StreamMediaLoader` construction time. This provides:

1. **Single configuration point** — Customers provide a custom `CDNRequester` once when creating `StreamMediaLoader`, rather than on every image/video/file load call
2. **Cleaner call sites** — All `loadImage`, `loadVideoAsset`, `loadVideoPreview` calls no longer need `cdnRequester` in their options
3. **Transparent file loading** — `loadFile(at:options:)` abstracts CDN URL resolution for file downloads, returning a `MediaLoaderFile` with the resolved URL and any required headers
4. **Flexibility preserved** — Customers who implement a fully custom `MediaLoader` can handle CDN resolution however they want internally, since `CDNRequester` is not part of the protocol contract

The enriched `MediaLoaderImage` (with `isAnimated`, `animatedImageData`, `cachingKey`) enables downstream consumers (like SwiftUI's `StreamAsyncImage`) to handle animated images and synchronous cache lookups without needing direct access to the underlying image loading library.

> **Note**: This is a breaking change. The `cdnRequester` property has been removed from `Components` and all options structs. Customers who were passing a custom `CDNRequester` through options should now pass it when constructing `StreamMediaLoader`.

### 🎨 Showcase

_No visual changes._

### 🧪 Manual Testing Notes

1. Verify images load correctly in channel list (avatars), message list (image attachments, link previews), and gallery
2. Verify video previews and playback work in composer and gallery
3. Verify file attachment downloads work (tap a file attachment to download/preview)
4. Verify animated GIFs render correctly in the message list

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated image/GIF support for avatars and attachments.
  * Attachment downloads use resolved file requests for more reliable downloads.

* **Refactor**
  * Simplified and unified image/video loading configuration across the UI, removing per-call CDN wiring for cleaner, more consistent media behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->