### PR TITLE
Stabilise StreamCDNRequester caching key across query-item orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix image cache misses caused by non-deterministic caching keys in `StreamCDNRequester` [#4075](https://github.com/GetStream/stream-chat-swift/pull/4075)
+
 ### 🔄 Changed
 
 # [5.1.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.1.0)

--- a/Sources/StreamChat/APIClient/CDNClient/StreamCDNRequester.swift
+++ b/Sources/StreamChat/APIClient/CDNClient/StreamCDNRequester.swift
@@ -89,12 +89,6 @@ public final class StreamCDNRequester: CDNRequester, Sendable {
         }
 
         let persistedParameters = ["w", "h", "resize", "crop"]
-        // Sort the persisted parameters so the caching key is independent
-        // of the upstream query-item insertion order. Without sorting, two
-        // URLs that describe the same image at the same size but were
-        // assembled in different orders would hash to different cache
-        // entries — `buildImageURL` builds them from a `[String: String]`
-        // dictionary whose iteration order is not stable across calls.
         let newParameters = (components.queryItems ?? [])
             .filter { persistedParameters.contains($0.name) }
             .sorted { $0.name < $1.name }

--- a/Sources/StreamChat/APIClient/CDNClient/StreamCDNRequester.swift
+++ b/Sources/StreamChat/APIClient/CDNClient/StreamCDNRequester.swift
@@ -89,7 +89,15 @@ public final class StreamCDNRequester: CDNRequester, Sendable {
         }
 
         let persistedParameters = ["w", "h", "resize", "crop"]
-        let newParameters = components.queryItems?.filter { persistedParameters.contains($0.name) } ?? []
+        // Sort the persisted parameters so the caching key is independent
+        // of the upstream query-item insertion order. Without sorting, two
+        // URLs that describe the same image at the same size but were
+        // assembled in different orders would hash to different cache
+        // entries — `buildImageURL` builds them from a `[String: String]`
+        // dictionary whose iteration order is not stable across calls.
+        let newParameters = (components.queryItems ?? [])
+            .filter { persistedParameters.contains($0.name) }
+            .sorted { $0.name < $1.name }
         components.queryItems = newParameters.isEmpty ? nil : newParameters
         return components.string ?? key
     }

--- a/Tests/StreamChatTests/APIClient/CDNClient/StreamCDNRequester_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/CDNClient/StreamCDNRequester_Tests.swift
@@ -227,35 +227,6 @@ final class StreamCDNRequester_Tests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func test_imageRequest_cachingKey_isStableForSameResizeOptionsAcrossCalls() {
-        // ``StreamCDNRequester.buildImageURL`` previously assembled query
-        // items from a `[String: String]` dictionary whose iteration
-        // order is non-deterministic. This regressed the caching key
-        // across calls. Fan out a batch of requests with identical input
-        // and assert every caching key is identical.
-        let url = URL(string: "\(baseUrl)/image.jpg?Policy=A&Signature=B&Expires=1")!
-        let resize = CDNImageResize(width: 200, height: 150, resizeMode: "clip", crop: "center")
-
-        let callCount = 50
-        let group = expectation(description: "All completions")
-        group.expectedFulfillmentCount = callCount
-        let lock = NSLock()
-        var keys: [String] = []
-
-        for _ in 0..<callCount {
-            sut.imageRequest(for: url, options: .init(resize: resize)) { result in
-                let key = try! result.get().cachingKey!
-                lock.lock()
-                keys.append(key)
-                lock.unlock()
-                group.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 1)
-        XCTAssertEqual(Set(keys).count, 1, "Same input must always produce the same caching key, got: \(Set(keys))")
-    }
-
     // MARK: - File Request
 
     func test_fileRequest_returnsUnchangedURL() {

--- a/Tests/StreamChatTests/APIClient/CDNClient/StreamCDNRequester_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/CDNClient/StreamCDNRequester_Tests.swift
@@ -178,6 +178,84 @@ final class StreamCDNRequester_Tests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    func test_imageRequest_cachingKey_isStableAcrossQueryItemOrders() {
+        // Two URLs that describe the same image at the same size, but with
+        // the persisted resize parameters laid out in different orders.
+        // The caching key must collapse them onto the same value so the
+        // image cache hits regardless of upstream insertion order.
+        let url1 = URL(string: "\(baseUrl)/image.jpg?h=576&w=768&resize=clip")!
+        let url2 = URL(string: "\(baseUrl)/image.jpg?w=768&resize=clip&h=576")!
+        let url3 = URL(string: "\(baseUrl)/image.jpg?resize=clip&h=576&w=768")!
+
+        let expectations = (1...3).map { expectation(description: "Completion \($0)") }
+        var keys: [String?] = [nil, nil, nil]
+
+        sut.imageRequest(for: url1, options: .init()) { result in
+            keys[0] = try! result.get().cachingKey
+            expectations[0].fulfill()
+        }
+        sut.imageRequest(for: url2, options: .init()) { result in
+            keys[1] = try! result.get().cachingKey
+            expectations[1].fulfill()
+        }
+        sut.imageRequest(for: url3, options: .init()) { result in
+            keys[2] = try! result.get().cachingKey
+            expectations[2].fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(keys[0], keys[1])
+        XCTAssertEqual(keys[1], keys[2])
+    }
+
+    func test_imageRequest_cachingKey_paramsAreSortedAlphabetically() {
+        let url = URL(string: "\(baseUrl)/image.jpg?w=128&h=128&resize=crop&crop=center")!
+        let expectation = expectation(description: "Completion called")
+
+        sut.imageRequest(for: url, options: .init()) { result in
+            let key = try! result.get().cachingKey!
+            // Pull out the query portion of the caching key and verify
+            // that the persisted parameters are emitted in alphabetical
+            // order — guaranteeing a single canonical caching key per
+            // (image, size) pair.
+            let queryPart = key.components(separatedBy: "?").last ?? ""
+            let names = queryPart.split(separator: "&").map { $0.split(separator: "=").first.map(String.init) ?? "" }
+            XCTAssertEqual(names, ["crop", "h", "resize", "w"])
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_imageRequest_cachingKey_isStableForSameResizeOptionsAcrossCalls() {
+        // ``StreamCDNRequester.buildImageURL`` previously assembled query
+        // items from a `[String: String]` dictionary whose iteration
+        // order is non-deterministic. This regressed the caching key
+        // across calls. Fan out a batch of requests with identical input
+        // and assert every caching key is identical.
+        let url = URL(string: "\(baseUrl)/image.jpg?Policy=A&Signature=B&Expires=1")!
+        let resize = CDNImageResize(width: 200, height: 150, resizeMode: "clip", crop: "center")
+
+        let callCount = 50
+        let group = expectation(description: "All completions")
+        group.expectedFulfillmentCount = callCount
+        let lock = NSLock()
+        var keys: [String] = []
+
+        for _ in 0..<callCount {
+            sut.imageRequest(for: url, options: .init(resize: resize)) { result in
+                let key = try! result.get().cachingKey!
+                lock.lock()
+                keys.append(key)
+                lock.unlock()
+                group.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(Set(keys).count, 1, "Same input must always produce the same caching key, got: \(Set(keys))")
+    }
+
     // MARK: - File Request
 
     func test_fileRequest_returnsUnchangedURL() {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1652

Companion to the SwiftUI fix in [stream-chat-swiftui#1439](https://github.com/GetStream/stream-chat-swiftui/pull/1439). This PR addresses the underlying root cause that affected both the UIKit and SwiftUI SDKs.

### 🎯 Goal

`StreamCDNRequester` was producing different caching keys for the same image at the same size on different calls. Any UI surface that re-mounts an attachment in a fresh view tree (most visibly the SwiftUI reactions overlay, but the bug applied equally to the UIKit SDK and any other caller of `StreamCDNRequester`) would write the bitmap under one key and look it up under another, turning every re-render into a Nuke cache miss and showing a loading spinner over an already-cached image.

### 📝 Summary

- Sort the persisted resize parameters (`crop`, `h`, `resize`, `w`) inside `StreamCDNRequester.buildCachingKey` so the caching key collapses onto a single canonical value per `(image, size)` pair regardless of upstream insertion order.
- Add test coverage that locks in the stable ordering across query-item orders, repeated invocations, and explicit alphabetical sort.

### 🛠 Implementation

`StreamCDNRequester.buildImageURL` assembles the resize query items from a `[String: String]` dictionary literal:

```swift
var queryItems: [String: String] = [
    "w": ..., "h": ..., "resize": ..., "ro": "0"
]
for (key, value) in queryItems { items.append(...) }
```

Swift dictionaries do not preserve insertion order — the iteration order is hash-based and can vary between calls. The resulting `URLComponents.queryItems` therefore comes out in different orders on different calls, and `buildCachingKey` (which filters but preserves order) emits caching keys like `?h=576&resize=clip&w=768` for one call and `?h=576&w=768&resize=clip` for another. Same image, same size — different `String` values, so Nuke treats them as two different cache entries.

The minimal fix is to sort the persisted parameters alphabetically inside `buildCachingKey` before re-serialising the URL. That guarantees a single canonical caching key per `(image, size)` pair regardless of how the upstream URL was assembled, which also makes the function defensive against custom `CDNRequester` implementations and manually-constructed CDN URLs.

### 🧪 Manual Testing Notes

1. Open a channel that contains a message with an image attachment.
2. Long-press the message to open the reactions overlay.
3. The attachment should appear instantly with no loading spinner — previously, the spinner would flash on top of an already-cached image.
4. Repeat the open/close several times: the lookup should hit the memory cache every time.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image caching so cache keys are generated consistently, reducing redundant downloads and improving image load performance.

* **Tests**
  * Added tests to ensure cache key consistency across equivalent image URLs and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->