### PR TITLE
Fix reconnection data race leaving WebSocket stuck at .disconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Fix WebSocket reconnection getting stuck in `.disconnecting` after the device temporarily loses network connectivity
+- Fix WebSocket reconnection getting stuck in `.disconnecting` after the device temporarily loses network connectivity [#4109](https://github.com/GetStream/stream-chat-swift/pull/4109)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix WebSocket reconnection getting stuck in `.disconnecting` after the device temporarily loses network connectivity
+
 ### 🔄 Changed
 
 # [4.100.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.100.1)

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -50,8 +50,9 @@ class WebSocketClient {
     /// The web socket engine used to make the actual WS connection
     @Atomic private(set) var engine: WebSocketEngine?
 
-    /// The queue on which web socket engine methods are called
-    private let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queue", qos: .userInitiated)
+    /// The queue on which web socket engine methods are called.
+    /// Also used by the connection recovery handler to serialize check-and-act sequences against engine state mutations.
+    let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queue", qos: .userInitiated)
 
     private let requestEncoder: RequestEncoder
 

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -108,9 +108,7 @@ extension DefaultConnectionRecoveryHandler {
 
         backgroundTaskScheduler?.endTask()
 
-        if canReconnectFromOffline {
-            webSocketClient.connect()
-        }
+        reconnectIfNeededFromOffline()
     }
 
     private func appDidEnterBackground() {
@@ -151,9 +149,7 @@ extension DefaultConnectionRecoveryHandler {
         log.debug("Internet -> \(isAvailable ? "✅" : "❌")", subsystems: .webSocket)
 
         if isAvailable {
-            if canReconnectFromOffline {
-                webSocketClient.connect()
-            }
+            reconnectIfNeededFromOffline()
         } else {
             disconnectIfNeeded()
         }
@@ -201,11 +197,52 @@ extension DefaultConnectionRecoveryHandler {
 // MARK: - Disconnection
 
 private extension DefaultConnectionRecoveryHandler {
+    /// Asks the web socket client to disconnect when the system decides we should drop the connection
+    /// (app went to background, internet became unavailable, background task expired, etc.).
+    ///
+    /// The work is dispatched onto `WebSocketClient.engineQueue` to serialize the check-and-act
+    /// (`canBeDisconnected` read + `webSocketClient.disconnect(...)` call) against the engine's
+    /// own state mutations. All `WebSocketEngineDelegate` callbacks — `webSocketDidConnect`,
+    /// `webSocketDidReceiveMessage`, `webSocketDidDisconnect` — run on `engineQueue` and mutate
+    /// `WebSocketClient.connectionState`. By piggy-backing on the same serial queue, our decision
+    /// cannot interleave with theirs.
+    ///
+    /// Bug this prevents: this method is called from multiple queues (main thread for app lifecycle
+    /// events, `io.getStream.chat.internet-monitor` for reachability changes). Previously the flow was:
+    ///
+    ///   1. `canBeDisconnected` reads `connectionState == .connected` on the internet-monitor queue → returns `true`.
+    ///   2. Meanwhile on `engineQueue`, `webSocketDidDisconnect` fires (Wi-Fi just dropped) and sets state to
+    ///      `.disconnected(.serverInitiated)`.
+    ///   3. The internet-monitor queue resumes and unconditionally calls `disconnect(source: .systemInitiated)`,
+    ///      which writes `.disconnecting(.systemInitiated)`, overwriting the legitimate `.disconnected`.
+    ///   4. The engine has already closed the socket, so no further `webSocketDidDisconnect` fires to
+    ///      transition `.disconnecting → .disconnected`. State stays stuck at `.disconnecting`.
+    ///   5. When Wi-Fi returns, automatic reconnection is rejected because the state's
+    ///      `isAutomaticReconnectionEnabled` only matches `.disconnected`. The client never recovers.
+    ///
+    /// With this dispatch, the two writers are serialized on the same queue, so either ordering
+    /// ends at `.disconnected` — no stuck `.disconnecting` state.
     func disconnectIfNeeded() {
-        guard canBeDisconnected else { return }
+        webSocketClient.engineQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard self.canBeDisconnected else { return }
 
-        webSocketClient.disconnect(source: .systemInitiated) {
-            log.debug("Did disconnect automatically", subsystems: .webSocket)
+            self.webSocketClient.disconnect(source: .systemInitiated) {
+                log.debug("Did disconnect automatically", subsystems: .webSocket)
+            }
+        }
+    }
+
+    /// Asks the web socket client to reconnect when conditions allow it (app foregrounding,
+    /// internet returning). Mirrors `disconnectIfNeeded`: the check (`canReconnectFromOffline`)
+    /// and the act (`webSocketClient.connect()`) are dispatched onto `engineQueue` so they cannot
+    /// race with the engine's own state mutations.
+    func reconnectIfNeededFromOffline() {
+        webSocketClient.engineQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard self.canReconnectFromOffline else { return }
+
+            self.webSocketClient.connect()
         }
     }
 
@@ -245,8 +282,11 @@ private extension DefaultConnectionRecoveryHandler {
             onFire: { [weak self] in
                 log.debug("Timer 🔥", subsystems: .webSocket)
 
-                if self?.canReconnectAutomatically == true {
-                    self?.webSocketClient.connect()
+                self?.webSocketClient.engineQueue.async { [weak self] in
+                    guard let self = self else { return }
+                    guard self.canReconnectAutomatically else { return }
+
+                    self.webSocketClient.connect()
                 }
             }
         )

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -197,31 +197,11 @@ extension DefaultConnectionRecoveryHandler {
 // MARK: - Disconnection
 
 private extension DefaultConnectionRecoveryHandler {
-    /// Asks the web socket client to disconnect when the system decides we should drop the connection
-    /// (app went to background, internet became unavailable, background task expired, etc.).
-    ///
-    /// The work is dispatched onto `WebSocketClient.engineQueue` to serialize the check-and-act
-    /// (`canBeDisconnected` read + `webSocketClient.disconnect(...)` call) against the engine's
-    /// own state mutations. All `WebSocketEngineDelegate` callbacks — `webSocketDidConnect`,
-    /// `webSocketDidReceiveMessage`, `webSocketDidDisconnect` — run on `engineQueue` and mutate
-    /// `WebSocketClient.connectionState`. By piggy-backing on the same serial queue, our decision
-    /// cannot interleave with theirs.
-    ///
-    /// Bug this prevents: this method is called from multiple queues (main thread for app lifecycle
-    /// events, `io.getStream.chat.internet-monitor` for reachability changes). Previously the flow was:
-    ///
-    ///   1. `canBeDisconnected` reads `connectionState == .connected` on the internet-monitor queue → returns `true`.
-    ///   2. Meanwhile on `engineQueue`, `webSocketDidDisconnect` fires (Wi-Fi just dropped) and sets state to
-    ///      `.disconnected(.serverInitiated)`.
-    ///   3. The internet-monitor queue resumes and unconditionally calls `disconnect(source: .systemInitiated)`,
-    ///      which writes `.disconnecting(.systemInitiated)`, overwriting the legitimate `.disconnected`.
-    ///   4. The engine has already closed the socket, so no further `webSocketDidDisconnect` fires to
-    ///      transition `.disconnecting → .disconnected`. State stays stuck at `.disconnecting`.
-    ///   5. When Wi-Fi returns, automatic reconnection is rejected because the state's
-    ///      `isAutomaticReconnectionEnabled` only matches `.disconnected`. The client never recovers.
-    ///
-    /// With this dispatch, the two writers are serialized on the same queue, so either ordering
-    /// ends at `.disconnected` — no stuck `.disconnecting` state.
+    /// Dispatches onto `WebSocketClient.engineQueue` so the `canBeDisconnected` check and the
+    /// `disconnect(...)` call are serialized against `WebSocketEngineDelegate` callbacks, which
+    /// mutate `connectionState` on the same queue. Without this, a concurrent `webSocketDidDisconnect`
+    /// can land `.disconnected` and then be overwritten by `.disconnecting`, leaving the client stuck
+    /// and blocking automatic reconnection.
     func disconnectIfNeeded() {
         webSocketClient.engineQueue.async { [weak self] in
             guard let self = self else { return }

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -196,8 +196,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Internet -> ON
         mockInternetConnection.monitorMock.status = .available(.great)
 
-        // Assert reconnection happens
-        XCTAssertTrue(mockChatClient.mockWebSocketClient.connect_called)
+        // Assert reconnection happens (handler dispatches through engineQueue, so wait for it)
+        AssertAsync.willBeTrue(mockChatClient.mockWebSocketClient.connect_called)
     }
 
     /// keepConnectionAliveInBackground == true
@@ -260,8 +260,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Backgroud task killed
         mockBackgroundTaskScheduler.beginBackgroundTask_expirationHandler?()
 
-        // Assert disconnection is initiated by the system
-        XCTAssertEqual(mockChatClient.mockWebSocketClient.disconnect_source, .systemInitiated)
+        // Assert disconnection is initiated by the system (handler dispatches through engineQueue)
+        AssertAsync.willBeEqual(mockChatClient.mockWebSocketClient.disconnect_source, .systemInitiated)
 
         // Disconnect (system initiated)
         disconnectWebSocket(source: .systemInitiated)
@@ -270,7 +270,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         mockBackgroundTaskScheduler.simulateAppGoingToForeground()
 
         // Assert reconnection happens
-        XCTAssertTrue(mockChatClient.mockWebSocketClient.connect_called)
+        AssertAsync.willBeTrue(mockChatClient.mockWebSocketClient.connect_called)
     }
 
     /// keepConnectionAliveInBackground == false
@@ -288,8 +288,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // App -> background
         mockBackgroundTaskScheduler.simulateAppGoingToBackground()
 
-        // Assert disconnect is initiated by the sytem
-        XCTAssertEqual(mockChatClient.mockWebSocketClient.disconnect_source, .systemInitiated)
+        // Assert disconnect is initiated by the sytem (handler dispatches through engineQueue)
+        AssertAsync.willBeEqual(mockChatClient.mockWebSocketClient.disconnect_source, .systemInitiated)
         // Assert no background task
         XCTAssertFalse(mockBackgroundTaskScheduler.beginBackgroundTask_called)
         // Assert no reconnect timer
@@ -302,7 +302,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         mockBackgroundTaskScheduler.simulateAppGoingToForeground()
 
         // Assert reconnection happens
-        XCTAssertTrue(mockChatClient.mockWebSocketClient.connect_called)
+        AssertAsync.willBeTrue(mockChatClient.mockWebSocketClient.connect_called)
     }
 
     /// keepConnectionAliveInBackground == true
@@ -387,8 +387,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Wait for reconnection delay to pass
         mockTime.run(numberOfSeconds: 10)
 
-        // Assert reconnection happens
-        XCTAssertTrue(mockChatClient.mockWebSocketClient.connect_called)
+        // Assert reconnection happens (timer onFire dispatches through engineQueue)
+        AssertAsync.willBeTrue(mockChatClient.mockWebSocketClient.connect_called)
     }
 
     /// 1. ws -> connected
@@ -602,6 +602,86 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         )
 
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+    }
+
+    // MARK: - Race regression: disconnect/reconnect must dispatch onto engineQueue
+
+    /// Regression test for the data race that left `connectionState` stuck at `.disconnecting`.
+    ///
+    /// Without the fix, `disconnectIfNeeded` ran synchronously on the caller's queue (typically
+    /// `io.getStream.chat.internet-monitor`). When the internet went down, the handler's
+    /// `webSocketClient.disconnect(source: .systemInitiated)` raced with the engine's own
+    /// `webSocketDidDisconnect` callback on `engineQueue`, allowing the handler to overwrite
+    /// the engine's legitimate `.disconnected` with `.disconnecting`.
+    ///
+    /// The fix dispatches the handler's check-and-act onto `engineQueue`, serialising it with
+    /// engine callbacks. This test verifies the dispatch mechanism by suspending the queue:
+    /// without the fix, `disconnect` would be called synchronously on the test thread; with
+    /// the fix, the call is queued and only runs once the queue is resumed.
+    func test_disconnectIfNeeded_dispatchesOntoEngineQueue() {
+        handler = makeConnectionRecoveryHandler(keepConnectionAliveInBackground: false)
+        connectWebSocket()
+
+        let webSocketClient = mockChatClient.mockWebSocketClient
+        webSocketClient.disconnect_calledCounter = 0
+
+        webSocketClient.engineQueue.suspend()
+        defer { webSocketClient.engineQueue.resume() }
+
+        // Trigger disconnectIfNeeded via internet OFF.
+        mockInternetConnection.monitorMock.status = .unavailable
+
+        // With the fix, the handler's block is queued on the suspended engineQueue — disconnect
+        // has not been invoked yet. Without the fix, disconnect would already have been called.
+        XCTAssertFalse(
+            webSocketClient.disconnect_called,
+            "Handler must dispatch disconnect onto engineQueue, not call it from the caller's queue."
+        )
+    }
+
+    /// Symmetric to `test_disconnectIfNeeded_dispatchesOntoEngineQueue` but for the reconnect
+    /// path triggered by internet returning (`reconnectIfNeededFromOffline`).
+    func test_reconnectFromOffline_dispatchesOntoEngineQueue() {
+        handler = makeConnectionRecoveryHandler(keepConnectionAliveInBackground: false)
+        // Put the client in a state from which automatic reconnection is allowed.
+        connectWebSocket()
+        disconnectWebSocket(source: .systemInitiated)
+
+        let webSocketClient = mockChatClient.mockWebSocketClient
+        webSocketClient.connect_calledCounter = 0
+
+        webSocketClient.engineQueue.suspend()
+        defer { webSocketClient.engineQueue.resume() }
+
+        // Trigger reconnect via internet ON.
+        mockInternetConnection.monitorMock.status = .available(.great)
+
+        XCTAssertFalse(
+            webSocketClient.connect_called,
+            "Handler must dispatch connect onto engineQueue, not call it from the caller's queue."
+        )
+    }
+
+    /// Verifies the reconnection-timer onFire path also dispatches onto `engineQueue`.
+    func test_reconnectTimerFire_dispatchesOntoEngineQueue() {
+        handler = makeConnectionRecoveryHandler(keepConnectionAliveInBackground: false)
+        connectWebSocket()
+        // Server-initiated disconnect schedules the reconnection timer.
+        disconnectWebSocket(source: .serverInitiated(error: nil))
+
+        let webSocketClient = mockChatClient.mockWebSocketClient
+        webSocketClient.connect_calledCounter = 0
+
+        webSocketClient.engineQueue.suspend()
+        defer { webSocketClient.engineQueue.resume() }
+
+        // Advance virtual time so the reconnect timer fires.
+        mockTime.run(numberOfSeconds: 10)
+
+        XCTAssertFalse(
+            webSocketClient.connect_called,
+            "Timer-driven reconnect must dispatch connect onto engineQueue, not call it from the timer's queue."
+        )
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1715](https://linear.app/stream/issue/IOS-1715)

Companion v5+ fix: [GetStream/stream-core-swift#50](https://github.com/GetStream/stream-core-swift/pull/50)

### 🎯 Goal

When the device loses and regains Wi-Fi, the WebSocket would sometimes stay stuck in `.disconnecting` and never reconnect. The root cause is a data race between `DefaultConnectionRecoveryHandler.disconnectIfNeeded()` (which runs on `io.getStream.chat.internet-monitor`) and `WebSocketClient`'s engine-driven state writes (on `engineQueue`). The handler performs a check-then-act on `connectionState`: it reads `.connected`, the engine queue independently writes `.disconnected(.serverInitiated)`, then the handler unconditionally writes `.disconnecting(.systemInitiated)` — overwriting the legitimate `.disconnected`. The engine has already closed the socket and never re-fires `webSocketDidDisconnect`, so the state stays stuck. Automatic reconnection then refuses to fire because `isAutomaticReconnectionEnabled` only matches `.disconnected`.

### 📝 Summary

- Wrap `disconnectIfNeeded`, the two `appDidBecomeActive`/internet-ON reconnect call sites (now extracted into a single `reconnectIfNeededFromOffline()` helper), and the reconnection-timer `onFire` closure in `webSocketClient.engineQueue.async { ... }` so the handler's check-and-act runs on the same serial queue that owns engine state mutations.
- Widen `WebSocketClient.engineQueue` from `private` to internal access so the handler in the same module can dispatch onto it.
- Add three regression tests covering all three new dispatch points (`disconnectIfNeeded`, internet-ON reconnect, timer-driven reconnect).
- Update four existing tests that asserted synchronously on `connect_called` / `disconnect_called` / `disconnect_source` immediately after a trigger to use `AssertAsync.willBe...`. The triggers now go through `engineQueue.async`, so the call is observed shortly after, not synchronously.

### 🛠 Implementation

Both writers (the handler and the engine's `WebSocketEngineDelegate` callbacks) now run on `WebSocketClient.engineQueue` — a serial dispatch queue. That serialises the previously racing accesses without introducing new locks or actor boundaries. Two possible orderings remain, and both end correctly at `.disconnected`:

- Engine's `webSocketDidDisconnect` runs first → handler block runs second, sees `.disconnected`, `canBeDisconnected` returns `false`, no `disconnect()` call.
- Handler block runs first → transitions to `.disconnecting`, queued engine callback then matches the `.disconnecting` case in `WebSocketClient.webSocketDidDisconnect` and transitions to `.disconnected(source: source)`.

Deadlock-safety was audited on the equivalent v5+ change in `stream-core-swift`: every `engineQueue` usage is `.async` (no `.sync`), `@Atomic`'s lock and the engine/connect-request locks are never nested, and the `connectionState` `didSet` (and therefore the delegate notification) fires outside the `@Atomic` setter's lock. The v4 layout is structurally identical, so the same conclusions apply.

### 🧪 Manual Testing Notes

Reproduce the original bug scenario on a physical iPhone:

1. Launch a chat demo, sign in, confirm `Web socket connection state changed: connected(...)` in logs.
2. Turn Wi-Fi **off**. State should reach `.disconnected(.serverInitiated)`. It should not flip to `.disconnecting(.systemInitiated)`; if it does, it must immediately return to `.disconnected` (engine's `.disconnecting → .disconnected` recovery path).
3. Wait ~10 seconds.
4. Turn Wi-Fi **on**. Reconnection should fire automatically: `connecting → waitingForConnectionId → connected(...)`.
5. Sanity check the lifecycle path: foreground → background → foreground while connected. Disconnect on background, reconnect on foreground, no stuck state.

The new and updated unit tests run as part of `StreamChatTests`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo