### PR TITLE
Forward CDN headers when generating local video previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix crash in `MarkdownParser` when parsing long messages with many presentation intents [#4098](https://github.com/GetStream/stream-chat-swift/pull/4098)
 
+## StreamChatCommonUI
+### 🐞 Fixed
+- Forward CDN authentication headers when generating local video preview thumbnails [#4105](https://github.com/GetStream/stream-chat-swift/pull/4105)
+
 # [5.2.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.2.0)
 _May 13, 2026_
 

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -177,9 +177,6 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
     /// Returns `nil` when there are no headers to forward. Otherwise returns a
     /// dictionary containing `AVURLAssetHTTPHeaderFieldsKey` so the asset's
     /// underlying network requests carry the CDN-provided authentication headers.
-    ///
-    /// Internal (not `private`) so the headers-forwarding contract can be
-    /// directly unit-tested via `@testable import`.
     func assetOptions(for cdnRequest: CDNRequest) -> [String: Any]? {
         guard let headers = cdnRequest.headers, !headers.isEmpty else { return nil }
         return ["AVURLAssetHTTPHeaderFieldsKey": headers]

--- a/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
+++ b/Sources/StreamChatCommonUI/ImageLoading/StreamMediaLoader.swift
@@ -94,14 +94,16 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
         options: VideoLoadOptions,
         completion: @escaping @MainActor (Result<MediaLoaderVideoAsset, Error>) -> Void
     ) {
-        cdnRequester.fileRequest(for: url, options: .init()) { result in
+        cdnRequester.fileRequest(for: url, options: .init()) { [weak self] result in
+            guard let self else {
+                StreamConcurrency.onMain {
+                    completion(.failure(ClientError.Unknown("MediaLoader was deallocated")))
+                }
+                return
+            }
             switch result {
             case let .success(cdnRequest):
-                var assetOptions: [String: Any] = [:]
-                if let headers = cdnRequest.headers, !headers.isEmpty {
-                    assetOptions["AVURLAssetHTTPHeaderFieldsKey"] = headers
-                }
-                let asset = AVURLAsset(url: cdnRequest.url, options: assetOptions.isEmpty ? nil : assetOptions)
+                let asset = self.makeAVURLAsset(from: cdnRequest)
                 StreamConcurrency.onMain {
                     completion(.success(MediaLoaderVideoAsset(asset: asset)))
                 }
@@ -169,6 +171,26 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
 
     // MARK: - Private
 
+    /// Builds the options dictionary used when constructing the `AVURLAsset`
+    /// for a video URL returned by the CDN.
+    ///
+    /// Returns `nil` when there are no headers to forward. Otherwise returns a
+    /// dictionary containing `AVURLAssetHTTPHeaderFieldsKey` so the asset's
+    /// underlying network requests carry the CDN-provided authentication headers.
+    ///
+    /// Internal (not `private`) so the headers-forwarding contract can be
+    /// directly unit-tested via `@testable import`.
+    func assetOptions(for cdnRequest: CDNRequest) -> [String: Any]? {
+        guard let headers = cdnRequest.headers, !headers.isEmpty else { return nil }
+        return ["AVURLAssetHTTPHeaderFieldsKey": headers]
+    }
+
+    /// Constructs an `AVURLAsset` from a `CDNRequest`, forwarding any CDN headers
+    /// so the asset's network requests are authenticated against signed CDNs.
+    private func makeAVURLAsset(from cdnRequest: CDNRequest) -> AVURLAsset {
+        AVURLAsset(url: cdnRequest.url, options: assetOptions(for: cdnRequest))
+    }
+
     private func generateVideoPreview(
         for url: URL,
         options: VideoLoadOptions,
@@ -182,10 +204,10 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
                 return
             }
 
-            let adjustedUrl: URL
+            let asset: AVURLAsset
             switch result {
             case let .success(cdnRequest):
-                adjustedUrl = cdnRequest.url
+                asset = self.makeAVURLAsset(from: cdnRequest)
             case let .failure(error):
                 StreamConcurrency.onMain {
                     completion(.failure(error))
@@ -193,7 +215,6 @@ open class StreamMediaLoader: MediaLoader, @unchecked Sendable {
                 return
             }
 
-            let asset = AVURLAsset(url: adjustedUrl)
             let imageGenerator = AVAssetImageGenerator(asset: asset)
             let frameTime = CMTime(seconds: 0.1, preferredTimescale: 600)
 

--- a/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Video_Tests.swift
+++ b/Tests/StreamChatCommonUITests/ImageLoading/StreamMediaLoader_Video_Tests.swift
@@ -121,6 +121,36 @@ final class StreamMediaLoader_Video_Tests: XCTestCase {
         waitForExpectations(timeout: 2)
     }
 
+    // MARK: - Asset options
+
+    func test_assetOptions_withHeaders_forwardsHeadersViaHTTPHeaderFieldsKey() {
+        let headers = ["Authorization": "Bearer abc", "X-Custom": "value"]
+        let cdnRequest = CDNRequest(
+            url: URL(string: "https://cdn.example.com/video.mp4")!,
+            headers: headers
+        )
+
+        let options = sut.assetOptions(for: cdnRequest)
+
+        let forwarded = options?["AVURLAssetHTTPHeaderFieldsKey"] as? [String: String]
+        XCTAssertEqual(forwarded, headers)
+    }
+
+    func test_assetOptions_withNilHeaders_returnsNil() {
+        let cdnRequest = CDNRequest(url: URL(string: "https://cdn.example.com/video.mp4")!)
+
+        XCTAssertNil(sut.assetOptions(for: cdnRequest))
+    }
+
+    func test_assetOptions_withEmptyHeaders_returnsNil() {
+        let cdnRequest = CDNRequest(
+            url: URL(string: "https://cdn.example.com/video.mp4")!,
+            headers: [:]
+        )
+
+        XCTAssertNil(sut.assetOptions(for: cdnRequest))
+    }
+
     // MARK: - Video preview caching
 
     func test_loadVideoPreview_secondCall_usesCacheAndSkipsCDN() {


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Fix a regression in `StreamMediaLoader` where local video preview thumbnails fail to load for videos served from authenticated/signed CDNs.

### 📝 Summary

- `StreamMediaLoader.generateVideoPreview` now forwards the CDN headers to `AVURLAsset`, matching `loadVideoAsset`.
- Extracts the asset-construction logic into a shared private helper so both call sites can't drift again.
- Adds unit tests for the headers-forwarding contract (`assetOptions(for:)`).

### 🛠 Implementation

`generateVideoPreview` was calling `cdnRequester.fileRequest(for:)` to obtain the signed URL and any authentication headers, but it constructed the asset as `AVURLAsset(url: adjustedUrl)` — silently dropping `cdnRequest.headers`. For self-hosted/authenticated CDNs, the resulting `AVAssetImageGenerator` request reached the server without `Authorization` / custom headers and failed, so local preview thumbnails for authenticated videos never rendered. `loadVideoAsset` had the correct behaviour all along (passing headers via `AVURLAssetHTTPHeaderFieldsKey`), so the two call sites were inconsistent.

The fix extracts the asset-construction logic into two helpers on `StreamMediaLoader`:

- `assetOptions(for:)` — pure helper that returns the options dictionary (or `nil` when there are no headers). Kept `internal` (not `private`) so the headers-forwarding contract is directly unit-testable via `@testable import`.
- `makeAVURLAsset(from:)` — private convenience that composes `AVURLAsset(url:options:)` with `assetOptions(for:)`.

Both `loadVideoAsset` and `generateVideoPreview` now route through `makeAVURLAsset(from:)`, so they can't drift again. `loadVideoAsset` now uses `[weak self]` + a "MediaLoader was deallocated" failure fallback for symmetry with `generateVideoPreview`.

I considered the reporter's alternative suggestion to have the preview path delegate to `loadVideoAsset`, but it would force constructing/discarding a `MediaLoaderVideoAsset` wrapper and change behaviour more than necessary. The shared helper gives the same correctness with a smaller blast radius.

### 🧪 Manual Testing Notes

- Configure a `CDNRequester` (or use the default `StreamCDNRequester` against a private/signed CDN) that returns non-empty `headers` from `fileRequest(for:options:)`.
- Send/render a video attachment without a remote thumbnail (so `generateVideoPreview` runs).
- Before the fix: the preview is blank because `AVAssetImageGenerator` fails authentication; after the fix: the thumbnail renders.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CDN authentication headers are now correctly forwarded when generating local video preview thumbnails.

* **Tests**
  * Added tests verifying header forwarding and correct behavior when CDN headers are nil or empty.

* **Documentation**
  * Added a changelog entry documenting the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swift/pull/4105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->