### PR TITLE
Fix `PartialKeyPath: Sendable` retroactive conformance breaking KeyPath usage with TCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix `PartialKeyPath: Sendable` retroactive conformance conflict with other modules
+
 ## StreamChatCommonUI
 ### 🔄 Changed
 - `Appearance.localizationProvider` now falls back from `Bundle.main` to the SDK bundle, so apps can override keys without installing a custom provider [#4088](https://github.com/GetStream/stream-chat-swift/pull/4088)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Fix `PartialKeyPath: Sendable` retroactive conformance conflict with other modules
+- Fix `PartialKeyPath: Sendable` retroactive conformance conflict with other modules [#4090](https://github.com/GetStream/stream-chat-swift/pull/4090)
 
 ## StreamChatCommonUI
 ### 🔄 Changed

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -89,7 +89,3 @@ extension ChatChannel {
         lastMessageAt ?? createdAt
     }
 }
-
-// Remove when InferSendableFromCaptures is enabled
-// https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md
-extension PartialKeyPath: @retroactive @unchecked Sendable where Root == ChatChannel {}

--- a/Sources/StreamChat/Query/Sorting/Sorting.swift
+++ b/Sources/StreamChat/Query/Sorting/Sorting.swift
@@ -45,7 +45,9 @@ extension Sorting: Equatable where Key: Equatable {}
 extension Sorting: Hashable where Key: Hashable {}
 
 /// A sorting key that can be converted to local DB query or local runtime sorting.
-public struct LocalConvertibleSortingKey<Model>: SortingKey, Encodable, Equatable {
+///
+/// Remove the `@unchecked` annotation once the `InferSendableFromCaptures` upcoming feature (SE-0418) is enabled.
+public struct LocalConvertibleSortingKey<Model>: SortingKey, Encodable, Equatable, @unchecked Sendable {
     let keyPath: PartialKeyPath<Model>?
     let localKey: String?
     let remoteKey: String


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1699](https://linear.app/stream/issue/IOS-1699)

### 🎯 Goal

Fix compilation when StreamChat SDK is compiled together with swift-dependencies

### 📝 Summary

- Drop the retroactive `extension PartialKeyPath: @retroactive @unchecked Sendable where Root == ChatChannel {}` in `ChannelListSortingKey.swift`.
- Mark `LocalConvertibleSortingKey<Model>` itself as `@unchecked Sendable` so `ChannelListSortingKey` / `ThreadListSortingKey` (and any future `LocalConvertibleSortingKey<…>` alias) stay Sendable without touching stdlib types.

### 🛠 Implementation

`extension PartialKeyPath: @retroactive @unchecked Sendable where Root == ChatChannel {}` in `ChannelListSortingKey.swift` registered `where Root == ChatChannel` as the conditional bound for `PartialKeyPath`'s Sendable conformance globally. Every other `KeyPath<X, Y>: Sendable` lookup in the same target then tried to unify `X` with `ChatChannel` and failed. Integrators using TCA / [`swift-dependencies`](https://github.com/pointfreeco/swift-dependencies) hit this even with a plain `@Dependency(\.uuid)`:

```
error: initializer 'init(_:fileID:filePath:line:column:)' requires the types 'DependencyValues' and 'ChatChannel' be equivalent
note: requirement from conditional conformance of 'KeyPath<DependencyValues, UUIDGenerator>' to 'Sendable'
```

The `@unchecked` annotation is safe here:

- All three stored properties (`keyPath`, `localKey`, `remoteKey`) are immutable `let`s.
- The `keyPath` field only ever holds simple property-access `PartialKeyPath` literals (e.g. `\.createdAt`, `\.membership?.pinnedAt`). None capture subscript indices or other non-Sendable state, so each `PartialKeyPath` instance is a functionally immutable value.
- `PartialKeyPath` is read-only at runtime via `object[keyPath: kp]` — pure value access, thread-safe by construction.

Cleanup trigger documented in code: once the `InferSendableFromCaptures` upcoming feature (SE-0418) is enabled or KeyPath types become unconditionally Sendable in the toolchain, the `@unchecked` annotation can be removed.

### 🧪 Manual Testing Notes

Reproduce the original bug end-to-end:

1. Create a minimal SwiftPM consumer (iOS 16+) that depends on the local StreamChat checkout and `swift-composable-architecture` 1.15+.
2. Add a feature using `@Dependency(\.uuid)`:
   ```swift
   import ComposableArchitecture
   import Foundation
   import StreamChat

   @Reducer struct Minimal {
       @ObservableState struct State: Equatable { var id: UUID? }
       enum Action { case generate }
       @Dependency(\.uuid) private var uuid
       var body: some ReducerOf<Self> {
           Reduce { state, _ in state.id = uuid(); return .none }
       }
   }
   ```
3. Before this PR: `xcodebuild` fails with `requires the types 'DependencyValues' and 'ChatChannel' be equivalent`.
4. After this PR: build succeeds. Verified with `xcodebuild -scheme StreamChat -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' build test` — all 3324 existing StreamChat tests pass.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo