### PR TITLE
Remove duplicated EmptyResponse

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", exact: "1.0.0"),
-        .package(url: "https://github.com/GetStream/stream-core-swift.git", exact: "0.6.2")
+        .package(url: "https://github.com/GetStream/stream-core-swift.git", exact: "0.6.3")
     ],
     targets: [
         .target(

--- a/Sources/StreamChat/APIClient/Endpoints/Endpoint.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Endpoint.swift
@@ -78,9 +78,6 @@ enum EndpointMethod: String, Codable, Equatable {
     case put = "PUT"
 }
 
-/// A type representing empty response of an Endpoint.
-public struct EmptyResponse: Decodable, Sendable {}
-
 /// A type representing empty body for `.post` Endpoints.
 /// Our backend currently expects a body (not `nil`), even if it's empty.
 struct EmptyBody: Codable, Equatable {}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -659,7 +659,6 @@
 				StreamChatTests/APIClient/APIClient_Tests.swift,
 				StreamChatTests/APIClient/CDNClient/CDNStorage_Tests.swift,
 				StreamChatTests/APIClient/CDNClient/StreamCDNRequester_Tests.swift,
-				StreamChatTests/APIClient/StreamCDNStorage_Tests.swift,
 				StreamChatTests/APIClient/ChatRemoteNotificationHandler_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/AppEndpoints_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/AttachmentEndpoints_Tests.swift,
@@ -722,6 +721,7 @@
 				StreamChatTests/APIClient/HTTPHeader_Tests.swift,
 				StreamChatTests/APIClient/RequestDecoder_Tests.swift,
 				StreamChatTests/APIClient/RequestEncoder_Tests.swift,
+				StreamChatTests/APIClient/StreamCDNStorage_Tests.swift,
 				StreamChatTests/Audio/AudioAnalysisEngine_Tests.swift,
 				StreamChatTests/Audio/AudioPlaybackContext_Tests.swift,
 				StreamChatTests/Audio/AudioPlaybackRate_Tests.swift,
@@ -5301,7 +5301,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-core-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 0.6.2;
+				version = 0.6.3;
 			};
 		};
 		A3BD4869281FD4500090D511 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {

--- a/TestTools/StreamChatTestTools/Extensions/EmptyResponse+Extensions.swift
+++ b/TestTools/StreamChatTestTools/Extensions/EmptyResponse+Extensions.swift
@@ -1,0 +1,12 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+
+public extension EmptyResponse {
+    init() {
+        self = try! JSONDecoder().decode(Self.self, from: Data("{}".utf8))
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1620](https://linear.app/stream/issue/IOS-1620)

### 🎯 Goal

Use EmptyResponse from StreamCore

### 📝 Summary

- Remove EmptyResponse from StreamChat
- Use StreamCore 0.6.3 which added Sendable to EmptyResponse

### 🛠 Implementation

StreamCore types are re-exported, so removing this from StreamChat is not a breaking change.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a Swift package dependency to version 0.6.3

* **Refactor**
  * Simplified internal response-type definitions for improved consistency

* **Tests**
  * Added a test helper to create empty-response instances for testing purposes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->