### PR TITLE
Allow custom CDNStorage to mutate attachment payload via UploadedFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### ✅ Added
+`UploadedFile` now carries an optional `attachment` so custom `CDNStorage` implementations can mutate the attachment payload [#4091](https://github.com/GetStream/stream-chat-swift/pull/4091)
+
 ## StreamChatCommonUI
 ### 🔄 Changed
 - `Appearance.localizationProvider` now falls back from `Bundle.main` to the SDK bundle, so apps can override keys without installing a custom provider [#4088](https://github.com/GetStream/stream-chat-swift/pull/4088)

--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -321,7 +321,7 @@ class APIClient: @unchecked Sendable {
             self?.cdnStorage.uploadAttachment(attachment, options: .init(progress: progress)) { [weak self] result in
                 let mappedResult = result.map { file in
                     UploadedAttachment(
-                        attachment: attachment,
+                        attachment: file.attachment ?? attachment,
                         remoteURL: file.fileURL,
                         thumbnailURL: file.thumbnailURL
                     )

--- a/Sources/StreamChat/APIClient/CDNClient/CDNStorage.swift
+++ b/Sources/StreamChat/APIClient/CDNClient/CDNStorage.swift
@@ -11,6 +11,10 @@ import Foundation
 public protocol CDNStorage: Sendable {
     /// Uploads an attachment tied to a message and returns the uploaded file information.
     ///
+    /// If your CDN response contains extra metadata (e.g. title, codec, dimensions, signed
+    /// thumbnail URLs) that you want to write into the attachment payload, mutate the typed
+    /// payload using ``AnyAttachmentUpdater`` and return it via ``UploadedFile/attachment``.
+    ///
     /// - Parameters:
     ///   - attachment: The message attachment to upload.
     ///   - options: Options for the upload, such as progress reporting.

--- a/Sources/StreamChat/APIClient/CDNClient/StreamCDNStorage.swift
+++ b/Sources/StreamChat/APIClient/CDNClient/StreamCDNStorage.swift
@@ -9,9 +9,40 @@ public struct UploadedFile: Sendable, Decodable {
     public let fileURL: URL
     public let thumbnailURL: URL?
 
-    public init(fileURL: URL, thumbnailURL: URL? = nil) {
+    /// The chat message attachment associated with the upload, after any payload mutations
+    /// performed by a custom ``CDNStorage`` implementation.
+    ///
+    /// Set this from `CDNStorage.uploadAttachment(_:options:completion:)` when your custom CDN
+    /// returns extra metadata (e.g. title, codec, dimensions, signed thumbnail URLs) that you
+    /// want to write into the attachment payload before the SDK persists it. Use
+    /// ``AnyAttachmentUpdater`` to mutate the typed payload and pass the resulting attachment here.
+    ///
+    /// - Note: This property is only meaningful when returned from
+    ///   ``CDNStorage/uploadAttachment(_:options:completion:)`` (the message-attached overload).
+    ///   It is ignored by ``CDNStorage/uploadAttachment(localUrl:options:completion:)`` because
+    ///   standalone file uploads have no message attachment context.
+    public let attachment: AnyChatMessageAttachment?
+
+    public init(
+        fileURL: URL,
+        thumbnailURL: URL? = nil,
+        attachment: AnyChatMessageAttachment? = nil
+    ) {
         self.fileURL = fileURL
         self.thumbnailURL = thumbnailURL
+        self.attachment = attachment
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case fileURL
+        case thumbnailURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        fileURL = try container.decode(URL.self, forKey: .fileURL)
+        thumbnailURL = try container.decodeIfPresent(URL.self, forKey: .thumbnailURL)
+        attachment = nil
     }
 }
 

--- a/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
@@ -414,6 +414,52 @@ final class APIClient_Tests: XCTestCase {
         XCTAssertEqual(receivedResult?.error as NSError?, error)
     }
 
+    func test_uploadAttachment_usesStorageReturnedAttachment_whenProvided() throws {
+        let attachment = AnyChatMessageAttachment.dummy(
+            payload: "original".data(using: .utf8)!
+        )
+        let mutatedAttachment = AnyChatMessageAttachment.dummy(
+            id: attachment.id,
+            payload: "mutated".data(using: .utf8)!
+        )
+        let mockedURL = URL(string: "https://hello.com")!
+        cdnStorage.uploadAttachmentResult = .success(
+            UploadedFile(fileURL: mockedURL, attachment: mutatedAttachment)
+        )
+
+        nonisolated(unsafe) var receivedResult: Result<UploadedAttachment, Error>?
+        waitUntil(timeout: defaultTimeout) { done in
+            apiClient.uploadAttachment(
+                attachment,
+                progress: nil,
+                completion: { receivedResult = $0; done() }
+            )
+        }
+
+        XCTAssertEqual(receivedResult?.value?.remoteURL, mockedURL)
+        XCTAssertEqual(receivedResult?.value?.attachment.payload, mutatedAttachment.payload)
+    }
+
+    func test_uploadAttachment_fallsBackToOriginalAttachment_whenStorageDoesNotReturnAttachment() throws {
+        let attachment = AnyChatMessageAttachment.dummy()
+        let mockedURL = URL(string: "https://hello.com")!
+        cdnStorage.uploadAttachmentResult = .success(
+            UploadedFile(fileURL: mockedURL)
+        )
+
+        nonisolated(unsafe) var receivedResult: Result<UploadedAttachment, Error>?
+        waitUntil(timeout: defaultTimeout) { done in
+            apiClient.uploadAttachment(
+                attachment,
+                progress: nil,
+                completion: { receivedResult = $0; done() }
+            )
+        }
+
+        XCTAssertEqual(receivedResult?.value?.remoteURL, mockedURL)
+        XCTAssertEqual(receivedResult?.value?.attachment.id, attachment.id)
+    }
+
     // MARK: - Token Refresh
 
     func test_requestFailedWithExpiredToken_refreshesToken() throws {

--- a/Tests/StreamChatTests/APIClient/CDNClient/CDNStorage_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/CDNClient/CDNStorage_Tests.swift
@@ -114,6 +114,32 @@ final class CDNStorage_Tests: XCTestCase {
         let file = UploadedFile(fileURL: url, thumbnailURL: thumb)
         XCTAssertEqual(file.fileURL, url)
         XCTAssertEqual(file.thumbnailURL, thumb)
+        XCTAssertNil(file.attachment)
+    }
+
+    func test_uploadedFile_initWithAttachment() {
+        let url = URL(string: "https://cdn.example.com/file.jpg")!
+        let attachment = AnyChatMessageAttachment.dummy()
+        let file = UploadedFile(fileURL: url, attachment: attachment)
+        XCTAssertEqual(file.fileURL, url)
+        XCTAssertNil(file.thumbnailURL)
+        XCTAssertEqual(file.attachment?.id, attachment.id)
+    }
+
+    func test_uploadedFile_decoding_ignoresAttachmentField() throws {
+        let url = URL(string: "https://cdn.example.com/file.jpg")!
+        let thumb = URL(string: "https://cdn.example.com/thumb.jpg")!
+        let json = """
+        {
+            "fileURL": "\(url.absoluteString)",
+            "thumbnailURL": "\(thumb.absoluteString)"
+        }
+        """.data(using: .utf8)!
+
+        let file = try JSONDecoder.stream.decode(UploadedFile.self, from: json)
+        XCTAssertEqual(file.fileURL, url)
+        XCTAssertEqual(file.thumbnailURL, thumb)
+        XCTAssertNil(file.attachment)
     }
 }
 

--- a/Tests/StreamChatTests/APIClient/StreamCDNStorage_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/StreamCDNStorage_Tests.swift
@@ -146,6 +146,8 @@ final class StreamCDNStorage_Tests: XCTestCase {
 
         // Check the outgoing data is from the decoder
         XCTAssertEqual(try result.get().fileURL, payload.fileURL)
+        // Default Stream CDN does not carry an attachment back; the SDK uses the original attachment.
+        XCTAssertNil(try result.get().attachment)
     }
     
     func test_standaloneUploadFileSuccess() throws {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1700/cdnstorage-mutate-attachment-payload

### 🎯 Goal

Custom `CDNStorage` implementations can already replace the file URL and the thumbnail URL of an uploaded attachment, but they have no way to write upload-time metadata (CDN-assigned IDs, codecs, dimensions, signed thumbnail URLs, custom titles, …) into the typed payload.

The existing `UploadedAttachmentPostProcessor` runs *after* the upload, on an `UploadedAttachment` that only carries `remoteURL` and `thumbnailURL`, so it has no access to the custom response data the storage saw during upload. This forces customers to re-fetch or re-derive that data outside of the upload flow.

This PR closes that gap without breaking the existing v5 `CDNStorage` contract.

### 📝 Summary

- Add an optional `attachment: AnyChatMessageAttachment?` to `UploadedFile`, so custom `CDNStorage` implementations can hand back a mutated attachment together with the file URLs.
- `APIClient.uploadAttachment` now uses `file.attachment ?? attachment` when constructing the final `UploadedAttachment`, so the storage's mutated attachment flows through the regular upload pipeline.
- Document the workflow on `CDNStorage.uploadAttachment(_:options:completion:)` and on `UploadedFile.attachment`, calling out that this is only meaningful for the message-attached overload (standalone uploads have no attachment context).

### 🛠 Implementation

`UploadedFile` gains a new `public let attachment: AnyChatMessageAttachment?` field with a defaulted `nil` initializer parameter, so the existing call sites (and the default `StreamCDNStorage`) keep compiling unchanged. The constructor signature stays source-compatible (the new parameter has a default value).

To preserve the existing wire format, `UploadedFile` now defines an explicit `CodingKeys` enum that omits `attachment` and a custom `init(from:)` that decodes only `fileURL` and `thumbnailURL`. The `attachment` field is therefore a runtime-only carrier from the CDN storage to the API client and is never serialized into a network payload.

`APIClient.uploadAttachment` was the only place that wrapped `UploadedFile` into an `UploadedAttachment`. It now prefers `file.attachment` over the original attachment when present, so any payload mutation a custom storage performs propagates through `AttachmentQueueUploader` and `UploadedAttachmentPostProcessor` as if the SDK had produced it itself.

The default `StreamCDNStorage` does not opt into this — `UploadedFile.attachment` is left at `nil` and the API client falls back to the original attachment, matching today's behavior.

### 🧪 Manual Testing Notes

This change is exercised through unit tests:

- `UploadedFile` initializes with and without an attachment, and `init(from:)` always decodes `attachment` as `nil` (network payloads stay forward/backward compatible).
- `APIClient.uploadAttachment` uses the storage-returned attachment when provided, and falls back to the original attachment otherwise.
- Default `StreamCDNStorage` upload result has `attachment == nil`.

To validate end-to-end, drop in a custom `CDNStorage` that mutates the attachment payload using `AnyAttachmentUpdater` (see the docs-content PR linked below), upload an image/video/audio attachment, and confirm the mutated `title` / `extraData` survive into `ChatMessage.attachments`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo (see [docs-content#1280](https://github.com/GetStream/docs-content/pull/1280))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File uploads can now include attachment metadata returned by custom CDN responses; the SDK will use CDN-provided attachment metadata when present and fall back to the original attachment otherwise.

* **Tests**
  * Added tests covering CDN-provided attachment handling and fallback behavior.

* **Documentation**
  * Clarified how custom CDN implementations can mutate and return attachment payloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swift/pull/4091)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->