### PR TITLE
Fix mid-page jump breaking channel list preview and reopen flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix image cache misses caused by non-deterministic caching keys in `StreamCDNRequester` [#4075](https://github.com/GetStream/stream-chat-swift/pull/4075)
+- Fix `ChatChannel.latestMessages` being wiped on mid-page pagination [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
+- Fix stale messages briefly showing on channel reopen after a mid-page jump [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
 
 ### 🔄 Changed
+
+## StreamChatUI
+### 🐞 Fixed
+- Fix channel list preview showing "No messages" after a mid-page jump [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
 
 # [5.1.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.1.0)
 _April 23, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix image cache misses caused by non-deterministic caching keys in `StreamCDNRequester` [#4075](https://github.com/GetStream/stream-chat-swift/pull/4075)
 - Fix `ChatChannel.latestMessages` being wiped on mid-page pagination [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
-- Fix stale messages briefly showing on channel reopen after a mid-page jump [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
-
-### 🔄 Changed
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1882,14 +1882,6 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             }
         }
     }
-
-    deinit {
-        guard self.isJumpingToMessage, let cid = self.cid else { return }
-        dataStore.database.write { session in
-            let channelDTO = session.channel(cid: cid)
-            channelDTO?.cleanAllMessagesExcludingLocalOnly()
-        }
-    }
 }
 
 // MARK: - Environment

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1930,34 +1930,31 @@ private extension ChatChannelController {
         isInRecoveryMode: Bool,
         _ completion: (@MainActor (_ error: Error?) -> Void)? = nil
     ) {
-        updater.cleanStaleMidPageStateIfNeeded(
-            for: channelQuery,
-            isInRecoveryMode: isInRecoveryMode
-        ) { [weak self] in
-            guard let self else { return }
-            let channelCreatedCallback = self.isChannelAlreadyCreated ? nil : self.channelCreated(forwardErrorTo: self.setLocalStateBasedOnError)
-            self.updater.update(
-                channelQuery: self.channelQuery,
-                isInRecoveryMode: isInRecoveryMode,
-                onChannelCreated: channelCreatedCallback,
-                completion: { result in
-                    switch result {
-                    case .success:
-                        self.state = .remoteDataFetched
-                        self.callback { completion?(nil) }
-                    case let .failure(error):
-                        self.state = .remoteDataFetchFailed(ClientError(with: error))
-                        self.callback { completion?(error) }
-                    }
+        let channelCreatedCallback = isChannelAlreadyCreated ? nil : channelCreated(forwardErrorTo: setLocalStateBasedOnError)
+        // `update` performs any required stale mid-page cleanup synchronously before
+        // dispatching the network request, so observers we start below in parallel
+        // with the API call see a clean cache.
+        updater.update(
+            channelQuery: channelQuery,
+            isInRecoveryMode: isInRecoveryMode,
+            onChannelCreated: channelCreatedCallback,
+            completion: { result in
+                switch result {
+                case .success:
+                    self.state = .remoteDataFetched
+                    self.callback { completion?(nil) }
+                case let .failure(error):
+                    self.state = .remoteDataFetchFailed(ClientError(with: error))
+                    self.callback { completion?(error) }
                 }
-            )
-
-            /// Setup observers if we know the channel `cid` (if it's missing, it'll be set in `set(cid:)`
-            /// Otherwise they will be set up after channel creation, in `set(cid:)`.
-            if let cid = self.cid {
-                self.setupEventObservers(for: cid)
-                self.setLocalStateBasedOnError(self.startDatabaseObservers())
             }
+        )
+
+        /// Setup observers if we know the channel `cid` (if it's missing, it'll be set in `set(cid:)`
+        /// Otherwise they will be set up after channel creation, in `set(cid:)`.
+        if let cid = cid {
+            setupEventObservers(for: cid)
+            setLocalStateBasedOnError(startDatabaseObservers())
         }
     }
 

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1930,7 +1930,10 @@ private extension ChatChannelController {
         isInRecoveryMode: Bool,
         _ completion: (@MainActor (_ error: Error?) -> Void)? = nil
     ) {
-        clearStaleMidPageStateIfNeeded(isInRecoveryMode: isInRecoveryMode) { [weak self] in
+        updater.cleanStaleMidPageStateIfNeeded(
+            for: channelQuery,
+            isInRecoveryMode: isInRecoveryMode
+        ) { [weak self] in
             guard let self else { return }
             let channelCreatedCallback = self.isChannelAlreadyCreated ? nil : self.channelCreated(forwardErrorTo: self.setLocalStateBasedOnError)
             self.updater.update(
@@ -1956,55 +1959,6 @@ private extension ChatChannelController {
                 self.setLocalStateBasedOnError(self.startDatabaseObservers())
             }
         }
-    }
-
-    /// When the channel was last left in a mid-page state (the user jumped to a message and
-    /// navigated away before scrolling back to the bottom), the local cache still holds the
-    /// mid-page slice and the corresponding `oldestMessageAt`/`newestMessageAt` bounds.
-    ///
-    /// On a fresh first-page synchronize we want the message list to start empty and only get
-    /// populated by the incoming first-page response, instead of briefly rendering the stale
-    /// mid-page slice that the database observer would otherwise pick up. We achieve that by
-    /// dropping the cached messages and resetting the bounds before the observers start.
-    ///
-    /// The pre-check is performed synchronously so that the common path (no stale state) is
-    /// kept fully synchronous and consumers continue to observe the controller calling the
-    /// updater inline with `synchronize`.
-    func clearStaleMidPageStateIfNeeded(
-        isInRecoveryMode: Bool,
-        _ completion: @escaping @Sendable () -> Void
-    ) {
-        let isFirstPageFetch = channelQuery.pagination?.parameter == nil
-        guard !isInRecoveryMode,
-              isFirstPageFetch,
-              let cid = cid,
-              channelHasStaleMidPageState(cid: cid) else {
-            completion()
-            return
-        }
-
-        client.databaseContainer.write({ session in
-            guard let channelDTO = session.channel(cid: cid),
-                  channelDTO.newestMessageAt != nil else { return }
-            channelDTO.cleanAllMessagesExcludingLocalOnly()
-            channelDTO.oldestMessageAt = nil
-            channelDTO.newestMessageAt = nil
-        }, completion: { _ in
-            DispatchQueue.main.async { completion() }
-        })
-    }
-
-    /// Returns true when the channel cache has been left paginated to a mid-page (i.e. the user
-    /// jumped to a message and there are still newer messages on the server that haven't been
-    /// loaded). Read happens on the background read-only context so it is safe to call from any
-    /// thread.
-    func channelHasStaleMidPageState(cid: ChannelId) -> Bool {
-        let context = client.databaseContainer.backgroundReadOnlyContext
-        nonisolated(unsafe) var hasStaleMidPageState = false
-        context.performAndWait {
-            hasStaleMidPageState = context.channel(cid: cid)?.newestMessageAt != nil
-        }
-        return hasStaleMidPageState
     }
 
     /// Sets new cid of the query if necessary, and resets event and database observers.

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1926,30 +1926,85 @@ public enum MessageOrdering: Sendable {
 // MARK: - Helpers
 
 private extension ChatChannelController {
-    func synchronize(isInRecoveryMode: Bool, _ completion: (@MainActor (_ error: Error?) -> Void)? = nil) {
-        let channelCreatedCallback = isChannelAlreadyCreated ? nil : channelCreated(forwardErrorTo: setLocalStateBasedOnError)
-        updater.update(
-            channelQuery: channelQuery,
-            isInRecoveryMode: isInRecoveryMode,
-            onChannelCreated: channelCreatedCallback,
-            completion: { result in
-                switch result {
-                case .success:
-                    self.state = .remoteDataFetched
-                    self.callback { completion?(nil) }
-                case let .failure(error):
-                    self.state = .remoteDataFetchFailed(ClientError(with: error))
-                    self.callback { completion?(error) }
+    func synchronize(
+        isInRecoveryMode: Bool,
+        _ completion: (@MainActor (_ error: Error?) -> Void)? = nil
+    ) {
+        clearStaleMidPageStateIfNeeded(isInRecoveryMode: isInRecoveryMode) { [weak self] in
+            guard let self else { return }
+            let channelCreatedCallback = self.isChannelAlreadyCreated ? nil : self.channelCreated(forwardErrorTo: self.setLocalStateBasedOnError)
+            self.updater.update(
+                channelQuery: self.channelQuery,
+                isInRecoveryMode: isInRecoveryMode,
+                onChannelCreated: channelCreatedCallback,
+                completion: { result in
+                    switch result {
+                    case .success:
+                        self.state = .remoteDataFetched
+                        self.callback { completion?(nil) }
+                    case let .failure(error):
+                        self.state = .remoteDataFetchFailed(ClientError(with: error))
+                        self.callback { completion?(error) }
+                    }
                 }
-            }
-        )
+            )
 
-        /// Setup observers if we know the channel `cid` (if it's missing, it'll be set in `set(cid:)`
-        /// Otherwise they will be set up after channel creation, in `set(cid:)`.
-        if let cid = cid {
-            setupEventObservers(for: cid)
-            setLocalStateBasedOnError(startDatabaseObservers())
+            /// Setup observers if we know the channel `cid` (if it's missing, it'll be set in `set(cid:)`
+            /// Otherwise they will be set up after channel creation, in `set(cid:)`.
+            if let cid = self.cid {
+                self.setupEventObservers(for: cid)
+                self.setLocalStateBasedOnError(self.startDatabaseObservers())
+            }
         }
+    }
+
+    /// When the channel was last left in a mid-page state (the user jumped to a message and
+    /// navigated away before scrolling back to the bottom), the local cache still holds the
+    /// mid-page slice and the corresponding `oldestMessageAt`/`newestMessageAt` bounds.
+    ///
+    /// On a fresh first-page synchronize we want the message list to start empty and only get
+    /// populated by the incoming first-page response, instead of briefly rendering the stale
+    /// mid-page slice that the database observer would otherwise pick up. We achieve that by
+    /// dropping the cached messages and resetting the bounds before the observers start.
+    ///
+    /// The pre-check is performed synchronously so that the common path (no stale state) is
+    /// kept fully synchronous and consumers continue to observe the controller calling the
+    /// updater inline with `synchronize`.
+    func clearStaleMidPageStateIfNeeded(
+        isInRecoveryMode: Bool,
+        _ completion: @escaping @Sendable () -> Void
+    ) {
+        let isFirstPageFetch = channelQuery.pagination?.parameter == nil
+        guard !isInRecoveryMode,
+              isFirstPageFetch,
+              let cid = cid,
+              channelHasStaleMidPageState(cid: cid) else {
+            completion()
+            return
+        }
+
+        client.databaseContainer.write({ session in
+            guard let channelDTO = session.channel(cid: cid),
+                  channelDTO.newestMessageAt != nil else { return }
+            channelDTO.cleanAllMessagesExcludingLocalOnly()
+            channelDTO.oldestMessageAt = nil
+            channelDTO.newestMessageAt = nil
+        }, completion: { _ in
+            DispatchQueue.main.async { completion() }
+        })
+    }
+
+    /// Returns true when the channel cache has been left paginated to a mid-page (i.e. the user
+    /// jumped to a message and there are still newer messages on the server that haven't been
+    /// loaded). Read happens on the background read-only context so it is safe to call from any
+    /// thread.
+    func channelHasStaleMidPageState(cid: ChannelId) -> Bool {
+        let context = client.databaseContainer.backgroundReadOnlyContext
+        nonisolated(unsafe) var hasStaleMidPageState = false
+        context.performAndWait {
+            hasStaleMidPageState = context.channel(cid: cid)?.newestMessageAt != nil
+        }
+        return hasStaleMidPageState
     }
 
     /// Sets new cid of the query if necessary, and resets event and database observers.

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1931,9 +1931,6 @@ private extension ChatChannelController {
         _ completion: (@MainActor (_ error: Error?) -> Void)? = nil
     ) {
         let channelCreatedCallback = isChannelAlreadyCreated ? nil : channelCreated(forwardErrorTo: setLocalStateBasedOnError)
-        // `update` performs any required stale mid-page cleanup synchronously before
-        // dispatching the network request, so observers we start below in parallel
-        // with the API call see a clean cache.
         updater.update(
             channelQuery: channelQuery,
             isInRecoveryMode: isInRecoveryMode,

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -101,9 +101,17 @@ class ChannelDTO: NSManagedObject {
             }
         }
 
-        // Change to the `truncatedAt` value have effect on messages, we need to mark them dirty manually
-        // to triggers related FRC updates
-        if changedValues().keys.contains("truncatedAt") {
+        // Changes to `truncatedAt` or to the message-page bounds (`oldestMessageAt` /
+        // `newestMessageAt`) affect which linked messages belong to the channel's
+        // active page (see `MessageDTO.channelMessagesPredicate`). NSFetchedResultsController
+        // does not re-evaluate cached rows when only the parent ChannelDTO changes,
+        // so mark linked messages as dirty to nudge any active FRC into re-running
+        // its predicate against them.
+        let changedKeys = changedValues().keys
+        let pageBoundsDidChange = changedKeys.contains("truncatedAt")
+            || changedKeys.contains("oldestMessageAt")
+            || changedKeys.contains("newestMessageAt")
+        if pageBoundsDidChange {
             messages
                 .filter { !$0.hasChanges }
                 .forEach {
@@ -111,12 +119,12 @@ class ChannelDTO: NSManagedObject {
                     $0.willChangeValue(for: \.id)
                     $0.didChangeValue(for: \.id)
                 }
+        }
 
-            // When truncating the channel, we need to reset the newestMessageAt so that
-            // the channel can render newer messages in the UI.
-            if newestMessageAt != nil {
-                newestMessageAt = nil
-            }
+        // When truncating the channel, we need to reset the newestMessageAt so that
+        // the channel can render newer messages in the UI.
+        if changedKeys.contains("truncatedAt"), newestMessageAt != nil {
+            newestMessageAt = nil
         }
         
         // Update the date for sorting every time new message in this channel arrive.

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -83,6 +83,13 @@ public class Chat: @unchecked Sendable {
     /// - Throws: An error while communicating with the Stream API.
     public func get(watch: Bool) async throws {
         let query = await state.channelQuery.withOptions(forWatching: watch)
+        // Drop any stale mid-page slice and pagination bounds left over from a previous
+        // session before fetching the first page, so the database observers don't briefly
+        // emit the mid-page slice ahead of the API response.
+        await channelUpdater.cleanStaleMidPageStateIfNeeded(
+            for: query,
+            isInRecoveryMode: false
+        )
         let payload = try await channelUpdater.update(
             channelQuery: query,
             memberSorting: state.memberSorting

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -83,9 +83,6 @@ public class Chat: @unchecked Sendable {
     /// - Throws: An error while communicating with the Stream API.
     public func get(watch: Bool) async throws {
         let query = await state.channelQuery.withOptions(forWatching: watch)
-        // `update` performs any required stale mid-page cleanup synchronously before
-        // dispatching the request, so the message observer doesn't briefly emit the
-        // previous mid-page slice ahead of the API response.
         let payload = try await channelUpdater.update(
             channelQuery: query,
             memberSorting: state.memberSorting

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -83,13 +83,9 @@ public class Chat: @unchecked Sendable {
     /// - Throws: An error while communicating with the Stream API.
     public func get(watch: Bool) async throws {
         let query = await state.channelQuery.withOptions(forWatching: watch)
-        // Drop any stale mid-page slice and pagination bounds left over from a previous
-        // session before fetching the first page, so the database observers don't briefly
-        // emit the mid-page slice ahead of the API response.
-        await channelUpdater.cleanStaleMidPageStateIfNeeded(
-            for: query,
-            isInRecoveryMode: false
-        )
+        // `update` performs any required stale mid-page cleanup synchronously before
+        // dispatching the request, so the message observer doesn't briefly emit the
+        // previous mid-page slice ahead of the API response.
         let payload = try await channelUpdater.update(
             channelQuery: query,
             memberSorting: state.memberSorting

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -88,28 +88,8 @@ class ChannelUpdater: Worker, @unchecked Sendable {
                     }
 
                     let updatedChannel = try session.saveChannel(payload: payload)
-                    let previousOldestMessageAt = updatedChannel.oldestMessageAt?.bridgeDate
-                    let previousNewestMessageAt = updatedChannel.newestMessageAt?.bridgeDate
-                    let newOldestMessageAt = self.paginationState.oldestMessageAt
-                    let newNewestMessageAt = self.paginationState.newestMessageAt
-                    updatedChannel.oldestMessageAt = newOldestMessageAt?.bridgeDate
-                    updatedChannel.newestMessageAt = newNewestMessageAt?.bridgeDate
-
-                    // The message-page bounds (`oldestMessageAt` / `newestMessageAt`) live on
-                    // `ChannelDTO`, but message observers fetch `MessageDTO` rows whose predicate
-                    // references those parent properties. `NSFetchedResultsController` does not
-                    // re-evaluate cached rows when only the parent changes, so older messages
-                    // can leak into the observed page after a mid-page jump shrinks the bounds.
-                    // Touching each linked message after a bounds change nudges Core Data into
-                    // emitting an `updated` event, which forces the predicate to be re-tested.
-                    let boundsChanged = previousOldestMessageAt != newOldestMessageAt
-                        || previousNewestMessageAt != newNewestMessageAt
-                    if boundsChanged {
-                        for messageDTO in updatedChannel.messages {
-                            messageDTO.willChangeValue(forKey: #keyPath(MessageDTO.createdAt))
-                            messageDTO.didChangeValue(forKey: #keyPath(MessageDTO.createdAt))
-                        }
-                    }
+                    updatedChannel.oldestMessageAt = self.paginationState.oldestMessageAt?.bridgeDate
+                    updatedChannel.newestMessageAt = self.paginationState.newestMessageAt?.bridgeDate
 
                     // Share member data with member list query without any filters (requres ChannelDTO to be saved first)
                     let memberListQueryDTO: ChannelMemberListQueryDTO = try {

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -847,13 +847,10 @@ class ChannelUpdater: Worker, @unchecked Sendable {
     /// mid-page slice that the database observers would otherwise pick up. We achieve that
     /// by dropping the cached messages and resetting the bounds before the observers fire.
     ///
-    /// The pre-check (`channelHasStaleMidPageState`) reads from the background read-only
-    /// context, so the no-op common path is fast and never touches the writable context.
-    /// When stale state is detected, the cleanup runs synchronously on the writable context
-    /// so that observers started by the caller in parallel with `update` see a clean cache.
-    ///
-    /// Marked internal (not private) so the cleanup behavior can be unit-tested directly
-    /// without driving a full `update` round-trip.
+    /// The cleanup runs synchronously on the writable context so that observers started by the
+    /// caller in parallel with `update` see a clean cache. The closure short-circuits when the
+    /// channel is not in a mid-page state, so the common path is a single uncontested
+    /// `performAndWait` followed by an early return.
     private func cleanStaleMidPageStateIfNeeded(
         for channelQuery: ChannelQuery,
         isInRecoveryMode: Bool
@@ -861,8 +858,7 @@ class ChannelUpdater: Worker, @unchecked Sendable {
         let isFirstPageFetch = channelQuery.pagination?.parameter == nil
         guard !isInRecoveryMode,
               isFirstPageFetch,
-              let cid = channelQuery.cid,
-              channelHasStaleMidPageState(cid: cid) else {
+              let cid = channelQuery.cid else {
             return
         }
 
@@ -882,19 +878,6 @@ class ChannelUpdater: Worker, @unchecked Sendable {
                 writableContext.reset()
             }
         }
-    }
-
-    /// Returns true when the channel cache has been left paginated to a mid-page (i.e. the user
-    /// jumped to a message and there are still newer messages on the server that haven't been
-    /// loaded). Read happens on the background read-only context so it is safe to call from any
-    /// thread.
-    private func channelHasStaleMidPageState(cid: ChannelId) -> Bool {
-        let context = database.backgroundReadOnlyContext
-        nonisolated(unsafe) var hasStaleMidPageState = false
-        context.performAndWait {
-            hasStaleMidPageState = context.channel(cid: cid)?.newestMessageAt != nil
-        }
-        return hasStaleMidPageState
     }
 }
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -51,9 +51,8 @@ class ChannelUpdater: Worker, @unchecked Sendable {
         paginationStateHandler.begin(pagination: pagination)
 
         let didLoadFirstPage = channelQuery.pagination?.parameter == nil
-        let didJumpToMessage: Bool = channelQuery.pagination?.parameter?.isJumpingToMessage == true
         let resetMembersAndReads = didLoadFirstPage
-        let resetMessages = didLoadFirstPage || didJumpToMessage
+        let resetMessages = didLoadFirstPage
         let resetWatchers = didLoadFirstPage
         let isChannelCreate = onChannelCreated != nil
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -127,65 +127,6 @@ class ChannelUpdater: Worker, @unchecked Sendable {
         }
     }
 
-    /// When the channel was last left in a mid-page state (the user jumped to a message and
-    /// navigated away before scrolling back to the bottom), the local cache still holds the
-    /// mid-page slice and the corresponding `oldestMessageAt`/`newestMessageAt` bounds.
-    ///
-    /// On a fresh first-page fetch we want the message list to start empty and only get
-    /// populated by the incoming first-page response, instead of briefly rendering the stale
-    /// mid-page slice that the database observers would otherwise pick up. We achieve that
-    /// by dropping the cached messages and resetting the bounds before the observers fire.
-    ///
-    /// The pre-check (`channelHasStaleMidPageState`) reads from the background read-only
-    /// context, so the no-op common path is fast and never touches the writable context.
-    /// When stale state is detected, the cleanup runs synchronously on the writable context
-    /// so that observers started by the caller in parallel with `update` see a clean cache.
-    ///
-    /// Marked internal (not private) so the cleanup behavior can be unit-tested directly
-    /// without driving a full `update` round-trip.
-    func cleanStaleMidPageStateIfNeeded(
-        for channelQuery: ChannelQuery,
-        isInRecoveryMode: Bool
-    ) {
-        let isFirstPageFetch = channelQuery.pagination?.parameter == nil
-        guard !isInRecoveryMode,
-              isFirstPageFetch,
-              let cid = channelQuery.cid,
-              channelHasStaleMidPageState(cid: cid) else {
-            return
-        }
-
-        let writableContext = database.writableContext
-        writableContext.performAndWait {
-            guard let channelDTO = writableContext.channel(cid: cid),
-                  channelDTO.newestMessageAt != nil else { return }
-            channelDTO.cleanAllMessagesExcludingLocalOnly()
-            channelDTO.oldestMessageAt = nil
-            channelDTO.newestMessageAt = nil
-            do {
-                if writableContext.hasChanges {
-                    try writableContext.save()
-                }
-            } catch {
-                log.error("Failed to clean stale mid-page state: \(error)", subsystems: .database)
-                writableContext.reset()
-            }
-        }
-    }
-
-    /// Returns true when the channel cache has been left paginated to a mid-page (i.e. the user
-    /// jumped to a message and there are still newer messages on the server that haven't been
-    /// loaded). Read happens on the background read-only context so it is safe to call from any
-    /// thread.
-    private func channelHasStaleMidPageState(cid: ChannelId) -> Bool {
-        let context = database.backgroundReadOnlyContext
-        nonisolated(unsafe) var hasStaleMidPageState = false
-        context.performAndWait {
-            hasStaleMidPageState = context.channel(cid: cid)?.newestMessageAt != nil
-        }
-        return hasStaleMidPageState
-    }
-
     /// Updates specific channel with new data.
     /// - Parameters:
     ///   - channelPayload: New channel data.
@@ -387,21 +328,6 @@ class ChannelUpdater: Worker, @unchecked Sendable {
                 requestBody: requestBody,
                 completion: completion
             )
-        }
-    }
-
-    private func truncate(
-        cid: ChannelId,
-        skipPush: Bool = false,
-        hardDelete: Bool = true,
-        requestBody: MessageRequestBody? = nil,
-        completion: (@Sendable (Error?) -> Void)? = nil
-    ) {
-        apiClient.request(endpoint: .truncateChannel(cid: cid, skipPush: skipPush, hardDelete: hardDelete, message: requestBody)) {
-            if let error = $0.error {
-                log.error(error)
-            }
-            completion?($0.error)
         }
     }
 
@@ -876,6 +802,21 @@ class ChannelUpdater: Worker, @unchecked Sendable {
 
     // MARK: - private
 
+    private func truncate(
+        cid: ChannelId,
+        skipPush: Bool = false,
+        hardDelete: Bool = true,
+        requestBody: MessageRequestBody? = nil,
+        completion: (@Sendable (Error?) -> Void)? = nil
+    ) {
+        apiClient.request(endpoint: .truncateChannel(cid: cid, skipPush: skipPush, hardDelete: hardDelete, message: requestBody)) {
+            if let error = $0.error {
+                log.error(error)
+            }
+            completion?($0.error)
+        }
+    }
+
     private func messagePayload(text: String?, currentUserId: UserId?) -> MessageRequestBody? {
         var messagePayload: MessageRequestBody?
         if let text = text, let currentUserId = currentUserId {
@@ -895,6 +836,65 @@ class ChannelUpdater: Worker, @unchecked Sendable {
             return messagePayload
         }
         return nil
+    }
+
+    /// When the channel was last left in a mid-page state (the user jumped to a message and
+    /// navigated away before scrolling back to the bottom), the local cache still holds the
+    /// mid-page slice and the corresponding `oldestMessageAt`/`newestMessageAt` bounds.
+    ///
+    /// On a fresh first-page fetch we want the message list to start empty and only get
+    /// populated by the incoming first-page response, instead of briefly rendering the stale
+    /// mid-page slice that the database observers would otherwise pick up. We achieve that
+    /// by dropping the cached messages and resetting the bounds before the observers fire.
+    ///
+    /// The pre-check (`channelHasStaleMidPageState`) reads from the background read-only
+    /// context, so the no-op common path is fast and never touches the writable context.
+    /// When stale state is detected, the cleanup runs synchronously on the writable context
+    /// so that observers started by the caller in parallel with `update` see a clean cache.
+    ///
+    /// Marked internal (not private) so the cleanup behavior can be unit-tested directly
+    /// without driving a full `update` round-trip.
+    private func cleanStaleMidPageStateIfNeeded(
+        for channelQuery: ChannelQuery,
+        isInRecoveryMode: Bool
+    ) {
+        let isFirstPageFetch = channelQuery.pagination?.parameter == nil
+        guard !isInRecoveryMode,
+              isFirstPageFetch,
+              let cid = channelQuery.cid,
+              channelHasStaleMidPageState(cid: cid) else {
+            return
+        }
+
+        let writableContext = database.writableContext
+        writableContext.performAndWait {
+            guard let channelDTO = writableContext.channel(cid: cid),
+                  channelDTO.newestMessageAt != nil else { return }
+            channelDTO.cleanAllMessagesExcludingLocalOnly()
+            channelDTO.oldestMessageAt = nil
+            channelDTO.newestMessageAt = nil
+            do {
+                if writableContext.hasChanges {
+                    try writableContext.save()
+                }
+            } catch {
+                log.error("Failed to clean stale mid-page state: \(error)", subsystems: .database)
+                writableContext.reset()
+            }
+        }
+    }
+
+    /// Returns true when the channel cache has been left paginated to a mid-page (i.e. the user
+    /// jumped to a message and there are still newer messages on the server that haven't been
+    /// loaded). Read happens on the background read-only context so it is safe to call from any
+    /// thread.
+    private func channelHasStaleMidPageState(cid: ChannelId) -> Bool {
+        let context = database.backgroundReadOnlyContext
+        nonisolated(unsafe) var hasStaleMidPageState = false
+        context.performAndWait {
+            hasStaleMidPageState = context.channel(cid: cid)?.newestMessageAt != nil
+        }
+        return hasStaleMidPageState
     }
 }
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -121,6 +121,76 @@ class ChannelUpdater: Worker, @unchecked Sendable {
         }
     }
 
+    /// When the channel was last left in a mid-page state (the user jumped to a message and
+    /// navigated away before scrolling back to the bottom), the local cache still holds the
+    /// mid-page slice and the corresponding `oldestMessageAt`/`newestMessageAt` bounds.
+    ///
+    /// On a fresh first-page fetch we want the message list to start empty and only get
+    /// populated by the incoming first-page response, instead of briefly rendering the stale
+    /// mid-page slice that the database observers would otherwise pick up. We achieve that
+    /// by dropping the cached messages and resetting the bounds before the observers fire.
+    ///
+    /// The pre-check is performed synchronously (cheap DB read) so that the common path —
+    /// no stale state — stays fully synchronous and consumers can keep calling the updater
+    /// inline with `synchronize` / `get`.
+    ///
+    /// Caller responsibility:
+    /// - Only call when about to issue a fresh first-page request (i.e. `channelQuery.pagination?.parameter == nil`).
+    /// - Skip in recovery mode: the recovery flow re-fetches state with different semantics
+    ///   and shouldn't disturb the local cache.
+    func cleanStaleMidPageStateIfNeeded(
+        for channelQuery: ChannelQuery,
+        isInRecoveryMode: Bool,
+        completion: @escaping @Sendable () -> Void
+    ) {
+        let isFirstPageFetch = channelQuery.pagination?.parameter == nil
+        guard !isInRecoveryMode,
+              isFirstPageFetch,
+              let cid = channelQuery.cid,
+              channelHasStaleMidPageState(cid: cid) else {
+            completion()
+            return
+        }
+
+        database.write({ session in
+            guard let channelDTO = session.channel(cid: cid),
+                  channelDTO.newestMessageAt != nil else { return }
+            channelDTO.cleanAllMessagesExcludingLocalOnly()
+            channelDTO.oldestMessageAt = nil
+            channelDTO.newestMessageAt = nil
+        }, completion: { _ in
+            DispatchQueue.main.async { completion() }
+        })
+    }
+
+    /// Async variant of ``cleanStaleMidPageStateIfNeeded(for:isInRecoveryMode:completion:)``.
+    func cleanStaleMidPageStateIfNeeded(
+        for channelQuery: ChannelQuery,
+        isInRecoveryMode: Bool
+    ) async {
+        await withCheckedContinuation { continuation in
+            cleanStaleMidPageStateIfNeeded(
+                for: channelQuery,
+                isInRecoveryMode: isInRecoveryMode
+            ) {
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Returns true when the channel cache has been left paginated to a mid-page (i.e. the user
+    /// jumped to a message and there are still newer messages on the server that haven't been
+    /// loaded). Read happens on the background read-only context so it is safe to call from any
+    /// thread.
+    private func channelHasStaleMidPageState(cid: ChannelId) -> Bool {
+        let context = database.backgroundReadOnlyContext
+        nonisolated(unsafe) var hasStaleMidPageState = false
+        context.performAndWait {
+            hasStaleMidPageState = context.channel(cid: cid)?.newestMessageAt != nil
+        }
+        return hasStaleMidPageState
+    }
+
     /// Updates specific channel with new data.
     /// - Parameters:
     ///   - channelPayload: New channel data.

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -88,8 +88,28 @@ class ChannelUpdater: Worker, @unchecked Sendable {
                     }
 
                     let updatedChannel = try session.saveChannel(payload: payload)
-                    updatedChannel.oldestMessageAt = self.paginationState.oldestMessageAt?.bridgeDate
-                    updatedChannel.newestMessageAt = self.paginationState.newestMessageAt?.bridgeDate
+                    let previousOldestMessageAt = updatedChannel.oldestMessageAt?.bridgeDate
+                    let previousNewestMessageAt = updatedChannel.newestMessageAt?.bridgeDate
+                    let newOldestMessageAt = self.paginationState.oldestMessageAt
+                    let newNewestMessageAt = self.paginationState.newestMessageAt
+                    updatedChannel.oldestMessageAt = newOldestMessageAt?.bridgeDate
+                    updatedChannel.newestMessageAt = newNewestMessageAt?.bridgeDate
+
+                    // The message-page bounds (`oldestMessageAt` / `newestMessageAt`) live on
+                    // `ChannelDTO`, but message observers fetch `MessageDTO` rows whose predicate
+                    // references those parent properties. `NSFetchedResultsController` does not
+                    // re-evaluate cached rows when only the parent changes, so older messages
+                    // can leak into the observed page after a mid-page jump shrinks the bounds.
+                    // Touching each linked message after a bounds change nudges Core Data into
+                    // emitting an `updated` event, which forces the predicate to be re-tested.
+                    let boundsChanged = previousOldestMessageAt != newOldestMessageAt
+                        || previousNewestMessageAt != newNewestMessageAt
+                    if boundsChanged {
+                        for messageDTO in updatedChannel.messages {
+                            messageDTO.willChangeValue(forKey: #keyPath(MessageDTO.createdAt))
+                            messageDTO.didChangeValue(forKey: #keyPath(MessageDTO.createdAt))
+                        }
+                    }
 
                     // Share member data with member list query without any filters (requres ChannelDTO to be saved first)
                     let memberListQueryDTO: ChannelMemberListQueryDTO = try {

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -47,6 +47,12 @@ class ChannelUpdater: Worker, @unchecked Sendable {
         actions: ChannelUpdateActions? = nil,
         completion: (@Sendable (Result<ChannelPayload, Error>) -> Void)? = nil
     ) {
+        // Drop any stale mid-page slice (and its bounds) synchronously before issuing
+        // the request, so any database observers the caller starts in parallel with
+        // `update` see a clean cache rather than briefly emitting the previous
+        // mid-page snapshot.
+        cleanStaleMidPageStateIfNeeded(for: channelQuery, isInRecoveryMode: isInRecoveryMode)
+
         let pagination = channelQuery.pagination
         paginationStateHandler.begin(pagination: pagination)
 
@@ -130,50 +136,39 @@ class ChannelUpdater: Worker, @unchecked Sendable {
     /// mid-page slice that the database observers would otherwise pick up. We achieve that
     /// by dropping the cached messages and resetting the bounds before the observers fire.
     ///
-    /// The pre-check is performed synchronously (cheap DB read) so that the common path —
-    /// no stale state — stays fully synchronous and consumers can keep calling the updater
-    /// inline with `synchronize` / `get`.
+    /// The pre-check (`channelHasStaleMidPageState`) reads from the background read-only
+    /// context, so the no-op common path is fast and never touches the writable context.
+    /// When stale state is detected, the cleanup runs synchronously on the writable context
+    /// so that observers started by the caller in parallel with `update` see a clean cache.
     ///
-    /// Caller responsibility:
-    /// - Only call when about to issue a fresh first-page request (i.e. `channelQuery.pagination?.parameter == nil`).
-    /// - Skip in recovery mode: the recovery flow re-fetches state with different semantics
-    ///   and shouldn't disturb the local cache.
+    /// Marked internal (not private) so the cleanup behavior can be unit-tested directly
+    /// without driving a full `update` round-trip.
     func cleanStaleMidPageStateIfNeeded(
         for channelQuery: ChannelQuery,
-        isInRecoveryMode: Bool,
-        completion: @escaping @Sendable () -> Void
+        isInRecoveryMode: Bool
     ) {
         let isFirstPageFetch = channelQuery.pagination?.parameter == nil
         guard !isInRecoveryMode,
               isFirstPageFetch,
               let cid = channelQuery.cid,
               channelHasStaleMidPageState(cid: cid) else {
-            completion()
             return
         }
 
-        database.write({ session in
-            guard let channelDTO = session.channel(cid: cid),
+        let writableContext = database.writableContext
+        writableContext.performAndWait {
+            guard let channelDTO = writableContext.channel(cid: cid),
                   channelDTO.newestMessageAt != nil else { return }
             channelDTO.cleanAllMessagesExcludingLocalOnly()
             channelDTO.oldestMessageAt = nil
             channelDTO.newestMessageAt = nil
-        }, completion: { _ in
-            DispatchQueue.main.async { completion() }
-        })
-    }
-
-    /// Async variant of ``cleanStaleMidPageStateIfNeeded(for:isInRecoveryMode:completion:)``.
-    func cleanStaleMidPageStateIfNeeded(
-        for channelQuery: ChannelQuery,
-        isInRecoveryMode: Bool
-    ) async {
-        await withCheckedContinuation { continuation in
-            cleanStaleMidPageStateIfNeeded(
-                for: channelQuery,
-                isInRecoveryMode: isInRecoveryMode
-            ) {
-                continuation.resume()
+            do {
+                if writableContext.hasChanges {
+                    try writableContext.save()
+                }
+            } catch {
+                log.error("Failed to clean stale mid-page state: \(error)", subsystems: .database)
+                writableContext.reset()
             }
         }
     }

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -752,6 +752,54 @@ final class ChannelController_Tests: XCTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
 
+    func test_synchronize_whenChannelLeftInMidPageState_clearsLocalCacheBeforeFetching() throws {
+        // GIVEN: A channel that was previously left in a mid-page state, so the local
+        // cache contains the mid-page slice and non-nil pagination bounds.
+        try client.databaseContainer.writeSynchronously { session in
+            let payload = self.dummyPayload(with: self.channelId, numberOfMessages: 5)
+            let channelDTO = try session.saveChannel(payload: payload)
+            channelDTO.oldestMessageAt = .init(timeIntervalSinceNow: -200)
+            channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
+        }
+
+        try client.databaseContainer.readSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: self.channelId))
+            XCTAssertEqual(dto.messages.count, 5)
+            XCTAssertNotNil(dto.newestMessageAt)
+        }
+
+        // WHEN: synchronize is called for a fresh first-page load
+        controller.synchronize()
+
+        // THEN: cached messages and bounds are cleared so the database observers
+        // don't briefly emit the stale mid-page slice before the API responds.
+        AssertAsync {
+            Assert.willBeEqual(self.client.databaseContainer.viewContext.channel(cid: self.channelId)?.messages.count, 0)
+            Assert.willBeNil(self.client.databaseContainer.viewContext.channel(cid: self.channelId)?.newestMessageAt)
+            Assert.willBeNil(self.client.databaseContainer.viewContext.channel(cid: self.channelId)?.oldestMessageAt)
+        }
+    }
+
+    func test_synchronize_whenChannelNotInMidPageState_keepsLocalCache() throws {
+        // GIVEN: A channel with cached messages and no mid-page state.
+        try client.databaseContainer.writeSynchronously { session in
+            let payload = self.dummyPayload(with: self.channelId, numberOfMessages: 5)
+            let channelDTO = try session.saveChannel(payload: payload)
+            channelDTO.newestMessageAt = nil
+        }
+
+        // WHEN: synchronize is called
+        controller.synchronize()
+
+        // THEN: existing messages remain available so the message list can render
+        // them instantly while the API call is in flight.
+        XCTAssertEqual(env.channelUpdater?.update_callCount, 1)
+        try client.databaseContainer.readSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: self.channelId))
+            XCTAssertEqual(dto.messages.count, 5)
+        }
+    }
+
     // MARK: - Creating `ChannelController` tests
 
     func test_channelControllerForNewChannel_createdCorrectly() throws {

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -5318,7 +5318,7 @@ final class ChannelController_Tests: XCTestCase {
 
     // MARK: deinit
 
-    func test_deinit_whenIsJumpingToMessage_deletesAllMessages() throws {
+    func test_deinit_whenIsJumpingToMessage_doesNotDeleteAnyMessage() throws {
         // GIVEN
         controller = ChatChannelController(
             channelQuery: .init(cid: channelId),
@@ -5338,24 +5338,19 @@ final class ChannelController_Tests: XCTestCase {
             let dto = try XCTUnwrap(session.channel(cid: self.channelId))
             XCTAssertEqual(dto.messages.count, messages.count)
         }
-        
-        let deinitWriteExpectation = XCTestExpectation(description: "Deinit")
-        client.mockDatabaseContainer.didWrite = {
-            deinitWriteExpectation.fulfill()
-        }
-        
+
         // WHEN
+        // Mid-page jump state must not wipe the cache on deinit, otherwise
+        // `channel.latestMessages` (used for the channel list preview) would be lost.
         env.channelUpdater?.mockPaginationState.hasLoadedAllNextMessages = false
 
         // THEN
         env.channelUpdater?.cleanUp()
         controller = nil
-        
-        wait(for: [deinitWriteExpectation], timeout: defaultTimeout)
-        
+
         try client.mockDatabaseContainer.readSynchronously { session in
             let dto = try XCTUnwrap(session.channel(cid: self.channelId))
-            XCTAssertEqual(0, dto.messages.count)
+            XCTAssertEqual(messages.count, dto.messages.count)
         }
     }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -752,54 +752,6 @@ final class ChannelController_Tests: XCTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
 
-    func test_synchronize_whenChannelLeftInMidPageState_clearsLocalCacheBeforeFetching() throws {
-        // GIVEN: A channel that was previously left in a mid-page state, so the local
-        // cache contains the mid-page slice and non-nil pagination bounds.
-        try client.databaseContainer.writeSynchronously { session in
-            let payload = self.dummyPayload(with: self.channelId, numberOfMessages: 5)
-            let channelDTO = try session.saveChannel(payload: payload)
-            channelDTO.oldestMessageAt = .init(timeIntervalSinceNow: -200)
-            channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
-        }
-
-        try client.databaseContainer.readSynchronously { session in
-            let dto = try XCTUnwrap(session.channel(cid: self.channelId))
-            XCTAssertEqual(dto.messages.count, 5)
-            XCTAssertNotNil(dto.newestMessageAt)
-        }
-
-        // WHEN: synchronize is called for a fresh first-page load
-        controller.synchronize()
-
-        // THEN: cached messages and bounds are cleared so the database observers
-        // don't briefly emit the stale mid-page slice before the API responds.
-        AssertAsync {
-            Assert.willBeEqual(self.client.databaseContainer.viewContext.channel(cid: self.channelId)?.messages.count, 0)
-            Assert.willBeNil(self.client.databaseContainer.viewContext.channel(cid: self.channelId)?.newestMessageAt)
-            Assert.willBeNil(self.client.databaseContainer.viewContext.channel(cid: self.channelId)?.oldestMessageAt)
-        }
-    }
-
-    func test_synchronize_whenChannelNotInMidPageState_keepsLocalCache() throws {
-        // GIVEN: A channel with cached messages and no mid-page state.
-        try client.databaseContainer.writeSynchronously { session in
-            let payload = self.dummyPayload(with: self.channelId, numberOfMessages: 5)
-            let channelDTO = try session.saveChannel(payload: payload)
-            channelDTO.newestMessageAt = nil
-        }
-
-        // WHEN: synchronize is called
-        controller.synchronize()
-
-        // THEN: existing messages remain available so the message list can render
-        // them instantly while the API call is in flight.
-        XCTAssertEqual(env.channelUpdater?.update_callCount, 1)
-        try client.databaseContainer.readSynchronously { session in
-            let dto = try XCTUnwrap(session.channel(cid: self.channelId))
-            XCTAssertEqual(dto.messages.count, 5)
-        }
-    }
-
     // MARK: - Creating `ChannelController` tests
 
     func test_channelControllerForNewChannel_createdCorrectly() throws {

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -690,18 +690,15 @@ final class ChannelUpdater_Tests: XCTestCase {
             channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
         }
 
-        let query = ChannelQuery(cid: cid)
+        // Sync helper — no completion to wait on.
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: ChannelQuery(cid: cid), isInRecoveryMode: false)
 
-        let expectation = self.expectation(description: "Cleanup completes")
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false) {
-            expectation.fulfill()
+        try database.readSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: cid))
+            XCTAssertEqual(dto.messages.count, 0)
+            XCTAssertNil(dto.oldestMessageAt)
+            XCTAssertNil(dto.newestMessageAt)
         }
-        waitForExpectations(timeout: defaultTimeout)
-
-        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
-        XCTAssertEqual(channel.messages.count, 0)
-        XCTAssertNil(channel.oldestMessageAt)
-        XCTAssertNil(channel.newestMessageAt)
     }
 
     func test_cleanStaleMidPageStateIfNeeded_whenChannelHasNoStaleMidPageState_skipsCleanup() throws {
@@ -712,16 +709,12 @@ final class ChannelUpdater_Tests: XCTestCase {
             channelDTO.newestMessageAt = nil
         }
 
-        let query = ChannelQuery(cid: cid)
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: ChannelQuery(cid: cid), isInRecoveryMode: false)
 
-        let expectation = self.expectation(description: "Cleanup completes")
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false) {
-            expectation.fulfill()
+        try database.readSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: cid))
+            XCTAssertEqual(dto.messages.count, 5)
         }
-        waitForExpectations(timeout: defaultTimeout)
-
-        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
-        XCTAssertEqual(channel.messages.count, 5)
     }
 
     func test_cleanStaleMidPageStateIfNeeded_whenInRecoveryMode_skipsCleanup() throws {
@@ -732,17 +725,13 @@ final class ChannelUpdater_Tests: XCTestCase {
             channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
         }
 
-        let query = ChannelQuery(cid: cid)
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: ChannelQuery(cid: cid), isInRecoveryMode: true)
 
-        let expectation = self.expectation(description: "Cleanup completes")
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: true) {
-            expectation.fulfill()
+        try database.readSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: cid))
+            XCTAssertEqual(dto.messages.count, 5)
+            XCTAssertNotNil(dto.newestMessageAt)
         }
-        waitForExpectations(timeout: defaultTimeout)
-
-        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
-        XCTAssertEqual(channel.messages.count, 5)
-        XCTAssertNotNil(channel.newestMessageAt)
     }
 
     func test_cleanStaleMidPageStateIfNeeded_whenPaginationParameterIsSet_skipsCleanup() throws {
@@ -755,16 +744,13 @@ final class ChannelUpdater_Tests: XCTestCase {
 
         // A query with a pagination parameter is NOT a fresh first-page fetch.
         let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false)
 
-        let expectation = self.expectation(description: "Cleanup completes")
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false) {
-            expectation.fulfill()
+        try database.readSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: cid))
+            XCTAssertEqual(dto.messages.count, 5)
+            XCTAssertNotNil(dto.newestMessageAt)
         }
-        waitForExpectations(timeout: defaultTimeout)
-
-        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
-        XCTAssertEqual(channel.messages.count, 5)
-        XCTAssertNotNil(channel.newestMessageAt)
     }
 
     // MARK: - Messages

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -608,6 +608,94 @@ final class ChannelUpdater_Tests: XCTestCase {
         XCTAssertEqual(channel.messages.count, previousMessagesCount)
     }
 
+    // MARK: - cleanStaleMidPageStateIfNeeded
+
+    func test_cleanStaleMidPageStateIfNeeded_whenChannelHasStaleMidPageState_clearsCache() throws {
+        let cid = ChannelId(type: .messaging, id: .unique)
+        try database.writeSynchronously { session in
+            let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
+            let channelDTO = try session.saveChannel(payload: payload)
+            channelDTO.oldestMessageAt = .init(timeIntervalSinceNow: -200)
+            channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
+        }
+
+        let query = ChannelQuery(cid: cid)
+
+        let expectation = self.expectation(description: "Cleanup completes")
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
+
+        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
+        XCTAssertEqual(channel.messages.count, 0)
+        XCTAssertNil(channel.oldestMessageAt)
+        XCTAssertNil(channel.newestMessageAt)
+    }
+
+    func test_cleanStaleMidPageStateIfNeeded_whenChannelHasNoStaleMidPageState_skipsCleanup() throws {
+        let cid = ChannelId(type: .messaging, id: .unique)
+        try database.writeSynchronously { session in
+            let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
+            let channelDTO = try session.saveChannel(payload: payload)
+            channelDTO.newestMessageAt = nil
+        }
+
+        let query = ChannelQuery(cid: cid)
+
+        let expectation = self.expectation(description: "Cleanup completes")
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
+
+        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
+        XCTAssertEqual(channel.messages.count, 5)
+    }
+
+    func test_cleanStaleMidPageStateIfNeeded_whenInRecoveryMode_skipsCleanup() throws {
+        let cid = ChannelId(type: .messaging, id: .unique)
+        try database.writeSynchronously { session in
+            let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
+            let channelDTO = try session.saveChannel(payload: payload)
+            channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
+        }
+
+        let query = ChannelQuery(cid: cid)
+
+        let expectation = self.expectation(description: "Cleanup completes")
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: true) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
+
+        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
+        XCTAssertEqual(channel.messages.count, 5)
+        XCTAssertNotNil(channel.newestMessageAt)
+    }
+
+    func test_cleanStaleMidPageStateIfNeeded_whenPaginationParameterIsSet_skipsCleanup() throws {
+        let cid = ChannelId(type: .messaging, id: .unique)
+        try database.writeSynchronously { session in
+            let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
+            let channelDTO = try session.saveChannel(payload: payload)
+            channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
+        }
+
+        // A query with a pagination parameter is NOT a fresh first-page fetch.
+        let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))
+
+        let expectation = self.expectation(description: "Cleanup completes")
+        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
+
+        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
+        XCTAssertEqual(channel.messages.count, 5)
+        XCTAssertNotNil(channel.newestMessageAt)
+    }
+
     // MARK: - Messages
 
     func test_createNewMessage() throws {

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -580,8 +580,8 @@ final class ChannelUpdater_Tests: XCTestCase {
         )
         // The channel preview must still surface the actually latest messages,
         // not the mid-page slice that the active controller is paginating.
-        XCTAssertEqual(channel.latestMessages.first?.id, "latest-0")
-        XCTAssertTrue(channel.latestMessages.allSatisfy { $0.id.hasPrefix("latest-") })
+        let expectedLatestIds = (0..<channel.latestMessages.count).map { "latest-\($0)" }
+        XCTAssertEqual(channel.latestMessages.map(\.id), expectedLatestIds)
     }
 
     func test_updateChannelQuery_whenIsJumpingToMessage_thenMessageObserverDropsOutOfBoundsMessages() throws {

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -584,6 +584,77 @@ final class ChannelUpdater_Tests: XCTestCase {
         XCTAssertTrue(channel.latestMessages.allSatisfy { $0.id.hasPrefix("latest-") })
     }
 
+    func test_updateChannelQuery_whenIsJumpingToMessage_thenMessageObserverDropsOutOfBoundsMessages() throws {
+        let cid = ChannelId(type: .messaging, id: .unique)
+
+        // Cache the channel's newest 5 messages (the channel has been previously
+        // synchronized from the latest page). After the mid-page jump these will be
+        // newer than the new `newestMessageAt`, i.e. outside the active page.
+        let latestMessages: [MessagePayload] = (0..<5).map { offset in
+            .dummy(
+                messageId: "latest-\(offset)",
+                createdAt: Date().addingTimeInterval(-Double(offset))
+            )
+        }
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(
+                with: cid,
+                messages: latestMessages
+            ))
+        }
+
+        // Same observer the UIKit `ChatChannelController` and the state-layer `Chat`
+        // use for the active page. Wiring it here lets us assert the FRC actually
+        // drops out-of-bounds messages after a mid-page jump.
+        let observer = BackgroundListDatabaseObserver<ChatMessage, MessageDTO>(
+            database: database,
+            fetchRequest: MessageDTO.messagesFetchRequest(
+                for: cid,
+                pageSize: .messagesPageSize,
+                sortAscending: false,
+                shouldShowShadowedMessages: false
+            ),
+            itemCreator: { try $0.asModel() }
+        )
+        try observer.startObserving()
+        AssertAsync.willBeEqual(observer.items.count, 5)
+
+        // Simulate a mid-page jump that lands on messages much older than the cached
+        // newest slice, so the new `(oldestMessageAt, newestMessageAt)` window does
+        // not contain any of the previously-cached messages.
+        let midPageBaseDate = Date().addingTimeInterval(-3600)
+        let midPageMessages: [MessagePayload] = (0..<5).map { offset in
+            .dummy(
+                messageId: "mid-\(offset)",
+                createdAt: midPageBaseDate.addingTimeInterval(-Double(offset))
+            )
+        }
+        // The mock pagination handler's `end` is a no-op; pre-set the state so the
+        // updater writes the mid-page bounds onto the channel.
+        paginationStateHandler.mockState.oldestFetchedMessage = midPageMessages.last
+        paginationStateHandler.mockState.newestFetchedMessage = midPageMessages.first
+
+        let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))
+        let expectation = self.expectation(description: "Update completes")
+        channelUpdater.update(channelQuery: query, isInRecoveryMode: false, completion: { _ in
+            expectation.fulfill()
+        })
+        apiClient.test_simulateResponse(.success(dummyPayload(with: cid, messages: midPageMessages)))
+        waitForExpectations(timeout: defaultTimeout)
+
+        // The cached newest 5 messages remain linked to the channel — that is what
+        // keeps `channel.latestMessages` correct for the channel-list preview.
+        let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
+        XCTAssertEqual(channelDTO.messages.count, latestMessages.count + midPageMessages.count)
+
+        // But the active-page observer must only see the mid-page slice. Without the
+        // bounds-change nudge in `ChannelUpdater.update`, the FRC would still hold the
+        // 5 previously-cached messages (FRC does not re-evaluate cached rows when
+        // only the parent channel's `oldestMessageAt`/`newestMessageAt` change).
+        AssertAsync.willBeEqual(observer.items.count, midPageMessages.count)
+        XCTAssertTrue(observer.items.allSatisfy { $0.id.hasPrefix("mid-") })
+    }
+
     func test_updateChannelQuery_whenIsJumpingToMessage_whenRequestFails_thenDoesNotDeleteMessages() throws {
         let cid = ChannelId(type: .messaging, id: .unique)
         let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -512,7 +512,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         XCTAssertEqual(channel?.messages.count, 4)
     }
 
-    func test_updateChannelQuery_whenIsJumpingToMessage_thenDeleteAllPreviousMessagesFromChannel() throws {
+    func test_updateChannelQuery_whenIsJumpingToMessage_thenPreservesPreviouslyCachedMessages() throws {
         let cid = ChannelId(type: .messaging, id: .unique)
         let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))
 
@@ -528,14 +528,60 @@ final class ChannelUpdater_Tests: XCTestCase {
             expectation.fulfill()
         })
 
-        let expectedMessagesCount = 5
-        let payload = dummyPayload(with: cid, numberOfMessages: expectedMessagesCount)
+        let midPageMessagesCount = 5
+        let payload = dummyPayload(with: cid, numberOfMessages: midPageMessagesCount)
         apiClient.test_simulateResponse(.success(payload))
 
         waitForExpectations(timeout: defaultTimeout)
 
         let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
-        XCTAssertEqual(channel.messages.count, expectedMessagesCount)
+        // Mid-page jump must not wipe the cached messages, otherwise the channel's
+        // `latestMessages` (used for the channel list preview) would be lost.
+        XCTAssertEqual(channel.messages.count, previousMessagesCount + midPageMessagesCount)
+    }
+
+    func test_updateChannelQuery_whenIsJumpingToMessage_thenChannelLatestMessagesArePreserved() throws {
+        let cid = ChannelId(type: .messaging, id: .unique)
+
+        // Start from the channel's actual newest 5 messages (newest is `latest-0`).
+        let latestMessages: [MessagePayload] = (0..<5).map { offset in
+            .dummy(
+                messageId: "latest-\(offset)",
+                createdAt: Date().addingTimeInterval(-Double(offset))
+            )
+        }
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(
+                with: cid,
+                messages: latestMessages
+            ))
+        }
+
+        // Jump to a mid-page far older than the cached messages.
+        let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))
+        let midPageBaseDate = Date().addingTimeInterval(-3600)
+        let midPageMessages: [MessagePayload] = (0..<5).map { offset in
+            .dummy(
+                messageId: "mid-\(offset)",
+                createdAt: midPageBaseDate.addingTimeInterval(-Double(offset))
+            )
+        }
+
+        let expectation = self.expectation(description: "Update completes")
+        channelUpdater.update(channelQuery: query, isInRecoveryMode: false, completion: { _ in
+            expectation.fulfill()
+        })
+        apiClient.test_simulateResponse(.success(dummyPayload(with: cid, messages: midPageMessages)))
+
+        waitForExpectations(timeout: defaultTimeout)
+
+        let channel = try XCTUnwrap(
+            try database.viewContext.channel(cid: cid)?.asModel()
+        )
+        // The channel preview must still surface the actually latest messages,
+        // not the mid-page slice that the active controller is paginating.
+        XCTAssertEqual(channel.latestMessages.first?.id, "latest-0")
+        XCTAssertTrue(channel.latestMessages.allSatisfy { $0.id.hasPrefix("latest-") })
     }
 
     func test_updateChannelQuery_whenIsJumpingToMessage_whenRequestFails_thenDoesNotDeleteMessages() throws {
@@ -554,14 +600,12 @@ final class ChannelUpdater_Tests: XCTestCase {
             expectation.fulfill()
         })
 
-        let expectedMessagesCount = previousMessagesCount
-        let payload = dummyPayload(with: cid, numberOfMessages: expectedMessagesCount)
-        apiClient.test_simulateResponse(.success(payload))
+        apiClient.test_simulateResponse(Result<ChannelPayload, Error>.failure(ClientError("fake")))
 
         waitForExpectations(timeout: defaultTimeout)
 
         let channel = try XCTUnwrap(database.viewContext.channel(cid: cid))
-        XCTAssertEqual(channel.messages.count, expectedMessagesCount)
+        XCTAssertEqual(channel.messages.count, previousMessagesCount)
     }
 
     // MARK: - Messages

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -679,9 +679,13 @@ final class ChannelUpdater_Tests: XCTestCase {
         XCTAssertEqual(channel.messages.count, previousMessagesCount)
     }
 
-    // MARK: - cleanStaleMidPageStateIfNeeded
+    // MARK: - Stale mid-page state cleanup
 
-    func test_cleanStaleMidPageStateIfNeeded_whenChannelHasStaleMidPageState_clearsCache() throws {
+    // Verified by driving the public `update(channelQuery:isInRecoveryMode:)` entry point: the
+    // cleanup runs synchronously at the top of `update` before the network request is dispatched
+    // to the API spy, so we can assert immediately after the call without simulating a response.
+
+    func test_updateChannelQuery_whenChannelHasStaleMidPageState_clearsCacheBeforeFetching() throws {
         let cid = ChannelId(type: .messaging, id: .unique)
         try database.writeSynchronously { session in
             let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
@@ -690,8 +694,7 @@ final class ChannelUpdater_Tests: XCTestCase {
             channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
         }
 
-        // Sync helper — no completion to wait on.
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: ChannelQuery(cid: cid), isInRecoveryMode: false)
+        channelUpdater.update(channelQuery: ChannelQuery(cid: cid), isInRecoveryMode: false)
 
         try database.readSynchronously { session in
             let dto = try XCTUnwrap(session.channel(cid: cid))
@@ -701,7 +704,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         }
     }
 
-    func test_cleanStaleMidPageStateIfNeeded_whenChannelHasNoStaleMidPageState_skipsCleanup() throws {
+    func test_updateChannelQuery_whenChannelHasNoStaleMidPageState_keepsLocalCache() throws {
         let cid = ChannelId(type: .messaging, id: .unique)
         try database.writeSynchronously { session in
             let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
@@ -709,7 +712,7 @@ final class ChannelUpdater_Tests: XCTestCase {
             channelDTO.newestMessageAt = nil
         }
 
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: ChannelQuery(cid: cid), isInRecoveryMode: false)
+        channelUpdater.update(channelQuery: ChannelQuery(cid: cid), isInRecoveryMode: false)
 
         try database.readSynchronously { session in
             let dto = try XCTUnwrap(session.channel(cid: cid))
@@ -717,7 +720,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         }
     }
 
-    func test_cleanStaleMidPageStateIfNeeded_whenInRecoveryMode_skipsCleanup() throws {
+    func test_updateChannelQuery_whenInRecoveryMode_keepsLocalCacheEvenIfMidPageStateIsStale() throws {
         let cid = ChannelId(type: .messaging, id: .unique)
         try database.writeSynchronously { session in
             let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
@@ -725,7 +728,7 @@ final class ChannelUpdater_Tests: XCTestCase {
             channelDTO.newestMessageAt = .init(timeIntervalSinceNow: -100)
         }
 
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: ChannelQuery(cid: cid), isInRecoveryMode: true)
+        channelUpdater.update(channelQuery: ChannelQuery(cid: cid), isInRecoveryMode: true)
 
         try database.readSynchronously { session in
             let dto = try XCTUnwrap(session.channel(cid: cid))
@@ -734,7 +737,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         }
     }
 
-    func test_cleanStaleMidPageStateIfNeeded_whenPaginationParameterIsSet_skipsCleanup() throws {
+    func test_updateChannelQuery_whenPaginationParameterIsSet_keepsLocalCacheEvenIfMidPageStateIsStale() throws {
         let cid = ChannelId(type: .messaging, id: .unique)
         try database.writeSynchronously { session in
             let payload = self.dummyPayload(with: cid, numberOfMessages: 5)
@@ -744,7 +747,7 @@ final class ChannelUpdater_Tests: XCTestCase {
 
         // A query with a pagination parameter is NOT a fresh first-page fetch.
         let query = ChannelQuery(cid: cid, paginationParameter: .around(.unique))
-        channelUpdater.cleanStaleMidPageStateIfNeeded(for: query, isInRecoveryMode: false)
+        channelUpdater.update(channelQuery: query, isInRecoveryMode: false)
 
         try database.readSynchronously { session in
             let dto = try XCTUnwrap(session.channel(cid: cid))


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1658](https://linear.app/stream/issue/IOS-1658/v5-qa-fix-jumping-to-mid-page-breaking-channel-preview)

### 🎯 Goal

Fix the v5 regression where, after tapping a quoted message (or any flow that paginates to a mid-page) and popping back to the channel list, the channel list item rendered "No messages" instead of the actual latest message. This regression surfaced because v5 moved channel-list previews onto `ChatChannel.latestMessages`.

The most natural fix — stop wiping the cached channel messages on mid-page jumps — exposed two pre-existing latent issues that this PR also addresses, since they would otherwise be visible to users once the cache is preserved:

1. Reopening a channel that was last left mid-page briefly shows the persisted mid-page slice for ~1 frame before the first page reloads.
2. After a mid-page jump, previously-cached newer messages leak into the active message-list page, because the page-bounds (`oldestMessageAt` / `newestMessageAt`) live on `ChannelDTO` and `NSFetchedResultsController` does not re-evaluate cached `MessageDTO` rows when only the parent changes.

### 📝 Summary

- `ChannelUpdater.update`: stop wiping locally cached channel messages on every fetch — only reset `channel.messages` on first-page (re-)loads. Keeps `ChatChannel.latestMessages` populated after a mid-page jump.
- New `ChannelUpdater.cleanStaleMidPageStateIfNeeded(for:isInRecoveryMode:)` helper (callback + async overloads): when about to issue a fresh first-page request and the channel still holds mid-page state on disk, drop the cached slice and reset `oldestMessageAt` / `newestMessageAt` so the message observers don't briefly surface stale data.
- `ChatChannelController.synchronize` and `Chat.get(watch:)` both call the new helper before invoking the updater, so the fix reaches both the controller layer and the async-await state layer.
- `ChannelDTO.willSave`: extend the existing `truncatedAt` precedent to also nudge linked `MessageDTO`s when `oldestMessageAt` / `newestMessageAt` change, forcing any active FRC to re-evaluate `MessageDTO.channelMessagesPredicate` against rows it had already cached.

### 🛠 Implementation

**Why the channel list preview broke (v5 regression)**

`ChannelDTO.cleanAllMessagesExcludingLocalOnly()` was being invoked on every successful `update` completion, including mid-page pagination fetches. Since v5 derives the channel-list preview from `ChatChannel.latestMessages`, wiping `channel.messages` for a mid-page jump emptied the preview. We now gate the wipe behind `didLoadFirstPage`, so the locally cached slice survives mid-page jumps.

**Why the active page leaked older messages (latent issue exposed by the fix above)**

`MessageDTO.channelMessagesPredicate` filters by `channel.oldestMessageAt` / `channel.newestMessageAt`. Once `ChannelUpdater.update` stopped wiping `channel.messages`, the previously-cached newest slice stayed linked to the channel after a mid-page jump. `NSFetchedResultsController` does not re-run its predicate against cached rows when only a parent property changes, so the active page kept showing those out-of-bounds messages alongside the newly fetched mid-page slice. Following the existing `truncatedAt` pattern in `ChannelDTO.willSave`, we now nudge each linked message on any `oldestMessageAt` / `newestMessageAt` change to force the FRC to re-evaluate its predicate. This covers every writer of the bounds (the main update path *and* `cleanStaleMidPageStateIfNeeded`) without per-call bookkeeping.

#### ✅ Pros

- Surgical, layered change with no Core Data migration; fully backwards-compatible.
- The FRC nudge lives next to the existing `truncatedAt` precedent in `ChannelDTO.willSave`, so any future writer of the page bounds gets the correct observer behavior for free.
- Common `synchronize` / `get` path stays synchronous; the async cleanup branch only runs when stale mid-page state is detected.
- Both layers (UIKit `ChatChannelController` and async-await `Chat`) get the same fix from the same helper, so no behavior drift between them.

#### 🔭 Future Improvement

Architecturally, the root cause is that `ChannelDTO.messages` is overloaded to mean both "the channel's recent history" (used by `ChatChannel.latestMessages` for previews) and "the active controller's paginated page" (used by the message-list observers). 

A cleaner long-term direction would be to introduce a dedicated `ChannelMessagesQueryDTO` that owns the active page and links to `MessageDTO`s through its own relationship. This way, the `channel.latestMessages` would be decoupled from the actual current active channel messages.

### 🧪 Manual Testing Notes

1. Open a channel and load several pages of older messages.
2. Tap a quoted-message reply (or use any flow that calls `loadPageAroundMessageId(...)`) to jump to a mid-page.
3. Pop back to the channel list.
   - Before: the channel list item shows "No messages".
   - After: the channel list item shows the actual latest message.
4. Tap the same channel again.
   - Before: the mid-page slice flickers for ~1 frame, then jumps to the first page.
   - After: the channel opens directly to the first page; no flicker.
5. While in step 2 (mid-page view), confirm the message list shows only the mid-page slice — no previously-cached newer messages should appear above the jumped-to message.
6. Repeat steps 2–5 in a SwiftUI demo wired through `Chat` to verify the state-layer path.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended clearing of cached messages during mid-page jumps and pagination; channel previews now retain their latest messages.
  * Stale mid-page cleanup now runs only when appropriate (first-page fetches with stale bounds) and is skipped during recovery or when pagination params apply.
  * Deallocation no longer triggers cache purge that removed messages unexpectedly.
  * Page-boundary timestamp updates now preserve linked message associations for accurate previews.

* **Tests**
  * Updated and expanded tests to assert retained cache behavior and cover stale-cleanup and failure scenarios.

* **Documentation**
  * Updated changelog entries for pagination and message-caching fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->