### PR TITLE
Respect `shouldShowShadowedMessages` in livestream channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Respect `ChatClientConfig.shouldShowShadowedMessages` in livestream channels [#4118](https://github.com/GetStream/stream-chat-swift/pull/4118)
+- Respect `ChatClientConfig.shouldShowShadowedMessages` in `LivestreamChat` and `LivestreamChannelController` [#4118](https://github.com/GetStream/stream-chat-swift/pull/4118)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Respect `shouldShowShadowedMessages` in livestream channels [#4118](https://github.com/GetStream/stream-chat-swift/pull/4118)
+
 ### 🔄 Changed
 
 # [5.4.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Respect `shouldShowShadowedMessages` in livestream channels [#4118](https://github.com/GetStream/stream-chat-swift/pull/4118)
+- Respect `ChatClientConfig.shouldShowShadowedMessages` in livestream channels [#4118](https://github.com/GetStream/stream-chat-swift/pull/4118)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChatHandler.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChatHandler.swift
@@ -173,7 +173,7 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
             return
         }
         channel = cachedChannel
-        messages = cachedChannel.latestMessages
+        messages = cachedChannel.latestMessages.filter(isMessageVisible)
     }
 
     /// Applies the freshly-fetched channel payload to the in-memory state.
@@ -190,7 +190,7 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
 
         let newMessages = payload.messages.compactMap {
             $0.asModel(cid: payload.channel.cid, currentUserId: currentUserId, channelReads: newChannel.reads)
-        }
+        }.filter(isMessageVisible)
 
         updateMessagesArray(with: newMessages, pagination: channelQuery.pagination)
     }
@@ -261,6 +261,13 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
         DispatchQueue.main.async {
             callback(handlers)
         }
+    }
+
+    private func isMessageVisible(_ message: ChatMessage) -> Bool {
+        if message.isShadowed, !client.config.shouldShowShadowedMessages {
+            return false
+        }
+        return true
     }
 
     private func updateMessagesArray(with newMessages: [ChatMessage], pagination: MessagesPagination?) {
@@ -490,6 +497,10 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
             return
         }
 
+        // Skip messages that should not be visible (e.g. shadowed messages while
+        // `shouldShowShadowedMessages` is disabled)
+        guard isMessageVisible(message) else { return }
+
         // If paused and the message is not from the current user, skip processing
         if countSkippedMessagesWhenPaused, isPaused && message.author.id != currentUserId {
             skippedMessagesAmount += 1
@@ -507,6 +518,13 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
 
     private func handleUpdatedMessage(_ updatedMessage: ChatMessage) {
         if let index = messages.firstIndex(where: { $0.id == updatedMessage.id }) {
+            // If the message became hidden (e.g. shadowed while
+            // `shouldShowShadowedMessages` is disabled), remove it
+            guard isMessageVisible(updatedMessage) else {
+                messages.remove(at: index)
+                return
+            }
+
             let existingMessage = messages[index]
             messages[index] = updatedMessage
 

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChatHandler.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChatHandler.swift
@@ -297,6 +297,8 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
     private func handleChannelEvent(_ event: Event) {
         switch event {
         case let messageNewEvent as MessageNewEvent:
+            guard isMessageVisible(messageNewEvent.message) else { return }
+            
             handleNewMessage(messageNewEvent.message)
 
             // Apply message limit only when not paused
@@ -496,10 +498,6 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
             handleUpdatedMessage(message)
             return
         }
-
-        // Skip messages that should not be visible (e.g. shadowed messages while
-        // `shouldShowShadowedMessages` is disabled)
-        guard isMessageVisible(message) else { return }
 
         // If paused and the message is not from the current user, skip processing
         if countSkippedMessagesWhenPaused, isPaused && message.author.id != currentUserId {

--- a/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChatHandler_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/LivestreamChatHandler_Tests.swift
@@ -906,9 +906,101 @@ private extension LivestreamChatHandler.Handlers {
     }
 }
 
+// MARK: - Shadowed Messages
+
+extension LivestreamChatHandler_Tests {
+    func test_handleChannelPayload_whenShadowedMessagesHidden_filtersShadowedMessages() {
+        let payload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid),
+            messages: [
+                .dummy(messageId: "visible", text: "Visible", isShadowed: false),
+                .dummy(messageId: "shadowed", text: "Shadowed", isShadowed: true)
+            ]
+        )
+
+        handler.handleChannelPayload(payload, channelQuery: ChannelQuery(cid: cid))
+
+        XCTAssertEqual(handler.messages.map(\.id), ["visible"])
+    }
+
+    func test_handleChannelPayload_whenShadowedMessagesShown_keepsShadowedMessages() {
+        setUpHandler(showShadowedMessages: true)
+
+        let payload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid),
+            messages: [
+                .dummy(messageId: "visible", text: "Visible", isShadowed: false),
+                .dummy(messageId: "shadowed", text: "Shadowed", isShadowed: true)
+            ]
+        )
+
+        handler.handleChannelPayload(payload, channelQuery: ChannelQuery(cid: cid))
+
+        XCTAssertEqual(Set(handler.messages.map(\.id)), ["visible", "shadowed"])
+    }
+
+    func test_didReceiveEvent_messageNewEvent_whenShadowedMessagesHidden_isIgnored() {
+        let shadowedMessage = ChatMessage.mock(id: "shadowed", cid: cid, text: "Shadowed", isShadowed: true)
+        handler.didReceiveEvent(makeNewMessageEvent(message: shadowedMessage))
+        XCTAssertTrue(handler.messages.isEmpty)
+    }
+
+    func test_didReceiveEvent_messageNewEvent_whenShadowedMessagesShown_addsMessage() {
+        setUpHandler(showShadowedMessages: true)
+        let shadowedMessage = ChatMessage.mock(id: "shadowed", cid: cid, text: "Shadowed", isShadowed: true)
+        handler.didReceiveEvent(makeNewMessageEvent(message: shadowedMessage))
+        XCTAssertEqual(handler.messages.map(\.id), ["shadowed"])
+    }
+
+    func test_populateFromCacheIfEnabled_whenShadowedMessagesHidden_filtersShadowedMessages() throws {
+        let payload = ChannelPayload.dummy(
+            channel: .dummy(cid: cid),
+            messages: [
+                .dummy(messageId: "visible", text: "Visible", isShadowed: false),
+                .dummy(messageId: "shadowed", text: "Shadowed", isShadowed: true)
+            ]
+        )
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
+        handler.populateFromCacheIfEnabled()
+
+        XCTAssertEqual(handler.messages.map(\.id), ["visible"])
+    }
+
+    func test_didReceiveEvent_messageUpdatedEvent_whenMessageBecomesShadowed_removesMessage() {
+        // Seed a visible message.
+        handler.didReceiveEvent(makeNewMessageEvent(id: "msg", text: "Original"))
+        XCTAssertEqual(handler.messages.map(\.id), ["msg"])
+
+        // The same message is updated to a shadowed state and should be removed,
+        // matching the database fetch predicate.
+        let shadowedMessage = ChatMessage.mock(id: "msg", cid: cid, text: "Original", isShadowed: true)
+        handler.didReceiveEvent(MessageUpdatedEvent(
+            user: .mock(id: .unique),
+            channel: .mock(cid: cid),
+            message: shadowedMessage,
+            createdAt: .unique
+        ))
+
+        XCTAssertTrue(handler.messages.isEmpty)
+    }
+}
+
 // MARK: - Helpers
 
 private extension LivestreamChatHandler_Tests {
+    /// Rebuilds `client` and `handler` with the given shadowed-messages setting,
+    /// keeping `tearDown` responsible for their cleanup.
+    func setUpHandler(showShadowedMessages: Bool) {
+        client.cleanUp()
+        var config = ChatClient_Mock.defaultMockedConfig
+        config.shouldShowShadowedMessages = showShadowedMessages
+        client = ChatClient.mock(config: config)
+        handler = LivestreamChatHandler(channelQuery: ChannelQuery(cid: cid), client: client)
+    }
+
     func makeNewMessageEvent(id: MessageId, text: String = "msg", author: ChatUser? = nil, pinned: Bool = false) -> MessageNewEvent {
         let pinDetails: MessagePinDetails? = pinned
             ? .init(pinnedAt: .unique, pinnedBy: .unique, expiresAt: nil)


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1738](https://linear.app/stream/issue/IOS-1738)

### 🎯 Goal

Make livestream channels respect the `shouldShowShadowedMessages` configuration so shadowed messages are hidden by default, matching the database-backed controllers.

### 📝 Summary

- `LivestreamChatHandler` now filters shadowed messages out of its in-memory list when `ChatClientConfig.shouldShowShadowedMessages` is `false`.
- Filtering is applied at every point a message enters the list: cache population, channel payload (initial/paginated fetch), and `MessageNewEvent`
- A message that is updated into a shadowed state is now removed from the list.
- Fixes both `LivestreamChannelController` and `LivestreamChat`, which share the handler.

### 🛠 Implementation

Added a private `isMessageVisible(_:)` helper that mirrors the shadowed branch of `MessageDTO.channelMessagesPredicate` and reads `client.config.shouldShowShadowedMessages`. It is applied in `populateFromCacheIfEnabled`, `handleChannelPayload` (without altering the pagination cursor, which must track the full server page), `handleNewMessage`, and `handleUpdatedMessage`.

`shouldShowShadowedMessages` is the only `ChatClientConfig` flag the channel message-list predicate consults; the remaining predicate conditions (reply-in-channel, message types, drafts, truncation, deleted handling) are structural and already filtered server-side in payloads, so they are intentionally out of scope.

### 🎨 Showcase

N/A — non-UI behavior change.

### 🧪 Manual Testing Notes

On a livestream channel with a shadow-banned user, send messages from that user. With `shouldShowShadowedMessages = false` (default) they should not appear in the message list; with `true` they should appear. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Livestream channels now consistently respect the setting to show or hide shadowed/hidden messages during loading, incoming messages, and message updates.

* **Tests**
  * Added tests verifying shadowed message visibility behavior across payload handling, cache population, incoming messages, and updates.

* **Documentation**
  * Added an “Upcoming” changelog entry noting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->