### PR TITLE
Default Appearance.localizationProvider to a Bundle.main → SDK fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChatCommonUI
 ### 🔄 Changed
+- `Appearance.localizationProvider` now falls back from `Bundle.main` to the SDK bundle, so apps can override keys without installing a custom provider [#4088](https://github.com/GetStream/stream-chat-swift/pull/4088)
 
 # [5.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/5.1.1)
 _May 08, 2026_
@@ -18,10 +20,6 @@ _May 08, 2026_
 ### 🐞 Fixed
 - Fix channel list preview showing "No messages" after a mid-page jump [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
 - Fix layout shift on delivery-status transitions in message footer [#4078](https://github.com/GetStream/stream-chat-swift/pull/4078)
-
-## StreamChatCommonUI
-### 🔄 Changed
-- `Appearance.localizationProvider` now falls back from `Bundle.main` to the SDK bundle, so apps can override keys without installing a custom provider [#4088](https://github.com/GetStream/stream-chat-swift/pull/4088)
 
 # [5.1.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.1.0)
 _April 23, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChatCommonUI
 ### 🔄 Changed
-- `Appearance.localizationProvider` now resolves keys against `Bundle.main` first, then `Appearance.bundle`, and finally the SDK's bundle, so apps can override individual keys by adding them to their own `Localizable.strings` / `Localizable.stringsdict` without installing a custom provider
+- `Appearance.localizationProvider` now falls back from `Bundle.main` to the SDK bundle, so apps can override keys without installing a custom provider [#4088](https://github.com/GetStream/stream-chat-swift/pull/4088)
 
 # [5.1.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.1.0)
 _April 23, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix channel list preview showing "No messages" after a mid-page jump [#4077](https://github.com/GetStream/stream-chat-swift/pull/4077)
 - Fix layout shift on delivery-status transitions in message footer [#4078](https://github.com/GetStream/stream-chat-swift/pull/4078)
 
+## StreamChatCommonUI
+### 🔄 Changed
+- `Appearance.localizationProvider` now resolves keys against `Bundle.main` first, then `Appearance.bundle`, and finally the SDK's bundle, so apps can override individual keys by adding them to their own `Localizable.strings` / `Localizable.stringsdict` without installing a custom provider
+
 # [5.1.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.1.0)
 _April 23, 2026_
 

--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -23,16 +23,6 @@ extension StreamChatWrapper {
         if client == nil {
             client = ChatClient(config: config)
         }
-
-        // L10N
-        let localizationProvider = Appearance.default.localizationProvider
-        Appearance.default.localizationProvider = { key, table in
-            let localizedString = localizationProvider(key, table)
-
-            return localizedString == key
-                ? Bundle.main.localizedString(forKey: key, value: nil, table: table)
-                : localizedString
-        }
     }
 
     func configureUI() {

--- a/Sources/StreamChatCommonUI/Appearance.swift
+++ b/Sources/StreamChatCommonUI/Appearance.swift
@@ -36,10 +36,33 @@ import StreamChat
     
     public nonisolated(unsafe) static var bundle: Bundle?
 
-    /// Provider for custom localization which is dependent on App Bundle.
+    /// Provider for custom localization.
+    ///
+    /// The default implementation resolves each key by walking a fallback chain:
+    /// 1. The app's `Bundle.main` — so any key the integrating app overrides in its own
+    ///    `Localizable.strings` / `Localizable.stringsdict` automatically wins, without the
+    ///    app having to install a custom provider.
+    /// 2. `Appearance.bundle`, when set by a UI SDK (e.g. `StreamChatSwiftUI` points it at
+    ///    its own framework bundle so SwiftUI-specific keys are resolved there).
+    /// 3. `StreamChatCommonUI`'s own bundle, which ships the SDK's default translations.
+    ///
+    /// Replace this provider only if you need a more advanced setup; for simple
+    /// per-key overrides or adding new translations, just ship the keys you want to
+    /// customize in your app's `Localizable.strings` / `Localizable.stringsdict`.
     public var localizationProvider: @Sendable (_ key: String, _ table: String) -> String = { key, table in
-        let bundle = Appearance.bundle ?? Bundle.streamChatCommonUI
-        return bundle.localizedString(forKey: key, value: nil, table: table)
+        let mainLocalizedString = Bundle.main.localizedString(forKey: key, value: nil, table: table)
+        if mainLocalizedString != key {
+            return mainLocalizedString
+        }
+
+        if let bundle = Appearance.bundle {
+            let bundleLocalizedString = bundle.localizedString(forKey: key, value: nil, table: table)
+            if bundleLocalizedString != key {
+                return bundleLocalizedString
+            }
+        }
+
+        return Bundle.streamChatCommonUI.localizedString(forKey: key, value: nil, table: table)
     }
 
     public init() {


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1689](https://linear.app/stream/issue/IOS-1689/polls-results-view-with-missing-localization-keys-from-formatter)

### 🎯 Goal

Today, customizing a single SDK string forces every integrating app to install a custom `Appearance.default.localizationProvider`. The default provider only reads from `Appearance.bundle ?? Bundle.streamChatCommonUI`, so any string an app ships in its own `Localizable.strings` is silently ignored unless the customer reroutes the provider through `Bundle.main` themselves.

That's a sharp footgun: customers who go for the "replace the provider with `Bundle.main` only" pattern lose every key they haven't translated yet (any new key the SDK ships in a future release would render as the raw key in their app).

### 📝 Summary

- Bake a fallback chain into the default `Appearance.localizationProvider`: `Bundle.main` → `Appearance.bundle` → `StreamChatCommonUI`'s bundle.
- Customers can now override or add translations by simply shipping the keys they care about in their app's `Localizable.strings` / `Localizable.stringsdict`, no custom provider needed.
- Replacing the provider is still supported and unchanged in shape for apps with more advanced setups (e.g. providers backed by a server or feature flags).

### 🛠 Implementation

The default closure on `Appearance.localizationProvider` now walks three sources in order, returning the first one that resolves the key (i.e. returns something other than the raw key):

1. `Bundle.main` — anything the integrating app ships under that key wins.
2. `Appearance.bundle` (when set by a UI SDK, e.g. `StreamChatSwiftUI` points it at its own framework bundle so SwiftUI-specific keys are resolved there).
3. `Bundle.streamChatCommonUI` — the SDK's bundled defaults; always the final fallback.

`@Sendable` is preserved; nothing is captured in the closure beyond static accessors.

### 🧪 Manual Testing Notes

1. In a host app (DemoApp or DemoAppSwiftUI), override a single SDK key in the app's `Localizable.strings`, e.g.:

   ```
   "channel.name.and" = "&";
   "channel.name.andXMore" = "& %@ more";
   ```

2. Do **not** install a custom `localizationProvider`.
3. Run the app — channel names that previously read "Foo and Bar" / "Foo, Bar and 3 more" should now render with the `&` separator. All other strings remain on the SDK's bundled defaults.
4. Sanity-check by setting `Appearance.bundle = .streamChatSwiftUI` (already done by the SwiftUI SDK on init) and confirming SwiftUI-specific keys still resolve through that bundle when the app doesn't override them.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo (see [docs-content#1277](https://github.com/GetStream/docs-content/pull/1277))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localization now uses a fallback chain: app main bundle → custom appearance bundle → SDK bundle, letting apps override strings without a custom provider.
* **Chores**
  * Demo updated to rely on the new built-in fallback behavior for localization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swift/pull/4088)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->