### PR TITLE
[v4] Fix MarkdownParser crash on long markdown with many presentation intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix crash in `MarkdownParser` when parsing long messages with many presentation intents [#4099](https://github.com/GetStream/stream-chat-swift/pull/4099)
 
 # [4.100.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.100.0)
 _May 13, 2026_

--- a/Sources/StreamChat/Utils/MarkdownParser.swift
+++ b/Sources/StreamChat/Utils/MarkdownParser.swift
@@ -90,9 +90,27 @@ public struct MarkdownParser {
             }
         }
         
-        var previousPresentationIntentStyling: PresentationIntentStyling?
-        for (presentationIntent, range) in attributedString.runs[\.presentationIntent].reversed() {
+        let initialCharacters = attributedString.characters
+        var presentationIntentEntries: [(intent: PresentationIntent, lowerOffset: Int, upperOffset: Int)] = []
+        for (presentationIntent, range) in attributedString.runs[\.presentationIntent] {
             guard let presentationIntent else { continue }
+            let lowerOffset = initialCharacters.distance(from: initialCharacters.startIndex, to: range.lowerBound)
+            let upperOffset = initialCharacters.distance(from: initialCharacters.startIndex, to: range.upperBound)
+            presentationIntentEntries.append((presentationIntent, lowerOffset, upperOffset))
+        }
+        
+        // Remove presentation intent attributes from the final string because they are handled below.
+        attributedString = attributedString.transformingAttributes(\.presentationIntent) { attribute in
+            attribute.value = nil
+        }
+        
+        var previousPresentationIntentStyling: PresentationIntentStyling?
+        for entry in presentationIntentEntries.reversed() {
+            let presentationIntent = entry.intent
+            let currentCharacters = attributedString.characters
+            let lowerBound = currentCharacters.index(currentCharacters.startIndex, offsetBy: entry.lowerOffset)
+            let upperBound = currentCharacters.index(currentCharacters.startIndex, offsetBy: entry.upperOffset)
+            let range = lowerBound..<upperBound
             var presentationIntentStyling = PresentationIntentStyling(range: range, components: presentationIntent.components)
             
             for intentType in presentationIntent.components {
@@ -135,11 +153,6 @@ public struct MarkdownParser {
                     break
                 }
             }
-            // Remove presentation intent attribute from the final string because it has been handled
-            attributedString[range].replaceAttributes(
-                AttributeContainer().presentationIntent(presentationIntent),
-                with: AttributeContainer()
-            )
             // Paragraph applies to text and other intents
             if presentationIntentStyling.paragraphId != previousPresentationIntentStyling?.paragraphId {
                 presentationIntentStyling.succeedingNewlineCount += 1

--- a/Tests/StreamChatTests/Utils/MarkdownParser_Tests.swift
+++ b/Tests/StreamChatTests/Utils/MarkdownParser_Tests.swift
@@ -143,4 +143,104 @@ final class MarkdownParser_Tests: XCTestCase {
         let result = string.runs[\.link].compactMap { $0.0?.absoluteString }
         XCTAssertEqual(expected, result)
     }
+    
+    func test_style_doesNotCrashWithLongMarkdownContainingManyPresentationIntents() throws {
+        let text = """
+        How it works for the company
+        1. The company signs up with Lease a Bike
+
+        The employer registers on the Lease a Bike platform and defines the internal policy:
+
+        who is eligible
+        max bike budget (if any)
+        whether the company contributes financially
+        what happens if someone leaves early
+        whether commuting allowance changes
+        Typical setup time:
+        2. Employer chooses cost model
+
+        Most Dutch companies use one of these models:
+
+        Option A — Cost-neutral for employer (most common)
+        Because gross salary decreases:
+
+        employer pays less social security contributions
+        employee gets tax benefit
+
+        Lease a Bike claims employers save roughly €20–€25/month per leased bike in payroll taxes.
+        employer can offer the program with almost no extra cost
+        sometimes even slightly positive financially
+        Option B — Employer contributes
+        e.g. €25–€50/month contribution
+        often positioned as a mobility/wellness benefit
+
+        Very common in tech and corporate environments.
+
+        3. Employer approves employee requests
+        manager/HR gets approval request
+        one-click approval in the platform
+        Lease a Bike handles dealer + leasing admin
+
+        The employer mainly handles:
+
+        payroll deduction
+        monthly invoice
+        HR policy compliance
+        4. Monthly payroll administration
+
+        Every month:
+
+        employer receives invoice from Lease a Bike
+        payroll deducts agreed gross amount from employee salary
+        5. If employee leaves the company
+
+        employer settles remaining contract with leasing company
+        employee reimburses employer
+        affiliated bike shops
+        Lease a Bike dealer network
+        There are hundreds of brands available.
+        The agreement defines:
+        duration (usually 36 months)
+        insurance
+        maintenance
+        theft coverage
+        3. Employee receives tax advantage
+        Instead of paying from net salary:
+        employee pays less income tax
+        effective bike cost becomes much lower
+        sometimes more if employer contributes
+        4. Employee pays small "bijtelling"
+        €3,000 e-bike
+        taxable addition = €210/year
+        unlimited private use allowed
+        no minimum commuting requirement anymore
+        theft insurance
+        damage coverage
+        maintenance budget
+        roadside assistance
+        bike price = €3,500
+        lease term = 36 months
+        maintenance + insurance included
+        employer contributes €30/month
+        much cheaper than buying privately upfront
+        no large initial payment
+        services included
+        Why companies offer it
+        supports sustainability goals
+        promotes healthier commuting
+        helps employer branding
+        can reduce commuting reimbursements and sick days
+        For Amsterdam specifically, bike leasing has become almost a standard white-collar benefit now.
+
+        """
+        let result = try parser.style(
+            markdown: text,
+            options: MarkdownParser.ParsingOptions(),
+            attributes: AttributeContainer(),
+            inlinePresentationIntentAttributes: { _ in nil },
+            presentationIntentAttributes: { _, _ in nil }
+        )
+        let hasLeftoverPresentationIntent = result.runs[\.presentationIntent].contains { intent, _ in intent != nil }
+        XCTAssertFalse(hasLeftoverPresentationIntent, "MarkdownParser must clear NSPresentationIntent on the parsed output")
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1704](https://linear.app/stream/issue/IOS-1704)
- Backport of #4098

### 🎯 Goal

Fix `MarkdownParser` crash on long messages on the v4 release line.

### 📝 Summary

- Replace the per-run `attributedString[range].replaceAttributes(...)` (the trap site) with a single `transformingAttributes(\.presentationIntent)` pass that clears the attribute safely
- Capture presentation-intent ranges as character offsets so the styling/insertion loop can re-derive fresh `AttributedString.Index` values each iteration instead of holding indices across mutations
- Add a regression test that parses a long, presentation-intent-dense input and asserts no leftover `\.presentationIntent` attributes

### 🛠 Implementation

The crash trapped inside Foundation's `Rope._prepareModify` reached via `AttributedSubstring.replaceAttributes(_:with:)`. A standalone reproducer narrowed the root cause:

- `AttributedSubstring.replaceAttributes(_:with:)` traps on long inputs with many presentation-intent runs
- `mergeAttributes` and `setAttributes` on the same input do not trap
- `transformingAttributes(\.<key>)` is unaffected

The fix uses `transformingAttributes` (the safe transactional API) to clear all `\.presentationIntent` attributes in one pass. The presentation-intent loop now iterates pre-captured `(intent, lowerOffset, upperOffset)` tuples instead of live `attributedString.runs[\.presentationIntent].reversed()`; the body re-derives `AttributedString.Index` values from offsets each iteration so no index is held across a mutation.

This is a straight cherry-pick of the fix commit from #4098 — v4's `MarkdownParser.swift` matches `develop` at the patch site, so the patch applied cleanly.

### 🎨 Showcase

Not applicable — internal parsing change, no UI surface.

### 🧪 Manual Testing Notes

Paste a long markdown message into a chat (numbered list lines, blank lines, multiple paragraph breaks, ~3 kB+). Without the fix the parser traps via SIGTRAP inside Foundation; with the fix the message renders normally.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo