### PR TITLE
Remove iOS 15 from CI checks

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -36,9 +36,6 @@ jobs:
           - ios: "17.5"
             device: "iPhone 15 Pro"
             setup_runtime: true
-          - ios: "15.4"
-            device: "iPhone 13 Pro"
-            setup_runtime: true
       fail-fast: false
     runs-on: macos-15
     env:
@@ -105,9 +102,6 @@ jobs:
           - ios: "16.4"
             device: "iPhone 14 Pro"
             setup_runtime: true
-          - ios: "15.4"
-            device: "iPhone 13 Pro"
-            setup_runtime: true
       fail-fast: false
     runs-on: macos-15
     env:
@@ -157,9 +151,6 @@ jobs:
             setup_runtime: true
           - ios: "16.4"
             device: "iPhone 14 Pro"
-            setup_runtime: true
-          - ios: "15.5"
-            device: "iPhone 13 Pro"
             setup_runtime: true
       fail-fast: false
     runs-on: macos-15


### PR DESCRIPTION
Resolve https://linear.app/stream/issue/IOS-1643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed older iOS simulator test configurations from the CI/CD pipeline, reducing scheduled testing coverage for iOS versions 15.4 and 15.5 on iPhone 13 Pro simulator across multiple test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->