### PR TITLE
Make layout tokens customisable via Appearance.tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChatCommonUI
+### ✅ Added
+- Make layout tokens customisable in `Appearance.tokens` [#4114](https://github.com/GetStream/stream-chat-swift/pull/4114)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix attachment upload overlay text and action buttons being illegible in dark mode [#4111](https://github.com/GetStream/stream-chat-swift/pull/4111)

--- a/Sources/StreamChatCommonUI/Appearance+DesignTokens.swift
+++ b/Sources/StreamChatCommonUI/Appearance+DesignTokens.swift
@@ -9,75 +9,75 @@ extension Appearance {
     @MainActor public final class DesignSystemTokens {
         // MARK: Chat
 
-        public var buttonHitTargetMinHeight: CGFloat { size48 }
-        public var buttonHitTargetMinWidth: CGFloat { size48 }
-        public var buttonPaddingXIconOnlyLg: CGFloat { 14 }
-        public var buttonPaddingXIconOnlyMd: CGFloat { 10 }
-        public var buttonPaddingXIconOnlySm: CGFloat { 6 }
-        public var buttonPaddingXIconOnlyXs: CGFloat { 4 }
-        public var buttonPaddingXWithLabelLg: CGFloat { 16 }
-        public var buttonPaddingXWithLabelMd: CGFloat { 16 }
-        public var buttonPaddingXWithLabelSm: CGFloat { 16 }
-        public var buttonPaddingXWithLabelXs: CGFloat { 12 }
-        public var buttonPaddingYLg: CGFloat { 14 }
-        public var buttonPaddingYMd: CGFloat { 10 }
-        public var buttonPaddingYSm: CGFloat { 6 }
-        public var buttonPaddingYXs: CGFloat { 4 }
-        public var buttonRadiusFull: CGFloat { radiusFull }
-        public var buttonRadiusLg: CGFloat { radiusFull }
-        public var buttonRadiusMd: CGFloat { radiusFull }
-        public var buttonRadiusSm: CGFloat { radiusFull }
-        public var buttonVisualHeightLg: CGFloat { size48 }
-        public var buttonVisualHeightMd: CGFloat { size40 }
-        public var buttonVisualHeightSm: CGFloat { size32 }
-        public var buttonVisualHeightXs: CGFloat { size24 }
-        public var composerRadiusFixed: CGFloat { radius3xl }
-        public var composerRadiusFloating: CGFloat { radius3xl }
-        public var darkElevation1: BoxShadow { BoxShadow(x: 0, y: 1, blur: 3, spread: 0, color: UIColor(hex: 0x00000033)) }
-        public var darkElevation2: BoxShadow { BoxShadow(x: 0, y: 2, blur: 6, spread: 0, color: UIColor(hex: 0x00000038)) }
-        public var darkElevation3: BoxShadow { BoxShadow(x: 0, y: 4, blur: 12, spread: 0, color: UIColor(hex: 0x0000003d)) }
-        public var darkElevation4: BoxShadow { BoxShadow(x: 0, y: 8, blur: 24, spread: 0, color: UIColor(hex: 0x00000047)) }
-        public var deviceRadius: CGFloat { 62 }
-        public var deviceSafeAreaBottom: CGFloat { space32 }
-        public var deviceSafeAreaTop: CGFloat { 50 }
-        public var iconSizeLg: CGFloat { size32 }
-        public var iconSizeMd: CGFloat { size20 }
-        public var iconSizeSm: CGFloat { size16 }
-        public var iconSizeXs: CGFloat { size12 }
-        public var iconStrokeDefault: CGFloat { w150 }
-        public var iconStrokeEmphasis: CGFloat { w200 }
-        public var iconStrokeSubtle: CGFloat { w120 }
-        public var lightElevation1: BoxShadow { BoxShadow(x: 0, y: 1, blur: 3, spread: 0, color: UIColor(hex: 0x0000001f)) }
-        public var lightElevation2: BoxShadow { BoxShadow(x: 0, y: 2, blur: 6, spread: 0, color: UIColor(hex: 0x00000024)) }
-        public var lightElevation3: BoxShadow { BoxShadow(x: 0, y: 4, blur: 12, spread: 0, color: UIColor(hex: 0x00000029)) }
-        public var lightElevation4: BoxShadow { BoxShadow(x: 0, y: 8, blur: 24, spread: 0, color: UIColor(hex: 0x00000033)) }
-        public var messageBubbleRadiusAttachment: CGFloat { radiusLg }
-        public var messageBubbleRadiusAttachmentInline: CGFloat { radiusMd }
-        public var messageBubbleRadiusGroupBottom: CGFloat { radius2xl }
-        public var messageBubbleRadiusGroupMiddle: CGFloat { radius2xl }
-        public var messageBubbleRadiusGroupTop: CGFloat { radius2xl }
-        public var messageBubbleRadiusTail: CGFloat { radiusNone }
-        public var radius2xl: CGFloat { radius20 }
-        public var radius3xl: CGFloat { radius24 }
-        public var radius4xl: CGFloat { radius32 }
-        public var radiusLg: CGFloat { radius12 }
-        public var radiusMax: CGFloat { radiusFull }
-        public var radiusMd: CGFloat { radius8 }
-        public var radiusNone: CGFloat { radius0 }
-        public var radiusSm: CGFloat { radius6 }
-        public var radiusXl: CGFloat { radius16 }
-        public var radiusXs: CGFloat { radius4 }
-        public var radiusXxs: CGFloat { radius2 }
-        public var spacing2xl: CGFloat { space32 }
-        public var spacing3xl: CGFloat { space40 }
-        public var spacingLg: CGFloat { space20 }
-        public var spacingMd: CGFloat { space16 }
-        public var spacingNone: CGFloat { space0 }
-        public var spacingSm: CGFloat { space12 }
-        public var spacingXl: CGFloat { space24 }
-        public var spacingXs: CGFloat { space8 }
-        public var spacingXxs: CGFloat { space4 }
-        public var spacingXxxs: CGFloat { space2 }
+        public lazy var buttonHitTargetMinHeight: CGFloat = size48
+        public lazy var buttonHitTargetMinWidth: CGFloat = size48
+        public lazy var buttonPaddingXIconOnlyLg: CGFloat = 14
+        public lazy var buttonPaddingXIconOnlyMd: CGFloat = 10
+        public lazy var buttonPaddingXIconOnlySm: CGFloat = 6
+        public lazy var buttonPaddingXIconOnlyXs: CGFloat = 4
+        public lazy var buttonPaddingXWithLabelLg: CGFloat = 16
+        public lazy var buttonPaddingXWithLabelMd: CGFloat = 16
+        public lazy var buttonPaddingXWithLabelSm: CGFloat = 16
+        public lazy var buttonPaddingXWithLabelXs: CGFloat = 12
+        public lazy var buttonPaddingYLg: CGFloat = 14
+        public lazy var buttonPaddingYMd: CGFloat = 10
+        public lazy var buttonPaddingYSm: CGFloat = 6
+        public lazy var buttonPaddingYXs: CGFloat = 4
+        public lazy var buttonRadiusFull: CGFloat = radiusFull
+        public lazy var buttonRadiusLg: CGFloat = radiusFull
+        public lazy var buttonRadiusMd: CGFloat = radiusFull
+        public lazy var buttonRadiusSm: CGFloat = radiusFull
+        public lazy var buttonVisualHeightLg: CGFloat = size48
+        public lazy var buttonVisualHeightMd: CGFloat = size40
+        public lazy var buttonVisualHeightSm: CGFloat = size32
+        public lazy var buttonVisualHeightXs: CGFloat = size24
+        public lazy var composerRadiusFixed: CGFloat = radius3xl
+        public lazy var composerRadiusFloating: CGFloat = radius3xl
+        public lazy var darkElevation1: BoxShadow = BoxShadow(x: 0, y: 1, blur: 3, spread: 0, color: UIColor(hex: 0x00000033))
+        public lazy var darkElevation2: BoxShadow = BoxShadow(x: 0, y: 2, blur: 6, spread: 0, color: UIColor(hex: 0x00000038))
+        public lazy var darkElevation3: BoxShadow = BoxShadow(x: 0, y: 4, blur: 12, spread: 0, color: UIColor(hex: 0x0000003d))
+        public lazy var darkElevation4: BoxShadow = BoxShadow(x: 0, y: 8, blur: 24, spread: 0, color: UIColor(hex: 0x00000047))
+        public lazy var deviceRadius: CGFloat = 62
+        public lazy var deviceSafeAreaBottom: CGFloat = space32
+        public lazy var deviceSafeAreaTop: CGFloat = 50
+        public lazy var iconSizeLg: CGFloat = size32
+        public lazy var iconSizeMd: CGFloat = size20
+        public lazy var iconSizeSm: CGFloat = size16
+        public lazy var iconSizeXs: CGFloat = size12
+        public lazy var iconStrokeDefault: CGFloat = w150
+        public lazy var iconStrokeEmphasis: CGFloat = w200
+        public lazy var iconStrokeSubtle: CGFloat = w120
+        public lazy var lightElevation1: BoxShadow = BoxShadow(x: 0, y: 1, blur: 3, spread: 0, color: UIColor(hex: 0x0000001f))
+        public lazy var lightElevation2: BoxShadow = BoxShadow(x: 0, y: 2, blur: 6, spread: 0, color: UIColor(hex: 0x00000024))
+        public lazy var lightElevation3: BoxShadow = BoxShadow(x: 0, y: 4, blur: 12, spread: 0, color: UIColor(hex: 0x00000029))
+        public lazy var lightElevation4: BoxShadow = BoxShadow(x: 0, y: 8, blur: 24, spread: 0, color: UIColor(hex: 0x00000033))
+        public lazy var messageBubbleRadiusAttachment: CGFloat = radiusLg
+        public lazy var messageBubbleRadiusAttachmentInline: CGFloat = radiusMd
+        public lazy var messageBubbleRadiusGroupBottom: CGFloat = radius2xl
+        public lazy var messageBubbleRadiusGroupMiddle: CGFloat = radius2xl
+        public lazy var messageBubbleRadiusGroupTop: CGFloat = radius2xl
+        public lazy var messageBubbleRadiusTail: CGFloat = radiusNone
+        public lazy var radius2xl: CGFloat = radius20
+        public lazy var radius3xl: CGFloat = radius24
+        public lazy var radius4xl: CGFloat = radius32
+        public lazy var radiusLg: CGFloat = radius12
+        public lazy var radiusMax: CGFloat = radiusFull
+        public lazy var radiusMd: CGFloat = radius8
+        public lazy var radiusNone: CGFloat = radius0
+        public lazy var radiusSm: CGFloat = radius6
+        public lazy var radiusXl: CGFloat = radius16
+        public lazy var radiusXs: CGFloat = radius4
+        public lazy var radiusXxs: CGFloat = radius2
+        public lazy var spacing2xl: CGFloat = space32
+        public lazy var spacing3xl: CGFloat = space40
+        public lazy var spacingLg: CGFloat = space20
+        public lazy var spacingMd: CGFloat = space16
+        public lazy var spacingNone: CGFloat = space0
+        public lazy var spacingSm: CGFloat = space12
+        public lazy var spacingXl: CGFloat = space24
+        public lazy var spacingXs: CGFloat = space8
+        public lazy var spacingXxs: CGFloat = space4
+        public lazy var spacingXxxs: CGFloat = space2
 
         // MARK: Foundations
 

--- a/Sources/StreamChatCommonUI/Appearance+DesignTokens.swift
+++ b/Sources/StreamChatCommonUI/Appearance+DesignTokens.swift
@@ -7,7 +7,7 @@ import UIKit
 
 extension Appearance {
     @MainActor public final class DesignSystemTokens {
-        // MARK: Chat
+        // MARK: - Button
 
         public lazy var buttonHitTargetMinHeight: CGFloat = size48
         public lazy var buttonHitTargetMinWidth: CGFloat = size48
@@ -31,15 +31,27 @@ extension Appearance {
         public lazy var buttonVisualHeightMd: CGFloat = size40
         public lazy var buttonVisualHeightSm: CGFloat = size32
         public lazy var buttonVisualHeightXs: CGFloat = size24
+
+        // MARK: - Composer
+
         public lazy var composerRadiusFixed: CGFloat = radius3xl
         public lazy var composerRadiusFloating: CGFloat = radius3xl
+
+        // MARK: - Dark
+
         public lazy var darkElevation1: BoxShadow = BoxShadow(x: 0, y: 1, blur: 3, spread: 0, color: UIColor(hex: 0x00000033))
         public lazy var darkElevation2: BoxShadow = BoxShadow(x: 0, y: 2, blur: 6, spread: 0, color: UIColor(hex: 0x00000038))
         public lazy var darkElevation3: BoxShadow = BoxShadow(x: 0, y: 4, blur: 12, spread: 0, color: UIColor(hex: 0x0000003d))
         public lazy var darkElevation4: BoxShadow = BoxShadow(x: 0, y: 8, blur: 24, spread: 0, color: UIColor(hex: 0x00000047))
+
+        // MARK: - Device
+
         public lazy var deviceRadius: CGFloat = 62
         public lazy var deviceSafeAreaBottom: CGFloat = space32
         public lazy var deviceSafeAreaTop: CGFloat = 50
+
+        // MARK: - Icon
+
         public lazy var iconSizeLg: CGFloat = size32
         public lazy var iconSizeMd: CGFloat = size20
         public lazy var iconSizeSm: CGFloat = size16
@@ -47,16 +59,25 @@ extension Appearance {
         public lazy var iconStrokeDefault: CGFloat = w150
         public lazy var iconStrokeEmphasis: CGFloat = w200
         public lazy var iconStrokeSubtle: CGFloat = w120
+
+        // MARK: - Light
+
         public lazy var lightElevation1: BoxShadow = BoxShadow(x: 0, y: 1, blur: 3, spread: 0, color: UIColor(hex: 0x0000001f))
         public lazy var lightElevation2: BoxShadow = BoxShadow(x: 0, y: 2, blur: 6, spread: 0, color: UIColor(hex: 0x00000024))
         public lazy var lightElevation3: BoxShadow = BoxShadow(x: 0, y: 4, blur: 12, spread: 0, color: UIColor(hex: 0x00000029))
         public lazy var lightElevation4: BoxShadow = BoxShadow(x: 0, y: 8, blur: 24, spread: 0, color: UIColor(hex: 0x00000033))
+
+        // MARK: - Message
+
         public lazy var messageBubbleRadiusAttachment: CGFloat = radiusLg
         public lazy var messageBubbleRadiusAttachmentInline: CGFloat = radiusMd
         public lazy var messageBubbleRadiusGroupBottom: CGFloat = radius2xl
         public lazy var messageBubbleRadiusGroupMiddle: CGFloat = radius2xl
         public lazy var messageBubbleRadiusGroupTop: CGFloat = radius2xl
         public lazy var messageBubbleRadiusTail: CGFloat = radiusNone
+
+        // MARK: - Radius
+
         public lazy var radius2xl: CGFloat = radius20
         public lazy var radius3xl: CGFloat = radius24
         public lazy var radius4xl: CGFloat = radius32
@@ -68,6 +89,9 @@ extension Appearance {
         public lazy var radiusXl: CGFloat = radius16
         public lazy var radiusXs: CGFloat = radius4
         public lazy var radiusXxs: CGFloat = radius2
+
+        // MARK: - Spacing
+
         public lazy var spacing2xl: CGFloat = space32
         public lazy var spacing3xl: CGFloat = space40
         public lazy var spacingLg: CGFloat = space20


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1728](https://linear.app/stream/issue/IOS-1728)

### 🎯 Goal

Let integrators customise the SDK's layout tokens (radii, padding, sizing, elevation) by overriding values on `Appearance.tokens`.

### 📝 Summary

- Convert the public layout tokens on `Appearance.DesignSystemTokens` from read-only computed properties to settable `public lazy var`, so individual values can be overridden.
- Group the tokens with `// MARK: -` section headers (Button, Composer, Dark, Device, Icon, Light, Message, Radius, Spacing), matching `Appearance.ColorPalette`.

### 🛠 Implementation

- `DesignSystemTokens` is already a `@MainActor public final class`. Switching the layout tokens from computed `var { … }` to `lazy var = …` keeps each default (which references foundation constants or other tokens) while making them assignable — e.g. `Appearance.default.tokens.messageBubbleRadiusAttachment = 20`. `lazy` is required because the defaults reference other instance members.
- Reads are unchanged, so the change is additive and source-compatible; the grouping is comment-only.
- These tokens are generated upstream in the `design-system-tokens` repo; the generator was updated with the same `lazy var` + grouping change so future regenerations stay in sync.

### 🎨 Showcase

_N/A — no visual change; this exposes customisation points._

### 🧪 Manual Testing Notes

Override a token before first use and confirm the UI reflects it, e.g. set `Appearance.default.tokens.messageBubbleRadiusAttachment = 0` and observe attachment bubble corners become square.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout tokens (radii, padding, sizing, elevation, icons, spacing, and related UI measurements) are now customizable via Appearance.tokens, enabling easier visual theming and layout adjustments.
* **Documentation**
  * CHANGELOG updated with an “Upcoming” entry noting the new customizable layout tokens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swift/pull/4114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->