### PR TITLE
Add typing event support to LivestreamChannelController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### ✅ Added
+- Support typing indicators in `LivestreamChannelController` via new `sendKeystrokeEvent`, `sendStartTypingEvent`, and `sendStopTypingEvent` APIs, plus in-memory `channel.currentlyTypingUsers` updates
 ### 🐞 Fixed
 - Fix `PartialKeyPath: Sendable` retroactive conformance conflict with other modules [#4090](https://github.com/GetStream/stream-chat-swift/pull/4090)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### ✅ Added
-- Support typing indicators in `LivestreamChannelController` via new `sendKeystrokeEvent`, `sendStartTypingEvent`, and `sendStopTypingEvent` APIs, plus in-memory `channel.currentlyTypingUsers` updates
+- Support typing indicators in `LivestreamChannelController` [#4094](https://github.com/GetStream/stream-chat-swift/pull/4094)
 ### 🐞 Fixed
 - Fix `PartialKeyPath: Sendable` retroactive conformance conflict with other modules [#4090](https://github.com/GetStream/stream-chat-swift/pull/4090)
 

--- a/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
+++ b/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
@@ -393,6 +393,23 @@ class DemoLivestreamChatChannelVC: _ViewController,
         messageListVC.scrollToBottomButton.content = .init(messages: skippedMessagesAmount, mentions: 0)
     }
 
+    func livestreamChannelController(
+        _ controller: LivestreamChannelController,
+        didChangeTypingUsers typingUsers: Set<ChatUser>
+    ) {
+        guard controller.channel?.canSendTypingEvents == true else { return }
+
+        let typingUsersWithoutCurrentUser = typingUsers
+            .sorted { $0.id < $1.id }
+            .filter { $0.id != self.client.currentUserId }
+
+        if typingUsersWithoutCurrentUser.isEmpty {
+            messageListVC.hideTypingIndicator()
+        } else {
+            messageListVC.showTypingIndicator(typingUsers: typingUsersWithoutCurrentUser)
+        }
+    }
+
     func eventsController(_ controller: EventsController, didReceiveEvent event: any Event) {
         if event is NewMessagePendingEvent {
             if livestreamChannelController.isPaused {
@@ -490,6 +507,22 @@ class DemoLivestreamComposerVC: ComposerVC {
             skipEnrichUrl: content.skipEnrichUrl,
             extraData: content.extraData
         )
+    }
+
+    /// Route keystroke events through `LivestreamChannelController`, mirroring `ComposerVC.updateKeystrokeEvents`.
+    override open func updateKeystrokeEvents() {
+        super.updateKeystrokeEvents()
+        guard let livestreamController = livestreamChannelController else { return }
+        guard !content.isEmpty, livestreamController.channel?.config.typingEventsEnabled == true else { return }
+        livestreamController.sendKeystrokeEvent(parentMessageId: content.threadMessage?.id)
+    }
+
+    @objc override open func publishMessage(sender: UIButton) {
+        // The keystroke timer scheduled in `TypingEventsSender` will only fire after
+        // `.startTypingEventTimeout` of inactivity. Send a stop event explicitly when the user
+        // submits, matching the regular `ComposerVC.publishMessage` flow.
+        livestreamChannelController?.sendStopTypingEvent()
+        super.publishMessage(sender: sender)
     }
 
     /// Override to hide the record button for livestream

--- a/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
+++ b/DemoApp/Screens/Livestream/DemoLivestreamChatChannelVC.swift
@@ -510,8 +510,11 @@ class DemoLivestreamComposerVC: ComposerVC {
     }
 
     /// Route keystroke events through `LivestreamChannelController`, mirroring `ComposerVC.updateKeystrokeEvents`.
+    ///
+    /// We intentionally don't call `super` because the base implementation would forward to
+    /// `channelController?.sendKeystrokeEvent`, which is always nil here (we wire the demo to
+    /// the livestream controller instead).
     override open func updateKeystrokeEvents() {
-        super.updateKeystrokeEvents()
         guard let livestreamController = livestreamChannelController else { return }
         guard !content.isEmpty, livestreamController.channel?.config.typingEventsEnabled == true else { return }
         livestreamController.sendKeystrokeEvent(parentMessageId: content.threadMessage?.id)

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController+Combine.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController+Combine.swift
@@ -26,6 +26,11 @@ extension LivestreamChannelController {
         basePublishers.skippedMessagesAmount.keepAlive(self)
     }
 
+    /// A publisher emitting a new value every time the set of currently typing users changes.
+    public var typingUsersPublisher: AnyPublisher<Set<ChatUser>, Never> {
+        basePublishers.typingUsers.keepAlive(self)
+    }
+
     /// An internal backing object for all publicly available Combine publishers. We use it to simplify the way we expose
     /// publishers. Instead of creating custom `Publisher` types, we use `CurrentValueSubject` and `PassthroughSubject` internally,
     /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
@@ -45,12 +50,16 @@ extension LivestreamChannelController {
         // A backing subject for `skippedMessagesAmountPublisher`.
         let skippedMessagesAmount: CurrentValueSubject<Int, Never>
 
+        /// A backing subject for `typingUsersPublisher`.
+        let typingUsers: CurrentValueSubject<Set<ChatUser>, Never>
+
         init(controller: LivestreamChannelController) {
             self.controller = controller
             channelChange = .init(controller.channel)
             messagesChanges = .init(controller.messages)
             skippedMessagesAmount = .init(controller.skippedMessagesAmount)
             isPaused = .init(controller.isPaused)
+            typingUsers = .init(controller.channel?.currentlyTypingUsers ?? [])
             controller.multicastDelegate.add(additionalDelegate: self)
         }
     }
@@ -83,5 +92,12 @@ extension LivestreamChannelController.BasePublishers: LivestreamChannelControlle
         didChangeSkippedMessagesAmount skippedMessagesAmount: Int
     ) {
         self.skippedMessagesAmount.send(skippedMessagesAmount)
+    }
+
+    func livestreamChannelController(
+        _ controller: LivestreamChannelController,
+        didChangeTypingUsers typingUsers: Set<ChatUser>
+    ) {
+        self.typingUsers.send(typingUsers)
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController+Combine.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController+Combine.swift
@@ -27,6 +27,11 @@ extension LivestreamChannelController {
     }
 
     /// A publisher emitting a new value every time the set of currently typing users changes.
+    ///
+    /// The publisher's initial value is captured from `controller.channel?.currentlyTypingUsers`
+    /// at the time the controller's Combine bridge is first accessed. If a subscriber attaches
+    /// before `synchronize()` resolves the channel, the initial value will be an empty set;
+    /// subsequent updates are still delivered as typing events arrive.
     public var typingUsersPublisher: AnyPublisher<Set<ChatUser>, Never> {
         basePublishers.typingUsers.keepAlive(self)
     }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -899,7 +899,7 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
 
     /// A boolean value indicating if typing events can be sent.
     private var canSendTypingEvents: Bool {
-        channel?.canSendTypingEvents ?? true
+        channel?.canSendTypingEvents ?? false
     }
 
     /// Pauses the collecting of new messages.

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1208,15 +1208,21 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         // Thread typing events should not affect the channel-level typing indicator.
         guard event.parentId == nil else { return }
 
-        var typingUsers = (channel?.currentlyTypingUsers ?? []).filter { $0.id != event.user.id }
-        if event.isTyping {
-            typingUsers.insert(event.user)
-            scheduleTypingCleanup(for: event.user)
-        } else {
-            cancelTypingCleanup(for: event.user.id)
-        }
+        let currentTypingUsers = channel?.currentlyTypingUsers ?? []
+        let userId = event.user.id
 
-        updateCurrentlyTypingUsers(typingUsers)
+        if event.isTyping {
+            scheduleTypingCleanup(for: event.user)
+            var nextTypingUsers = currentTypingUsers.filter { $0.id != userId }
+            nextTypingUsers.insert(event.user)
+            updateCurrentlyTypingUsers(nextTypingUsers)
+        } else {
+            cancelTypingCleanup(for: userId)
+            // No-op when the user wasn't tracked locally (e.g. we joined mid-typing).
+            // Avoids allocating a filtered copy of the set for every spurious stop event.
+            guard currentTypingUsers.contains(where: { $0.id == userId }) else { return }
+            updateCurrentlyTypingUsers(currentTypingUsers.filter { $0.id != userId })
+        }
     }
 
     private func scheduleTypingCleanup(for user: ChatUser) {

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -221,7 +221,6 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         }
         appStateObserver.unsubscribe(self)
         typingCleanupTimers.values.forEach { $0.cancel() }
-        typingCleanupTimers.removeAll()
     }
 
     // MARK: - Public Methods

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1214,10 +1214,6 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         // Thread typing events should not affect the channel-level typing indicator.
         guard event.parentId == nil else { return }
 
-        // `ChatUser.Equatable` compares many fields (including `lastActiveAt`), but we want
-        // to identify typing users by `id` only. Drop any existing entry for the user so
-        // `Set` semantics don't keep stale copies when the payload metadata differs between
-        // typing.start and typing.stop events.
         var typingUsers = (channel?.currentlyTypingUsers ?? []).filter { $0.id != event.user.id }
         if event.isTyping {
             typingUsers.insert(event.user)

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1214,12 +1214,15 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         // Thread typing events should not affect the channel-level typing indicator.
         guard event.parentId == nil else { return }
 
-        var typingUsers = channel?.currentlyTypingUsers ?? []
+        // `ChatUser.Equatable` compares many fields (including `lastActiveAt`), but we want
+        // to identify typing users by `id` only. Drop any existing entry for the user so
+        // `Set` semantics don't keep stale copies when the payload metadata differs between
+        // typing.start and typing.stop events.
+        var typingUsers = (channel?.currentlyTypingUsers ?? []).filter { $0.id != event.user.id }
         if event.isTyping {
             typingUsers.insert(event.user)
             scheduleTypingCleanup(for: event.user)
         } else {
-            typingUsers.remove(event.user)
             cancelTypingCleanup(for: event.user.id)
         }
 
@@ -1243,8 +1246,9 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
 
     private func removeTypingUser(_ user: ChatUser) {
         cancelTypingCleanup(for: user.id)
-        guard var typingUsers = channel?.currentlyTypingUsers, typingUsers.contains(user) else { return }
-        typingUsers.remove(user)
+        guard let currentTypingUsers = channel?.currentlyTypingUsers,
+              currentTypingUsers.contains(where: { $0.id == user.id }) else { return }
+        let typingUsers = currentTypingUsers.filter { $0.id != user.id }
         updateCurrentlyTypingUsers(typingUsers)
     }
 

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -160,7 +160,7 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         apiClient: client.apiClient
     )
 
-    /// The timer scheduler used for the auto-stop typing cleanup. Injectable for testing.
+    /// The timer scheduler used for the auto-stop typing cleanup.
     var timerType: TimerScheduling.Type = DefaultTimer.self
 
     /// Per-user timers that synthesize a "stop typing" effect locally if a typing.stop event never arrives.

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1243,9 +1243,10 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
     }
 
     private func updateCurrentlyTypingUsers(_ typingUsers: Set<ChatUser>) {
-        let previousTypingUsers = channel?.currentlyTypingUsers
+        // Bail out before mutating `channel` so we don't trigger `didUpdateChannel`
+        // (or a new `ChatChannel` struct copy) on every redundant typing event.
+        guard channel?.currentlyTypingUsers != typingUsers else { return }
         channel = channel?.changing(currentlyTypingUsers: typingUsers)
-        guard previousTypingUsers != typingUsers else { return }
         delegateCallback { [weak self] in
             guard let self else { return }
             $0.livestreamChannelController(self, didChangeTypingUsers: typingUsers)

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -825,18 +825,8 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         parentMessageId: MessageId? = nil,
         completion: (@MainActor (Error?) -> Void)? = nil
     ) {
-        guard let cid = cid else {
-            callback {
-                completion?(ClientError.ChannelNotCreatedYet())
-            }
-            return
-        }
-        guard canSendTypingEvents else {
-            callback { completion?(nil) }
-            return
-        }
-        typingEventsSender.keystroke(in: cid, parentMessageId: parentMessageId) { [weak self] error in
-            self?.callback { completion?(error) }
+        sendTypingEvent(failsWhenDisabled: false, completion: completion) { cid, sendCompletion in
+            typingEventsSender.keystroke(in: cid, parentMessageId: parentMessageId, completion: sendCompletion)
         }
     }
 
@@ -853,20 +843,8 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         parentMessageId: MessageId? = nil,
         completion: (@MainActor (Error?) -> Void)? = nil
     ) {
-        guard let cid = cid else {
-            callback {
-                completion?(ClientError.ChannelNotCreatedYet())
-            }
-            return
-        }
-        guard canSendTypingEvents else {
-            callback {
-                completion?(ClientError.ChannelFeatureDisabled("Channel feature: typing events is disabled for this channel."))
-            }
-            return
-        }
-        typingEventsSender.startTyping(in: cid, parentMessageId: parentMessageId) { [weak self] error in
-            self?.callback { completion?(error) }
+        sendTypingEvent(failsWhenDisabled: true, completion: completion) { cid, sendCompletion in
+            typingEventsSender.startTyping(in: cid, parentMessageId: parentMessageId, completion: sendCompletion)
         }
     }
 
@@ -883,19 +861,39 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         parentMessageId: MessageId? = nil,
         completion: (@MainActor (Error?) -> Void)? = nil
     ) {
+        sendTypingEvent(failsWhenDisabled: true, completion: completion) { cid, sendCompletion in
+            typingEventsSender.stopTyping(in: cid, parentMessageId: parentMessageId, completion: sendCompletion)
+        }
+    }
+
+    /// Shared boilerplate for the three public typing-event entry points.
+    ///
+    /// - Parameters:
+    ///   - failsWhenDisabled: When `true`, the completion receives a
+    ///     `ChannelFeatureDisabled` error if typing events are disabled. When `false`
+    ///     (used by `sendKeystrokeEvent`) the completion is invoked with `nil` so a
+    ///     disabled channel is treated as a silent no-op.
+    ///   - completion: The caller's completion handler.
+    ///   - send: Performs the underlying send once a valid `cid` and an enabled
+    ///     channel have been confirmed.
+    private func sendTypingEvent(
+        failsWhenDisabled: Bool,
+        completion: (@MainActor (Error?) -> Void)?,
+        send: (ChannelId, @escaping (Error?) -> Void) -> Void
+    ) {
         guard let cid = cid else {
-            callback {
-                completion?(ClientError.ChannelNotCreatedYet())
-            }
+            callback { completion?(ClientError.ChannelNotCreatedYet()) }
             return
         }
         guard canSendTypingEvents else {
             callback {
-                completion?(ClientError.ChannelFeatureDisabled("Channel feature: typing events is disabled for this channel."))
+                completion?(failsWhenDisabled
+                    ? ClientError.ChannelFeatureDisabled("Channel feature: typing events is disabled for this channel.")
+                    : nil)
             }
             return
         }
-        typingEventsSender.stopTyping(in: cid, parentMessageId: parentMessageId) { [weak self] error in
+        send(cid) { [weak self] error in
             self?.callback { completion?(error) }
         }
     }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -19,7 +19,6 @@ public extension ChatClient {
 /// Unlike `ChatChannelController`, this controller manages all data in memory and communicates directly with the API.
 /// It is more performant than `ChatChannelController` but is more simpler and it has less features, like for example:
 /// - Read updates
-/// - Typing indicators
 /// - etc..
 public class LivestreamChannelController: DataStoreProvider, AppStateObserverDelegate, @unchecked Sendable {
     public typealias Delegate = LivestreamChannelControllerDelegate
@@ -155,6 +154,21 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
     /// The current user id.
     private var currentUserId: UserId? { client.currentUserId }
 
+    /// Sends typing events (keystroke/start/stop) for the current user.
+    private lazy var typingEventsSender: TypingEventsSender = TypingEventsSender(
+        database: client.databaseContainer,
+        apiClient: client.apiClient
+    )
+
+    /// The timer scheduler used for the auto-stop typing cleanup. Injectable for testing.
+    var timerType: TimerScheduling.Type = DefaultTimer.self
+
+    /// Per-user timers that synthesize a "stop typing" effect locally if a typing.stop event never arrives.
+    ///
+    /// Required because livestream channels bypass `TypingStartCleanupMiddleware`, which is responsible for
+    /// the timeout-based cleanup in regular channels.
+    private var typingCleanupTimers: [UserId: TimerControl] = [:]
+
     /// An internal backing object for all publicly available Combine publishers.
     var basePublishers: BasePublishers {
         if let value = _basePublishers as? BasePublishers {
@@ -206,6 +220,8 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
             client.eventNotificationCenter.unregisterManualEventHandling(for: cid)
         }
         appStateObserver.unsubscribe(self)
+        typingCleanupTimers.values.forEach { $0.cancel() }
+        typingCleanupTimers.removeAll()
     }
 
     // MARK: - Public Methods
@@ -796,6 +812,105 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         }
     }
 
+    // MARK: - Typing
+
+    /// Sends the start typing event and schedules a timer to send the stop typing event.
+    ///
+    /// This method is meant to be called every time the user presses a key. The method will manage requests and timer as needed.
+    ///
+    /// - Parameters:
+    ///   - parentMessageId: A message id of the message in a thread the user is replying to.
+    ///   - completion: a completion block with an error if the request was failed.
+    public func sendKeystrokeEvent(
+        parentMessageId: MessageId? = nil,
+        completion: (@MainActor (Error?) -> Void)? = nil
+    ) {
+        guard let cid = cid else {
+            callback {
+                completion?(ClientError.ChannelNotCreatedYet())
+            }
+            return
+        }
+        guard canSendTypingEvents else {
+            callback { completion?(nil) }
+            return
+        }
+        typingEventsSender.keystroke(in: cid, parentMessageId: parentMessageId) { [weak self] error in
+            self?.callback { completion?(error) }
+        }
+    }
+
+    /// Sends the start typing event.
+    ///
+    /// For the majority of cases, you don't need to call `sendStartTypingEvent` directly. Instead, use `sendKeystrokeEvent`
+    /// method and call it every time the user presses a key. The controller will manage
+    /// `sendStartTypingEvent`/`sendStopTypingEvent` calls automatically.
+    ///
+    /// - Parameters:
+    ///   - parentMessageId: A message id of the message in a thread the user is replying to.
+    ///   - completion: a completion block with an error if the request was failed.
+    public func sendStartTypingEvent(
+        parentMessageId: MessageId? = nil,
+        completion: (@MainActor (Error?) -> Void)? = nil
+    ) {
+        guard let cid = cid else {
+            callback {
+                completion?(ClientError.ChannelNotCreatedYet())
+            }
+            return
+        }
+        guard canSendTypingEvents else {
+            callback {
+                completion?(ClientError.ChannelFeatureDisabled("Channel feature: typing events is disabled for this channel."))
+            }
+            return
+        }
+        typingEventsSender.startTyping(in: cid, parentMessageId: parentMessageId) { [weak self] error in
+            self?.callback { completion?(error) }
+        }
+    }
+
+    /// Sends the stop typing event.
+    ///
+    /// For the majority of cases, you don't need to call `sendStopTypingEvent` directly. Instead, use `sendKeystrokeEvent`
+    /// method and call it every time the user presses a key. The controller will manage
+    /// `sendStartTypingEvent`/`sendStopTypingEvent` calls automatically.
+    ///
+    /// - Parameters:
+    ///   - parentMessageId: A message id of the message in a thread the user is replying to.
+    ///   - completion: a completion block with an error if the request was failed.
+    public func sendStopTypingEvent(
+        parentMessageId: MessageId? = nil,
+        completion: (@MainActor (Error?) -> Void)? = nil
+    ) {
+        guard let cid = cid else {
+            callback {
+                completion?(ClientError.ChannelNotCreatedYet())
+            }
+            return
+        }
+        guard canSendTypingEvents else {
+            callback {
+                completion?(ClientError.ChannelFeatureDisabled("Channel feature: typing events is disabled for this channel."))
+            }
+            return
+        }
+        typingEventsSender.stopTyping(in: cid, parentMessageId: parentMessageId) { [weak self] error in
+            self?.callback { completion?(error) }
+        }
+    }
+
+    /// A boolean value indicating if typing events can be sent.
+    ///
+    /// It is `true` if the channel has the `sendTypingEvents` capability. Unlike `ChatChannelController`,
+    /// this does not consult the user's privacy settings (`isTypingIndicatorsEnabled`) since the
+    /// livestream controller is intentionally decoupled from the local database. If you need to respect the
+    /// current user's typing privacy preference, gate the call site on the value of
+    /// `client.currentUserController().currentUser?.privacySettings.typingIndicators?.enabled`.
+    private var canSendTypingEvents: Bool {
+        channel?.canSendTypingEvents ?? true
+    }
+
     /// Pauses the collecting of new messages.
     ///
     /// When paused, new messages from other users will not be added to the messages array.
@@ -1083,8 +1198,63 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
                 messages = []
             }
 
+        case let typingEvent as TypingEvent:
+            handleTypingEvent(typingEvent)
+
         default:
             break
+        }
+    }
+
+    private func handleTypingEvent(_ event: TypingEvent) {
+        // The current user's typing state is sent over the wire, but we don't want to render
+        // ourselves in our own typing indicator. This matches `TypingStartCleanupMiddleware`.
+        guard event.user.id != currentUserId else { return }
+
+        // Thread typing events should not affect the channel-level typing indicator.
+        guard event.parentId == nil else { return }
+
+        var typingUsers = channel?.currentlyTypingUsers ?? []
+        if event.isTyping {
+            typingUsers.insert(event.user)
+            scheduleTypingCleanup(for: event.user)
+        } else {
+            typingUsers.remove(event.user)
+            cancelTypingCleanup(for: event.user.id)
+        }
+
+        updateCurrentlyTypingUsers(typingUsers)
+    }
+
+    private func scheduleTypingCleanup(for user: ChatUser) {
+        cancelTypingCleanup(for: user.id)
+        typingCleanupTimers[user.id] = timerType.schedule(
+            timeInterval: .incomingTypingStartEventTimeout,
+            queue: .main
+        ) { [weak self] in
+            self?.removeTypingUser(user)
+        }
+    }
+
+    private func cancelTypingCleanup(for userId: UserId) {
+        typingCleanupTimers[userId]?.cancel()
+        typingCleanupTimers[userId] = nil
+    }
+
+    private func removeTypingUser(_ user: ChatUser) {
+        cancelTypingCleanup(for: user.id)
+        guard var typingUsers = channel?.currentlyTypingUsers, typingUsers.contains(user) else { return }
+        typingUsers.remove(user)
+        updateCurrentlyTypingUsers(typingUsers)
+    }
+
+    private func updateCurrentlyTypingUsers(_ typingUsers: Set<ChatUser>) {
+        let previousTypingUsers = channel?.currentlyTypingUsers
+        channel = channel?.changing(currentlyTypingUsers: typingUsers)
+        guard previousTypingUsers != typingUsers else { return }
+        delegateCallback { [weak self] in
+            guard let self else { return }
+            $0.livestreamChannelController(self, didChangeTypingUsers: typingUsers)
         }
     }
 
@@ -1311,6 +1481,15 @@ public protocol LivestreamChannelControllerDelegate: AnyObject {
         _ controller: LivestreamChannelController,
         didChangeSkippedMessagesAmount skippedMessagesAmount: Int
     )
+
+    /// Called when the set of currently typing users in the channel changes.
+    /// - Parameters:
+    ///   - controller: The controller that updated.
+    ///   - typingUsers: The current set of users typing in the channel (excludes thread typing events).
+    func livestreamChannelController(
+        _ controller: LivestreamChannelController,
+        didChangeTypingUsers typingUsers: Set<ChatUser>
+    )
 }
 
 // MARK: - Default Implementations
@@ -1334,6 +1513,11 @@ public extension LivestreamChannelControllerDelegate {
     func livestreamChannelController(
         _ controller: LivestreamChannelController,
         didChangeSkippedMessagesAmount skippedMessagesAmount: Int
+    ) {}
+
+    func livestreamChannelController(
+        _ controller: LivestreamChannelController,
+        didChangeTypingUsers typingUsers: Set<ChatUser>
     ) {}
 }
 

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -901,12 +901,6 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
     }
 
     /// A boolean value indicating if typing events can be sent.
-    ///
-    /// It is `true` if the channel has the `sendTypingEvents` capability. Unlike `ChatChannelController`,
-    /// this does not consult the user's privacy settings (`isTypingIndicatorsEnabled`) since the
-    /// livestream controller is intentionally decoupled from the local database. If you need to respect the
-    /// current user's typing privacy preference, gate the call site on the value of
-    /// `client.currentUserController().currentUser?.privacySettings.typingIndicators?.enabled`.
     private var canSendTypingEvents: Bool {
         channel?.canSendTypingEvents ?? true
     }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1249,9 +1249,14 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
     }
 
     private func updateCurrentlyTypingUsers(_ typingUsers: Set<ChatUser>) {
-        // Bail out before mutating `channel` so we don't trigger `didUpdateChannel`
-        // (or a new `ChatChannel` struct copy) on every redundant typing event.
-        guard channel?.currentlyTypingUsers != typingUsers else { return }
+        // Compare by user id only. `Set<ChatUser>.==` falls back to `ChatUser.Equatable`,
+        // which checks ~13 fields including `lastActiveAt` and `extraData`. The server
+        // refreshes those on each re-emitted `typing.start`, so a strict comparison would
+        // report a change for every keystroke from an already-typing user and fire
+        // `didUpdateChannel` (plus rebuild the `ChatChannel` struct) for free.
+        let previousIds = Set((channel?.currentlyTypingUsers ?? []).map(\.id))
+        let newIds = Set(typingUsers.map(\.id))
+        guard previousIds != newIds else { return }
         channel = channel?.changing(currentlyTypingUsers: typingUsers)
         delegateCallback { [weak self] in
             guard let self else { return }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -878,7 +878,7 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
     private func sendTypingEvent(
         failsWhenDisabled: Bool,
         completion: (@MainActor (Error?) -> Void)?,
-        send: (ChannelId, @escaping (Error?) -> Void) -> Void
+        send: (ChannelId, @escaping @Sendable (Error?) -> Void) -> Void
     ) {
         guard let cid = cid else {
             callback { completion?(ClientError.ChannelNotCreatedYet()) }

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChannelController.swift
@@ -1226,12 +1226,15 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
     }
 
     private func scheduleTypingCleanup(for user: ChatUser) {
-        cancelTypingCleanup(for: user.id)
-        typingCleanupTimers[user.id] = timerType.schedule(
+        let userId = user.id
+        cancelTypingCleanup(for: userId)
+        // Capture only `userId` so the timer doesn't retain a full `ChatUser` value
+        // (and the strings/dates it references) for up to 30 seconds.
+        typingCleanupTimers[userId] = timerType.schedule(
             timeInterval: .incomingTypingStartEventTimeout,
             queue: .main
         ) { [weak self] in
-            self?.removeTypingUser(user)
+            self?.removeTypingUser(withId: userId)
         }
     }
 
@@ -1240,11 +1243,11 @@ public class LivestreamChannelController: DataStoreProvider, AppStateObserverDel
         typingCleanupTimers[userId] = nil
     }
 
-    private func removeTypingUser(_ user: ChatUser) {
-        cancelTypingCleanup(for: user.id)
+    private func removeTypingUser(withId userId: UserId) {
+        cancelTypingCleanup(for: userId)
         guard let currentTypingUsers = channel?.currentlyTypingUsers,
-              currentTypingUsers.contains(where: { $0.id == user.id }) else { return }
-        let typingUsers = currentTypingUsers.filter { $0.id != user.id }
+              currentTypingUsers.contains(where: { $0.id == userId }) else { return }
+        let typingUsers = currentTypingUsers.filter { $0.id != userId }
         updateCurrentlyTypingUsers(typingUsers)
     }
 

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -325,6 +325,7 @@ public struct ChatChannel: Sendable {
         cooldownDuration: Int? = nil,
         pinnedMessages: [ChatMessage]? = nil,
         pushPreference: PushPreference? = nil,
+        currentlyTypingUsers: Set<ChatUser>? = nil,
         extraData: [String: RawJSON]? = nil
     ) -> ChatChannel {
         .init(
@@ -346,7 +347,7 @@ public struct ChatChannel: Sendable {
             isBlocked: isBlocked ?? self.isBlocked,
             lastActiveMembers: members ?? lastActiveMembers,
             membership: membership ?? self.membership,
-            currentlyTypingUsers: currentlyTypingUsers,
+            currentlyTypingUsers: currentlyTypingUsers ?? self.currentlyTypingUsers,
             lastActiveWatchers: watchers ?? lastActiveWatchers,
             team: team ?? self.team,
             unreadCount: unreadCount,

--- a/Sources/StreamChat/Workers/ManualEventHandler.swift
+++ b/Sources/StreamChat/Workers/ManualEventHandler.swift
@@ -81,6 +81,9 @@ class ManualEventHandler: @unchecked Sendable {
         case .reactionDeleted:
             return createReactionDeletedEvent(from: eventPayload, cid: cid)
 
+        case .userStartTyping, .userStopTyping:
+            return createTypingEvent(from: eventPayload, cid: cid)
+
         default:
             return nil
         }
@@ -199,6 +202,21 @@ class ManualEventHandler: @unchecked Sendable {
             cid: cid,
             message: message,
             reaction: reactionPayload.asModel(messageId: messagePayload.id),
+            createdAt: createdAt
+        )
+    }
+
+    private func createTypingEvent(from payload: EventPayload, cid: ChannelId) -> TypingEvent? {
+        guard
+            let userPayload = payload.user,
+            let createdAt = payload.createdAt
+        else { return nil }
+
+        return TypingEvent(
+            isTyping: payload.eventType == .userStartTyping,
+            cid: cid,
+            user: userPayload.asModel(),
+            parentId: payload.parentId,
             createdAt: createdAt
         )
     }

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -3450,7 +3450,7 @@ extension LivestreamChannelController_Tests {
         XCTAssertEqual(controller.channel?.currentlyTypingUsers, [])
     }
 
-    func test_didReceiveEvent_typingStartEvent_replacesStaleUserMetadata() {
+    func test_didReceiveEvent_typingStartEvent_forAlreadyTypingUser_doesNotDuplicateEntry() {
         // Given
         loadChannel()
         let userId = UserId.unique
@@ -3478,12 +3478,60 @@ extension LivestreamChannelController_Tests {
             )
         )
 
-        // Then we should have a single entry reflecting the latest metadata,
-        // not two stale entries with the same id.
+        // Then we still have a single entry for that user (no duplicate). The cached
+        // user-metadata is intentionally NOT refreshed mid-session: a same-id update
+        // is treated as a no-op so we don't broadcast `didUpdateChannel` on every
+        // re-emitted `typing.start`. The user is removed via auto-cleanup or an
+        // explicit `typing.stop`.
         let typingUsers = controller.channel?.currentlyTypingUsers ?? []
         XCTAssertEqual(typingUsers.count, 1)
         XCTAssertEqual(typingUsers.first?.id, userId)
-        XCTAssertEqual(typingUsers.first?.isOnline, true)
+    }
+
+    @MainActor
+    func test_didReceiveEvent_typingStart_withRefreshedUserMetadata_doesNotFireDelegatesAgain() {
+        // Given
+        loadChannel()
+        let delegate = LivestreamChannelControllerDelegate_Mock()
+        controller.delegate = delegate
+        let userId = UserId.unique
+
+        // First typing.start adds the user.
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: .mock(id: userId, name: "Alice", lastActiveAt: .init(timeIntervalSince1970: 100)),
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+        AssertAsync.willBeTrue(delegate.didChangeTypingUsersCalled)
+        AssertAsync.willBeTrue(delegate.didUpdateChannelCalled)
+        delegate.didChangeTypingUsersCalled = false
+        delegate.didUpdateChannelCalled = false
+
+        // When a second typing.start arrives for the same user id but with refreshed
+        // server metadata (e.g. an updated `lastActiveAt`). `Set<ChatUser>.==` would
+        // otherwise report this as a change because `ChatUser.Equatable` compares
+        // ~13 fields, and the controller would fire `didUpdateChannel` on every
+        // keystroke from an already-typing user.
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: .mock(id: userId, name: "Alice", lastActiveAt: .init(timeIntervalSince1970: 200)),
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then neither delegate should fire again because the typing-user set is
+        // unchanged when compared by id.
+        AssertAsync {
+            Assert.staysFalse(delegate.didChangeTypingUsersCalled)
+            Assert.staysFalse(delegate.didUpdateChannelCalled)
+        }
     }
 
     @MainActor

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -3765,6 +3765,42 @@ extension LivestreamChannelController_Tests {
         waitForExpectations(timeout: defaultTimeout)
         XCTAssertTrue(receivedError is ClientError.ChannelFeatureDisabled)
     }
+
+    func test_sendTypingEvents_whenChannelIsNotLoaded_doesNotHitTypingEventsSender() {
+        // Given - controller starts with `channel == nil` from setUp(), so we have no idea
+        // whether typing events are enabled. The conservative default is to treat them as
+        // disabled rather than fire API requests that may not be supported.
+        let apiClient = client.mockAPIClient
+        XCTAssertNil(controller.channel)
+
+        let keystrokeExp = expectation(description: "keystroke completion called")
+        let startExp = expectation(description: "start typing completion called")
+        let stopExp = expectation(description: "stop typing completion called")
+        nonisolated(unsafe) var keystrokeError: Error?
+        nonisolated(unsafe) var startError: Error?
+        nonisolated(unsafe) var stopError: Error?
+
+        // When
+        controller.sendKeystrokeEvent { error in
+            keystrokeError = error
+            keystrokeExp.fulfill()
+        }
+        controller.sendStartTypingEvent { error in
+            startError = error
+            startExp.fulfill()
+        }
+        controller.sendStopTypingEvent { error in
+            stopError = error
+            stopExp.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: defaultTimeout)
+        XCTAssertNil(apiClient.request_endpoint)
+        XCTAssertNil(keystrokeError)
+        XCTAssertTrue(startError is ClientError.ChannelFeatureDisabled)
+        XCTAssertTrue(stopError is ClientError.ChannelFeatureDisabled)
+    }
 }
 
 class MockPaginationStateHandler: MessagesPaginationStateHandling, @unchecked Sendable {

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -3415,6 +3415,77 @@ extension LivestreamChannelController_Tests {
         XCTAssertEqual(controller.channel?.currentlyTypingUsers, [])
     }
 
+    func test_didReceiveEvent_typingStopEvent_removesUserEvenWhenUserMetadataChanged() {
+        // Given
+        loadChannel()
+        let userId = UserId.unique
+        let startUser = ChatUser.mock(id: userId, name: "Alice", isOnline: true, lastActiveAt: .init(timeIntervalSince1970: 100))
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: startUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers.map(\.id), [userId])
+
+        // When the typing.stop payload reflects updated metadata for the same user
+        // (e.g. a refreshed `lastActiveAt`), the user should still be removed from
+        // the set. `Set.remove` would otherwise no-op because `ChatUser.Equatable`
+        // compares many fields, leaving the indicator stuck visible.
+        let stopUser = ChatUser.mock(id: userId, name: "Alice", isOnline: true, lastActiveAt: .init(timeIntervalSince1970: 200))
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: false,
+                cid: controller.cid!,
+                user: stopUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers, [])
+    }
+
+    func test_didReceiveEvent_typingStartEvent_replacesStaleUserMetadata() {
+        // Given
+        loadChannel()
+        let userId = UserId.unique
+        let firstUser = ChatUser.mock(id: userId, name: "Alice", isOnline: false)
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: firstUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers.count, 1)
+
+        // When a second typing.start arrives for the same user id with updated metadata
+        let updatedUser = ChatUser.mock(id: userId, name: "Alice", isOnline: true)
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: updatedUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then we should have a single entry reflecting the latest metadata,
+        // not two stale entries with the same id.
+        let typingUsers = controller.channel?.currentlyTypingUsers ?? []
+        XCTAssertEqual(typingUsers.count, 1)
+        XCTAssertEqual(typingUsers.first?.id, userId)
+        XCTAssertEqual(typingUsers.first?.isOnline, true)
+    }
+
     func test_didReceiveEvent_typingEvent_fromCurrentUser_isIgnored() {
         // Given
         let currentUserId = UserId.unique

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -764,7 +764,10 @@ extension LivestreamChannelController_Tests {
         
         var didChangeSkippedMessagesAmountCalled = false
         var didChangeSkippedMessagesAmountCalledWith: Int?
-        
+
+        var didChangeTypingUsersCalled = false
+        var didChangeTypingUsersCalledWith: Set<ChatUser>?
+
         func livestreamChannelController(
             _ controller: LivestreamChannelController,
             didUpdateChannel channel: ChatChannel
@@ -795,6 +798,14 @@ extension LivestreamChannelController_Tests {
         ) {
             didChangeSkippedMessagesAmountCalled = true
             didChangeSkippedMessagesAmountCalledWith = skippedMessagesAmount
+        }
+
+        func livestreamChannelController(
+            _ controller: LivestreamChannelController,
+            didChangeTypingUsers typingUsers: Set<ChatUser>
+        ) {
+            didChangeTypingUsersCalled = true
+            didChangeTypingUsersCalledWith = typingUsers
         }
     }
 }
@@ -3333,6 +3344,318 @@ extension LivestreamChannelController_Tests {
         let expectedEndpoint = Endpoint<EmptyResponse>.freezeChannel(false, cid: controller.cid!)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
         XCTAssertNil(unfreezeError)
+    }
+}
+
+// MARK: - Typing Events Tests
+
+extension LivestreamChannelController_Tests {
+    private func loadChannel(
+        cid: ChannelId? = nil,
+        ownCapabilities: [ChannelCapability] = [.sendTypingEvents]
+    ) {
+        let cid = cid ?? controller.cid!
+        let exp = expectation(description: "sync completes")
+        controller.synchronize { _ in exp.fulfill() }
+        let channelPayload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid, ownCapabilities: ownCapabilities.map(\.rawValue))
+        )
+        client.mockAPIClient.test_simulateResponse(.success(channelPayload))
+        waitForExpectations(timeout: defaultTimeout)
+    }
+
+    // MARK: Receiving typing events
+
+    func test_didReceiveEvent_typingStartEvent_addsUserToTypingUsers() {
+        // Given
+        loadChannel()
+        let typingUser = ChatUser.mock(id: .unique)
+
+        // When
+        let event = TypingEvent(
+            isTyping: true,
+            cid: controller.cid!,
+            user: typingUser,
+            parentId: nil,
+            createdAt: .unique
+        )
+        controller.didReceiveEvent(event)
+
+        // Then
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers, [typingUser])
+    }
+
+    func test_didReceiveEvent_typingStopEvent_removesUserFromTypingUsers() {
+        // Given
+        loadChannel()
+        let typingUser = ChatUser.mock(id: .unique)
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers, [typingUser])
+
+        // When
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: false,
+                cid: controller.cid!,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers, [])
+    }
+
+    func test_didReceiveEvent_typingEvent_fromCurrentUser_isIgnored() {
+        // Given
+        let currentUserId = UserId.unique
+        client.mockAuthenticationRepository.mockedCurrentUserId = currentUserId
+        loadChannel()
+
+        // When
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: .mock(id: currentUserId),
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then
+        XCTAssertTrue(controller.channel?.currentlyTypingUsers.isEmpty ?? true)
+    }
+
+    func test_didReceiveEvent_typingEvent_inThread_doesNotAffectChannelTyping() {
+        // Given
+        loadChannel()
+
+        // When
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: .mock(id: .unique),
+                parentId: .unique,
+                createdAt: .unique
+            )
+        )
+
+        // Then
+        XCTAssertTrue(controller.channel?.currentlyTypingUsers.isEmpty ?? true)
+    }
+
+    func test_didReceiveEvent_typingEvent_forDifferentChannel_isIgnored() {
+        // Given
+        loadChannel()
+        let typingUser = ChatUser.mock(id: .unique)
+
+        // When
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: .unique,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then
+        XCTAssertTrue(controller.channel?.currentlyTypingUsers.isEmpty ?? true)
+    }
+
+    @MainActor func test_didReceiveEvent_typingEvent_callsDelegate() {
+        // Given
+        loadChannel()
+        let delegate = LivestreamChannelControllerDelegate_Mock()
+        controller.delegate = delegate
+        let typingUser = ChatUser.mock(id: .unique)
+
+        // When
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // Then
+        AssertAsync.willBeTrue(delegate.didChangeTypingUsersCalled)
+        AssertAsync.willBeEqual(delegate.didChangeTypingUsersCalledWith, [typingUser])
+    }
+
+    func test_didReceiveEvent_typingStart_autoCleansUp_afterTimeout() {
+        // Given
+        let virtualTime = VirtualTime()
+        VirtualTimeTimer.time = virtualTime
+        controller.timerType = VirtualTimeTimer.self
+        loadChannel()
+
+        let typingUser = ChatUser.mock(id: .unique)
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+        XCTAssertEqual(controller.channel?.currentlyTypingUsers, [typingUser])
+
+        // When
+        virtualTime.run(numberOfSeconds: .incomingTypingStartEventTimeout + 1)
+
+        // Then
+        XCTAssertTrue(controller.channel?.currentlyTypingUsers.isEmpty ?? false)
+
+        VirtualTimeTimer.invalidate()
+    }
+
+    func test_didReceiveEvent_typingStop_cancelsAutoCleanup() {
+        // Given
+        let virtualTime = VirtualTime()
+        VirtualTimeTimer.time = virtualTime
+        controller.timerType = VirtualTimeTimer.self
+        loadChannel()
+
+        let typingUser = ChatUser.mock(id: .unique)
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: true,
+                cid: controller.cid!,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+        // Stop typing before the timeout.
+        controller.didReceiveEvent(
+            TypingEvent(
+                isTyping: false,
+                cid: controller.cid!,
+                user: typingUser,
+                parentId: nil,
+                createdAt: .unique
+            )
+        )
+
+        // When - the timeout would have fired, but the timer must have been cancelled.
+        virtualTime.run(numberOfSeconds: .incomingTypingStartEventTimeout + 1)
+
+        // Then - typing set stays empty (and importantly the cleanup did not raise an error or re-trigger).
+        XCTAssertTrue(controller.channel?.currentlyTypingUsers.isEmpty ?? false)
+
+        VirtualTimeTimer.invalidate()
+    }
+
+    // MARK: Sending typing events
+
+    func test_sendKeystrokeEvent_callsCorrectEndpoint() {
+        // Given
+        loadChannel()
+        let apiClient = client.mockAPIClient
+
+        // When
+        controller.sendKeystrokeEvent()
+
+        // Then
+        let expectedEndpoint = Endpoint<EmptyResponse>.startTypingEvent(cid: controller.cid!, parentMessageId: nil)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
+    func test_sendKeystrokeEvent_withParentMessageId_callsCorrectEndpoint() {
+        // Given
+        loadChannel()
+        let apiClient = client.mockAPIClient
+        let parentMessageId = MessageId.unique
+
+        // When
+        controller.sendKeystrokeEvent(parentMessageId: parentMessageId)
+
+        // Then
+        let expectedEndpoint = Endpoint<EmptyResponse>.startTypingEvent(
+            cid: controller.cid!,
+            parentMessageId: parentMessageId
+        )
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
+    func test_sendStartTypingEvent_callsCorrectEndpoint() {
+        // Given
+        loadChannel()
+        let apiClient = client.mockAPIClient
+
+        // When
+        controller.sendStartTypingEvent()
+
+        // Then
+        let expectedEndpoint = Endpoint<EmptyResponse>.startTypingEvent(cid: controller.cid!, parentMessageId: nil)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
+    func test_sendStopTypingEvent_callsCorrectEndpoint() {
+        // Given
+        loadChannel()
+        let apiClient = client.mockAPIClient
+
+        // When
+        controller.sendStopTypingEvent()
+
+        // Then
+        let expectedEndpoint = Endpoint<EmptyResponse>.stopTypingEvent(cid: controller.cid!, parentMessageId: nil)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
+    func test_sendKeystrokeEvent_whenTypingEventsAreDisabled_doesNothing() {
+        // Given
+        loadChannel(ownCapabilities: [])
+        let apiClient = client.mockAPIClient
+        apiClient.cleanUp()
+        let exp = expectation(description: "completion called")
+        nonisolated(unsafe) var receivedError: Error?
+
+        // When
+        controller.sendKeystrokeEvent { error in
+            receivedError = error
+            exp.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: defaultTimeout)
+        XCTAssertNil(receivedError)
+        XCTAssertNil(apiClient.request_endpoint)
+    }
+
+    func test_sendStartTypingEvent_whenTypingEventsAreDisabled_errors() {
+        // Given
+        loadChannel(ownCapabilities: [])
+        let exp = expectation(description: "completion called")
+        nonisolated(unsafe) var receivedError: Error?
+
+        // When
+        controller.sendStartTypingEvent { error in
+            receivedError = error
+            exp.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: defaultTimeout)
+        XCTAssertTrue(receivedError is ClientError.ChannelFeatureDisabled)
     }
 }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChannelController_Tests.swift
@@ -3486,6 +3486,43 @@ extension LivestreamChannelController_Tests {
         XCTAssertEqual(typingUsers.first?.isOnline, true)
     }
 
+    @MainActor
+    func test_didReceiveEvent_duplicateTypingStart_doesNotFireDelegatesAgain() {
+        // Given
+        loadChannel()
+        let delegate = LivestreamChannelControllerDelegate_Mock()
+        controller.delegate = delegate
+        let typingUser = ChatUser.mock(id: .unique)
+        let event = TypingEvent(
+            isTyping: true,
+            cid: controller.cid!,
+            user: typingUser,
+            parentId: nil,
+            createdAt: .unique
+        )
+
+        // When the first typing.start arrives the user is added and both delegates fire.
+        controller.didReceiveEvent(event)
+        AssertAsync.willBeTrue(delegate.didChangeTypingUsersCalled)
+        AssertAsync.willBeTrue(delegate.didUpdateChannelCalled)
+
+        // Reset the flags before sending an identical typing.start for the same user
+        // (this happens in practice because senders re-emit `typing.start` periodically).
+        delegate.didChangeTypingUsersCalled = false
+        delegate.didUpdateChannelCalled = false
+
+        // When the duplicate event arrives
+        controller.didReceiveEvent(event)
+
+        // Then neither delegate should fire again, because the typing set is unchanged.
+        // Otherwise the controller would re-allocate `ChatChannel` and broadcast
+        // `didUpdateChannel` on every keystroke from every typing user.
+        AssertAsync {
+            Assert.staysFalse(delegate.didChangeTypingUsersCalled)
+            Assert.staysFalse(delegate.didUpdateChannelCalled)
+        }
+    }
+
     func test_didReceiveEvent_typingEvent_fromCurrentUser_isIgnored() {
         // Given
         let currentUserId = UserId.unique

--- a/Tests/StreamChatTests/Workers/ManualEventHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ManualEventHandler_Tests.swift
@@ -98,14 +98,15 @@ final class ManualEventHandler_Tests: XCTestCase {
     // MARK: - Event Handling - Unsupported Event Type
     
     func test_handle_unsupportedEventType_returnsNil() throws {
-        // Use a typing event which is not handled by ManualEventHandler
+        // Use a user watching event which is not handled by ManualEventHandler.
         let eventPayload = EventPayload(
-            eventType: .userStartTyping,
+            eventType: .userStartWatching,
             cid: cid,
             user: .dummy(userId: .unique),
+            watcherCount: 1,
             createdAt: .unique
         )
-        let eventDTO = try! TypingEventDTO(from: eventPayload)
+        let eventDTO = try! UserWatchingEventDTO(from: eventPayload)
         
         nonisolated(unsafe) var result: Event!
         try database.writeSynchronously { _ in
@@ -322,5 +323,95 @@ final class ManualEventHandler_Tests: XCTestCase {
         XCTAssertEqual(reactionDeletedEvent.cid, cid)
         XCTAssertEqual(reactionDeletedEvent.reaction.type, reactionType)
         XCTAssertEqual(reactionDeletedEvent.createdAt, createdAt)
+    }
+
+    // MARK: - Typing Events
+
+    func test_handle_typingStartEvent_withValidData_returnsEvent() throws {
+        let userId: UserId = .unique
+        let createdAt = Date.unique
+
+        let eventPayload = EventPayload(
+            eventType: .userStartTyping,
+            cid: cid,
+            user: .dummy(userId: userId),
+            createdAt: createdAt
+        )
+        let eventDTO = try! TypingEventDTO(from: eventPayload)
+
+        nonisolated(unsafe) var result: Event!
+        try database.writeSynchronously { _ in
+            result = self.handler.handle(eventDTO)
+        }
+
+        let typingEvent = try XCTUnwrap(result as? TypingEvent)
+        XCTAssertTrue(typingEvent.isTyping)
+        XCTAssertEqual(typingEvent.user.id, userId)
+        XCTAssertEqual(typingEvent.cid, cid)
+        XCTAssertEqual(typingEvent.createdAt, createdAt)
+        XCTAssertNil(typingEvent.parentId)
+        XCTAssertFalse(typingEvent.isThread)
+    }
+
+    func test_handle_typingStopEvent_withValidData_returnsEvent() throws {
+        let userId: UserId = .unique
+        let createdAt = Date.unique
+
+        let eventPayload = EventPayload(
+            eventType: .userStopTyping,
+            cid: cid,
+            user: .dummy(userId: userId),
+            createdAt: createdAt
+        )
+        let eventDTO = try! TypingEventDTO(from: eventPayload)
+
+        nonisolated(unsafe) var result: Event!
+        try database.writeSynchronously { _ in
+            result = self.handler.handle(eventDTO)
+        }
+
+        let typingEvent = try XCTUnwrap(result as? TypingEvent)
+        XCTAssertFalse(typingEvent.isTyping)
+        XCTAssertEqual(typingEvent.user.id, userId)
+        XCTAssertEqual(typingEvent.cid, cid)
+    }
+
+    func test_handle_typingEvent_inThread_returnsEventWithParentId() throws {
+        let parentMessageId: MessageId = .unique
+        let eventPayload = EventPayload(
+            eventType: .userStartTyping,
+            cid: cid,
+            user: .dummy(userId: .unique),
+            createdAt: .unique,
+            parentId: parentMessageId
+        )
+        let eventDTO = try! TypingEventDTO(from: eventPayload)
+
+        nonisolated(unsafe) var result: Event!
+        try database.writeSynchronously { _ in
+            result = self.handler.handle(eventDTO)
+        }
+
+        let typingEvent = try XCTUnwrap(result as? TypingEvent)
+        XCTAssertEqual(typingEvent.parentId, parentMessageId)
+        XCTAssertTrue(typingEvent.isThread)
+    }
+
+    func test_handle_typingEvent_onUnregisteredChannel_returnsNil() throws {
+        let unregisteredCid: ChannelId = .unique
+        let eventPayload = EventPayload(
+            eventType: .userStartTyping,
+            cid: unregisteredCid,
+            user: .dummy(userId: .unique),
+            createdAt: .unique
+        )
+        let eventDTO = try! TypingEventDTO(from: eventPayload)
+
+        nonisolated(unsafe) var result: Event!
+        try database.writeSynchronously { _ in
+            result = self.handler.handle(eventDTO)
+        }
+
+        XCTAssertNil(result)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

`LivestreamChannelController` operates without local Core Data persistence, but typing events were unsupported. This PR plugs the gap, so livestream channels get the same typing indicator experience as regular channels, while staying off the database.

### 📝 Summary

- Route `typing.start` and `typing.stop` events through `ManualEventHandler` for manually-handled channels (no Core Data writes).
- Add `sendKeystrokeEvent`, `sendStartTypingEvent`, and `sendStopTypingEvent` public APIs on `LivestreamChannelController`, gated by the channel's `canSendTypingEvents` capability.
- Replace `TypingStartCleanupMiddleware` for manually-handled channels with a per-user 30s auto-stop timer kept inside the controller.
- Expose the typing state to consumers via a new `livestreamChannelController(_:didChangeTypingUsers:)` delegate method and a `typingUsersPublisher` Combine publisher.
- Wire `DemoLivestreamChatChannelVC` to send keystroke / stop-typing events through the livestream controller and show/hide the typing indicator from the new delegate, mirroring `ChatChannelVC`..

### 🧪 Manual Testing Notes

1. Open the Livestream channel screen in the demo app from two users (or two simulators/devices).
2. With user A focused on the composer, start typing. The typing indicator should appear for user B within a second.
3. Stop typing in user A's composer. The indicator should hide on user B once `typing.stop` arrives, or at the latest after the 30s auto-cleanup timer.
4. Send a message from user A: the indicator should hide immediately on user B (we send `typing.stop` on submit).
5. Try typing in a thread reply: the channel-level indicator should not show (thread typing is intentionally ignored).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typing indicators for livestream channels (show who’s typing) with composer behavior to send keystrokes/start/stop typing and a real-time typing-users publisher.

* **Documentation**
  * Clarified upcoming notes and formatted an entry documenting an optional attachment field for uploaded files.

* **Tests**
  * Comprehensive typing-events tests for controllers, event handling, manual event parsing, and automatic cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swift/pull/4094)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->