### PR TITLE
Fix poll comments button singular title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix the poll comments button showing "1 comments" instead of "1 comment" for a single comment [#4123](https://github.com/GetStream/stream-chat-swift/pull/4123)
+
 # [5.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.5.0)
 _June 03, 2026_
 

--- a/Sources/StreamChatCommonUI/Generated/L10n.swift
+++ b/Sources/StreamChatCommonUI/Generated/L10n.swift
@@ -415,7 +415,7 @@ public enum L10n {
       public static var showAll: String { L10n.tr("Localizable", "polls.button.show-all") }
       /// Suggest an Option
       public static var suggestOption: String { L10n.tr("Localizable", "polls.button.suggest-option") }
-      /// View %d Comments
+      /// Plural format key: "%#@comments@"
       public static func viewComments(_ p1: Int) -> String {
         return L10n.tr("Localizable", "polls.button.view-comments", p1)
       }

--- a/Sources/StreamChatCommonUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatCommonUI/Resources/en.lproj/Localizable.strings
@@ -247,8 +247,6 @@
 
 /// Shown in the message poll view on the button to add a poll comment.
 "polls.button.add-comment" = "Add Comment";
-/// Shown in the message poll view on the button to view the poll comments.
-"polls.button.view-comments" = "View %d Comments";
 /// Shown in the message poll view on the button to to show all options.
 "polls.button.all-options" = "See %d More Options";
 /// Shown in the message poll results on the button to show more votes.

--- a/Sources/StreamChatCommonUI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/StreamChatCommonUI/Resources/en.lproj/Localizable.stringsdict
@@ -90,6 +90,24 @@
 			<string>%d UNREAD MESSAGES</string>
 		</dict>
 	</dict>
+	<key>polls.button.view-comments</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@comments@</string>
+		<key>comments</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>View %d Comments</string>
+			<key>one</key>
+			<string>View %d Comment</string>
+			<key>other</key>
+			<string>View %d Comments</string>
+		</dict>
+	</dict>
 	<key>reaction.authors.number-of-reactions</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1744/uikit-polls-has-plural-issue-view-1-comments.

### 🎯 Goal

Fix a bug with the comments button title.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Add Comment" button to the poll interface for easier commenting.

* **Localization**
  * Fixed pluralization on the poll comments button so singular/plural forms display correctly (e.g., "1 comment" vs "2 comments") across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->