### PR TITLE
[v4] Fix CurrentUserController.setPushPreference not updating local state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix `CurrentUserController.setPushPreference` and `snoozePushNotifications` not updating the local push preference state [#PRNUM](https://github.com/GetStream/stream-chat-swift/pull/PRNUM)
+
 ### 🔄 Changed
 
 # [4.99.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.99.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Fix `CurrentUserController.setPushPreference` and `snoozePushNotifications` not updating the local push preference state [#PRNUM](https://github.com/GetStream/stream-chat-swift/pull/PRNUM)
+- Fix `CurrentUserController.setPushPreference` and `snoozePushNotifications` not updating the local push preference state [#4086](https://github.com/GetStream/stream-chat-swift/pull/4086)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -472,8 +472,8 @@ public extension CurrentChatUserController {
             removeDisable: true
         )
 
-        currentUserUpdater.setPushPreference(userPreference) { [weak self] result in
-            self?.callback {
+        currentUserUpdater.setPushPreference(userPreference) { result in
+            self.callback {
                 completion?(result)
             }
         }
@@ -494,8 +494,8 @@ public extension CurrentChatUserController {
             removeDisable: nil
         )
 
-        currentUserUpdater.setPushPreference(userPreference) { [weak self] result in
-            self?.callback {
+        currentUserUpdater.setPushPreference(userPreference) { result in
+            self.callback {
                 completion?(result)
             }
         }

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -215,16 +215,19 @@ class CurrentUserUpdater: Worker {
                     completion(.failure(ClientError.CurrentUserDoesNotExist()))
                     return
                 }
-                self?.database.write {
-                    // No need to use the actual current user id.
-                    // There is only one push preference related to a user, which is the current user.
-                    try $0.savePushPreference(
-                        id: "currentUserId",
+                self?.database.write { session in
+                    guard let currentUserDTO = session.currentUser else {
+                        log.error("Cannot save push preference: no current user in the database")
+                        return
+                    }
+                    let savedDTO = try session.savePushPreference(
+                        id: currentUserDTO.user.id,
                         payload: .init(
                             chatLevel: currentUserPushPref.level.rawValue,
                             disabledUntil: currentUserPushPref.disabledUntil
                         )
                     )
+                    currentUserDTO.pushPreference = savedDTO
                 }
                 completion(.success(currentUserPushPref))
             case let .failure(error):

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -906,6 +906,12 @@ final class CurrentUserUpdater_Tests: XCTestCase {
 
     func test_setPushPreference_successfulResponse_savesToDatabase() throws {
         // GIVEN
+        let userId: UserId = .unique
+        let userPayload: CurrentUserPayload = .dummy(userId: userId, role: .user)
+        try database.writeSynchronously {
+            try $0.saveCurrentUser(payload: userPayload)
+        }
+
         let preference = PushPreferenceRequestPayload(
             chatLevel: "all",
             channelId: nil,
@@ -924,16 +930,51 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         )
 
         // WHEN
-        var completionCalled = false
-        currentUserUpdater.setPushPreference(preference) { result in
-            XCTAssertNil(result.error)
-            completionCalled = true
+        let completionResult: Result<PushPreference, Error> = try waitFor { done in
+            currentUserUpdater.setPushPreference(preference, completion: done)
+            apiClient.test_simulateResponse(.success(response))
         }
 
-        apiClient.test_simulateResponse(.success(response))
-
         // THEN
-        AssertAsync.willBeTrue(completionCalled)
+        XCTAssertNil(completionResult.error)
+        AssertAsync {
+            Assert.willBeEqual(self.database.viewContext.currentUser?.pushPreference?.id, userId)
+            Assert.willBeEqual(self.database.viewContext.currentUser?.pushPreference?.chatLevel, "all")
+        }
+
+        // Regression: the DTO must not be saved under the literal "currentUserId" string.
+        XCTAssertNil(PushPreferenceDTO.load(id: "currentUserId", context: database.viewContext))
+    }
+
+    func test_setPushPreference_successfulResponse_whenNoCurrentUser_doesNotCrashOrSave() throws {
+        // GIVEN — no current user seeded in the database
+        let preference = PushPreferenceRequestPayload(
+            chatLevel: "all",
+            channelId: nil,
+            disabledUntil: nil,
+            removeDisable: true
+        )
+
+        let response = PushPreferencesPayloadResponse(
+            userPreferences: [
+                "userId": PushPreferencePayload(
+                    chatLevel: "all",
+                    disabledUntil: nil
+                )
+            ],
+            channelPreferences: [:]
+        )
+
+        // WHEN
+        let completionResult: Result<PushPreference, Error> = try waitFor { done in
+            currentUserUpdater.setPushPreference(preference, completion: done)
+            apiClient.test_simulateResponse(.success(response))
+        }
+
+        // THEN — completion still propagates the API success, but nothing is written to the DB.
+        XCTAssertNil(completionResult.error)
+        XCTAssertNil(PushPreferenceDTO.load(id: "currentUserId", context: database.viewContext))
+        XCTAssertNil(database.viewContext.currentUser)
     }
 
     func test_setPushPreference_propagatesNetworkError() {


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1570](https://linear.app/stream/issue/IOS-1570)

### 🎯 Goal

`CurrentUserController.setPushPreference(level:)` succeeded against the API but the local `currentUser.pushPreference` never reflected the change, so UIs bound to it stayed stale until the app reconnected and re-fetched the current user. This PR makes the local round-trip work the way callers expect.

### 📝 Summary

- Save the `PushPreferenceDTO` under the actual current user id and wire `CurrentUserDTO.pushPreference = savedDTO`.
- Strongly capture `self` in `CurrentUserController.setPushPreference` and `snoozePushNotifications` callbacks, matching the rest of the controller.
- Cover the round-trip in `CurrentUserUpdater_Tests` (saved-id assertion + `currentUser.pushPreference` wired up + regression check that no DTO is saved under the literal `"currentUserId"`).

### 🛠 Implementation

`CurrentUserUpdater.setPushPreference` was previously writing the DTO under the literal id `"currentUserId"`. The remote-fetch path (`CurrentUserDTO.saveCurrentUser`) saves the same kind of DTO under the real user id and sets the inverse relationship to `CurrentUserDTO`. The local-save therefore created an orphan `PushPreferenceDTO` that was never linked to the current user, which is why the model never refreshed.

The fix reads `session.currentUser` inside the existing `database.write` block, saves with `currentUserDTO.user.id`, and explicitly sets `currentUserDTO.pushPreference = savedDTO`. Core Data's inverse handling sets `pushPreferenceDTO.currentUser = currentUserDTO` automatically. If there is no current user in the DB the save is logged and skipped — the API success still propagates to the completion to preserve the existing public contract.

The two `CurrentUserController` callsites for `currentUserUpdater.setPushPreference(_:)` were the only methods on that controller that captured `self` weakly while routing through `self.callback { … }`. They are now consistent with `updateUserData`, `addDevice`, `removeDevice`, etc.

### 🎨 Showcase

N/A — no UI surface in this SDK PR.

### 🧪 Manual Testing Notes

In the demo app or an integration test:

1. Sign in.
2. Call `chatClient.currentUserController().setPushPreference(level: .none)`; assert success.
3. Read `chatClient.currentUserController().currentUser?.pushPreference?.level` — should be `.none`.
4. Call again with `.all`; the observed value should flip to `.all` without restarting the client.

Before this PR, step 3/4 reflected the value only after a fresh fetch of the current user; after this PR, it updates immediately.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo