### PR TITLE
Fix avatar placeholders change locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix group channel avatars changing while the channel list is displayed when the last active members are updated [#4124](https://github.com/GetStream/stream-chat-swift/pull/4124)
+
 # [5.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.5.0)
 _June 03, 2026_
 

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -31,9 +31,26 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
     /// Set to `nil` to perform processing synchronously on the calling thread.
     open var imageProcessingQueue: DispatchQueue? = .global(qos: .userInitiated)
 
+    /// The cached merged avatar together with the channel id it was rendered for.
+    ///
+    /// The merged avatar is computed only once per channel and then reused. This keeps the
+    /// avatar stable when the channel's last active members change while it's displayed
+    /// (for example, due to member activity updates). It's recomputed only when the view is
+    /// bound to a different channel, e.g. on cell reuse.
+    private var cachedMergedAvatar: (channelId: ChannelId, image: UIImage)?
+
     override open func setUpLayout() {
         super.setUpLayout()
         embed(presenceAvatarView)
+    }
+
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            // The merged avatar can include appearance-dependent initials placeholders, so the
+            // cache must be invalidated when the interface style changes to re-render it.
+            cachedMergedAvatar = nil
+        }
+        super.traitCollectionDidChange(previousTraitCollection)
     }
 
     override open func updateContent() {
@@ -94,6 +111,13 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
         // The channel is a non-DM channel, hide the online indicator
         presenceAvatarView.isOnlineIndicatorVisible = false
 
+        // Reuse the previously rendered avatar for this channel so that updates to the
+        // channel's last active members don't change the avatar while it's displayed.
+        if let cachedMergedAvatar, cachedMergedAvatar.channelId == channel.cid {
+            loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
+            return
+        }
+
         let lastActiveMembers = self.lastActiveMembers()
 
         // If there are no members other than the current user in the channel, load a placeholder
@@ -132,6 +156,13 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
 
                 StreamConcurrency.onMain {
                     guard let self, channelId == self.content.channel?.cid else { return }
+                    // If a merged avatar for this channel was already cached (e.g. by an
+                    // earlier in-flight computation), keep it to avoid changing the avatar.
+                    if let cachedMergedAvatar = self.cachedMergedAvatar, cachedMergedAvatar.channelId == channelId {
+                        self.loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
+                        return
+                    }
+                    self.cachedMergedAvatar = (channelId, combinedImage)
                     self.loadIntoAvatarImageView(from: nil, placeholder: combinedImage)
                 }
             }

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -31,14 +31,16 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
     /// Set to `nil` to perform processing synchronously on the calling thread.
     open var imageProcessingQueue: DispatchQueue? = .global(qos: .userInitiated)
 
-    /// The cached merged avatar together with the channel id and the ids of the members shown in it.
+    /// The cached merged avatar together with the channel id, the ids of the members shown in it, and
+    /// the channel's member count at the time it was rendered.
     ///
-    /// The merged avatar is computed once and then reused for as long as every member shown in it is
-    /// still in the channel. This keeps the avatar stable while it's displayed when the channel's last
-    /// active members are reordered (e.g. due to member activity updates) or when members that aren't
-    /// shown change. It's recomputed when the view is bound to a different channel (e.g. on cell reuse)
-    /// or when one of the shown members leaves or is replaced.
-    private var cachedMergedAvatar: (channelId: ChannelId, memberIds: Set<UserId>, image: UIImage)?
+    /// The merged avatar is computed once and then reused while it's still valid. This keeps the avatar
+    /// stable while it's displayed when the channel's last active members are reordered (e.g. due to
+    /// member activity updates) or when members that aren't shown change. It's recomputed when the view
+    /// is bound to a different channel (e.g. on cell reuse), when one of the shown members leaves or is
+    /// replaced, or — while it shows fewer than the maximum number of members — when the member count
+    /// changes, so that a newly added member is shown.
+    private var cachedMergedAvatar: (channelId: ChannelId, memberIds: Set<UserId>, memberCount: Int, image: UIImage)?
 
     override open func setUpLayout() {
         super.setUpLayout()
@@ -112,17 +114,19 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
         // The channel is a non-DM channel, hide the online indicator
         presenceAvatarView.isOnlineIndicatorVisible = false
 
-        // Reuse the previously rendered avatar while every member it shows is still in the channel.
-        // The avatar only becomes stale when one of those members leaves (or is replaced), so
-        // reordering of the last active members and changes to members that aren't shown don't
-        // recompute it. Only the shown members (at most four) are checked, against the unsorted
-        // member list, so the sorting done by `lastActiveMembers()` is skipped on this hot path
-        // while the avatar is still valid.
+        // Reuse the previously rendered avatar while it's still valid. It stays valid as long as every
+        // member it shows is still in the channel, so reordering and changes to members that aren't
+        // shown don't recompute it. While it shows fewer than the maximum number of members it also
+        // requires the member count to be unchanged, so that a newly added member gets shown. Only the
+        // shown members (at most four) are checked, against the unsorted member list, so the sorting
+        // done by `lastActiveMembers()` is skipped on this hot path while the avatar is still valid.
         if let cachedMergedAvatar, cachedMergedAvatar.channelId == channel.cid {
-            let avatarIsStillValid = cachedMergedAvatar.memberIds.allSatisfy { memberId in
+            let allShownMembersStillPresent = cachedMergedAvatar.memberIds.allSatisfy { memberId in
                 channel.lastActiveMembers.contains { $0.id == memberId }
             }
-            if avatarIsStillValid {
+            let showsMaximumMembers = cachedMergedAvatar.memberIds.count >= maxNumberOfImagesInCombinedAvatar
+            let memberCountUnchanged = cachedMergedAvatar.memberCount == channel.memberCount
+            if allShownMembersStillPresent, showsMaximumMembers || memberCountUnchanged {
                 loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
                 return
             }
@@ -138,6 +142,7 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
 
         let members = Array(lastActiveMembers.prefix(maxNumberOfImagesInCombinedAvatar))
         let shownMemberIds = Set(members.map(\.id))
+        let memberCount = channel.memberCount
         let urls = members.map(\.imageURL)
         let names = members.map { $0.name ?? "" }
 
@@ -175,7 +180,7 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
                         self.loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
                         return
                     }
-                    self.cachedMergedAvatar = (channelId, shownMemberIds, combinedImage)
+                    self.cachedMergedAvatar = (channelId, shownMemberIds, memberCount, combinedImage)
                     self.loadIntoAvatarImageView(from: nil, placeholder: combinedImage)
                 }
             }

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -31,13 +31,14 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
     /// Set to `nil` to perform processing synchronously on the calling thread.
     open var imageProcessingQueue: DispatchQueue? = .global(qos: .userInitiated)
 
-    /// The cached merged avatar together with the channel id it was rendered for.
+    /// The cached merged avatar together with the channel id and the ids of the members shown in it.
     ///
-    /// The merged avatar is computed only once per channel and then reused. This keeps the
-    /// avatar stable when the channel's last active members change while it's displayed
-    /// (for example, due to member activity updates). It's recomputed only when the view is
-    /// bound to a different channel, e.g. on cell reuse.
-    private var cachedMergedAvatar: (channelId: ChannelId, image: UIImage)?
+    /// The merged avatar is computed once and then reused for as long as every member shown in it is
+    /// still in the channel. This keeps the avatar stable while it's displayed when the channel's last
+    /// active members are reordered (e.g. due to member activity updates) or when members that aren't
+    /// shown change. It's recomputed when the view is bound to a different channel (e.g. on cell reuse)
+    /// or when one of the shown members leaves or is replaced.
+    private var cachedMergedAvatar: (channelId: ChannelId, memberIds: Set<UserId>, image: UIImage)?
 
     override open func setUpLayout() {
         super.setUpLayout()
@@ -111,11 +112,20 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
         // The channel is a non-DM channel, hide the online indicator
         presenceAvatarView.isOnlineIndicatorVisible = false
 
-        // Reuse the previously rendered avatar for this channel so that updates to the
-        // channel's last active members don't change the avatar while it's displayed.
+        // Reuse the previously rendered avatar while every member it shows is still in the channel.
+        // The avatar only becomes stale when one of those members leaves (or is replaced), so
+        // reordering of the last active members and changes to members that aren't shown don't
+        // recompute it. Only the shown members (at most four) are checked, against the unsorted
+        // member list, so the sorting done by `lastActiveMembers()` is skipped on this hot path
+        // while the avatar is still valid.
         if let cachedMergedAvatar, cachedMergedAvatar.channelId == channel.cid {
-            loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
-            return
+            let avatarIsStillValid = cachedMergedAvatar.memberIds.allSatisfy { memberId in
+                channel.lastActiveMembers.contains { $0.id == memberId }
+            }
+            if avatarIsStillValid {
+                loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
+                return
+            }
         }
 
         let lastActiveMembers = self.lastActiveMembers()
@@ -127,6 +137,7 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
         }
 
         let members = Array(lastActiveMembers.prefix(maxNumberOfImagesInCombinedAvatar))
+        let shownMemberIds = Set(members.map(\.id))
         let urls = members.map(\.imageURL)
         let names = members.map { $0.name ?? "" }
 
@@ -156,13 +167,15 @@ open class ChatChannelAvatarView: _View, ThemeProvider {
 
                 StreamConcurrency.onMain {
                     guard let self, channelId == self.content.channel?.cid else { return }
-                    // If a merged avatar for this channel was already cached (e.g. by an
-                    // earlier in-flight computation), keep it to avoid changing the avatar.
-                    if let cachedMergedAvatar = self.cachedMergedAvatar, cachedMergedAvatar.channelId == channelId {
+                    // If an avatar showing the same members was already cached (e.g. by an earlier
+                    // in-flight computation), keep it to avoid changing the avatar.
+                    if let cachedMergedAvatar = self.cachedMergedAvatar,
+                       cachedMergedAvatar.channelId == channelId,
+                       cachedMergedAvatar.memberIds == shownMemberIds {
                         self.loadIntoAvatarImageView(from: nil, placeholder: cachedMergedAvatar.image)
                         return
                     }
-                    self.cachedMergedAvatar = (channelId, combinedImage)
+                    self.cachedMergedAvatar = (channelId, shownMemberIds, combinedImage)
                     self.loadIntoAvatarImageView(from: nil, placeholder: combinedImage)
                 }
             }

--- a/Tests/StreamChatUITests/SnapshotTests/CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift
@@ -178,6 +178,64 @@ import XCTest
         AssertSnapshot(view, variants: .onlyUserInterfaceStyles)
     }
 
+    func test_loadMergedAvatars_doesNotRecomputeAvatar_whenLastActiveMembersChangeForSameChannel() {
+        let cid = ChannelId.unique
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        // Add to a window so that `content` updates trigger `updateContent()`.
+        let window = UIWindow()
+        window.addSubview(view)
+
+        view.content = (
+            channel: groupChannel(cid: cid, memberImageURLs: [TestImages.yoda.url, TestImages.chewbacca.url, TestImages.r2.url]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+        let renderedImage = view.presenceAvatarView.avatarView.imageView.image
+        XCTAssertNotNil(renderedImage)
+
+        // Simulate the last active members changing for the same channel.
+        imageMergerSpy.reset()
+        view.content = (
+            channel: groupChannel(cid: cid, memberImageURLs: [TestImages.vader.url, TestImages.yoda.url, TestImages.chewbacca.url]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertEqual(imageMergerSpy.mergeCallCount, 0, "The avatar should not be recomputed when the last active members change")
+        XCTAssertTrue(view.presenceAvatarView.avatarView.imageView.image === renderedImage)
+    }
+
+    func test_loadMergedAvatars_recomputesAvatar_whenBoundToADifferentChannel() {
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        let window = UIWindow()
+        window.addSubview(view)
+
+        view.content = (
+            channel: groupChannel(cid: .unique, memberImageURLs: [TestImages.yoda.url, TestImages.chewbacca.url, TestImages.r2.url]),
+            currentUserId: currentUserId
+        )
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+
+        // Simulate the view being reused for a different channel (e.g. cell reuse).
+        imageMergerSpy.reset()
+        view.content = (
+            channel: groupChannel(cid: .unique, memberImageURLs: [TestImages.vader.url, TestImages.yoda.url, TestImages.chewbacca.url]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0, "The avatar should be recomputed when bound to a different channel")
+    }
+
     func test_appearanceCustomization_usingAppearanceAndComponents() {
         class RectIndicator: UIView, MaskProviding {
             override func didMoveToSuperview() {
@@ -227,6 +285,41 @@ import XCTest
         view.components = .mock
         view.content = (channel: channel, currentUserId: currentUserId)
         AssertSnapshot(view, variants: .onlyUserInterfaceStyles)
+    }
+}
+
+private extension ChatChannelAvatarView_Tests {
+    /// Creates a group channel (more than two members) whose avatar is rendered by merging member images.
+    func groupChannel(cid: ChannelId, memberImageURLs: [URL]) -> ChatChannel {
+        var members: [ChatChannelMember] = [.mock(id: currentUserId, imageURL: TestImages.vader.url)]
+        members += memberImageURLs.map { .mock(id: .unique, imageURL: $0) }
+        return .mock(cid: cid, lastActiveMembers: members, memberCount: members.count)
+    }
+}
+
+/// An `ImageMerging` spy that counts how many times the merge happens while delegating to the default merger.
+private final class ImageMergerSpy: ImageMerging, @unchecked Sendable {
+    private let wrapped = DefaultImageMerger()
+    private let lock = NSLock()
+    private var count = 0
+
+    var mergeCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func reset() {
+        lock.lock()
+        count = 0
+        lock.unlock()
+    }
+
+    func merge(images: [UIImage], orientation: ImageMergeOrientation) -> UIImage? {
+        lock.lock()
+        count += 1
+        lock.unlock()
+        return wrapped.merge(images: images, orientation: orientation)
     }
 }
 

--- a/Tests/StreamChatUITests/SnapshotTests/CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift
@@ -305,6 +305,38 @@ import XCTest
         XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0, "The avatar should be recomputed when a member shown in it is replaced even if the member count is unchanged")
     }
 
+    func test_loadMergedAvatars_recomputesAvatar_whenAMemberIsAddedWhileFewerThanTheMaximumAreShown() {
+        let cid = ChannelId.unique
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        let window = UIWindow()
+        window.addSubview(view)
+
+        let memberA: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url)
+        let memberB: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.chewbacca.url)
+        let memberC: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.r2.url)
+
+        // The avatar shows two members, fewer than the maximum of four.
+        view.content = (
+            channel: groupChannel(cid: cid, members: [memberA, memberB]),
+            currentUserId: currentUserId
+        )
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+
+        // A member is added. Since the avatar wasn't full, the new member should be shown.
+        imageMergerSpy.reset()
+        view.content = (
+            channel: groupChannel(cid: cid, members: [memberA, memberB, memberC]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0, "The avatar should be recomputed when a member is added while it shows fewer than the maximum number of members")
+    }
+
     func test_loadMergedAvatars_doesNotRecomputeAvatar_whenANonShownMemberLeavesTheChannel() {
         let cid = ChannelId.unique
         let imageMergerSpy = ImageMergerSpy()

--- a/Tests/StreamChatUITests/SnapshotTests/CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift
@@ -178,7 +178,7 @@ import XCTest
         AssertSnapshot(view, variants: .onlyUserInterfaceStyles)
     }
 
-    func test_loadMergedAvatars_doesNotRecomputeAvatar_whenLastActiveMembersChangeForSameChannel() {
+    func test_loadMergedAvatars_doesNotRecomputeAvatar_whenLastActiveMembersAreReorderedForSameChannel() {
         let cid = ChannelId.unique
         let imageMergerSpy = ImageMergerSpy()
 
@@ -190,8 +190,12 @@ import XCTest
         let window = UIWindow()
         window.addSubview(view)
 
+        let memberA: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url)
+        let memberB: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.chewbacca.url)
+        let memberC: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.r2.url)
+
         view.content = (
-            channel: groupChannel(cid: cid, memberImageURLs: [TestImages.yoda.url, TestImages.chewbacca.url, TestImages.r2.url]),
+            channel: groupChannel(cid: cid, members: [memberA, memberB, memberC]),
             currentUserId: currentUserId
         )
 
@@ -199,14 +203,15 @@ import XCTest
         let renderedImage = view.presenceAvatarView.avatarView.imageView.image
         XCTAssertNotNil(renderedImage)
 
-        // Simulate the last active members changing for the same channel.
+        // Simulate the last active members being reordered for the same channel (e.g. because a
+        // member's activity changed). The set of members is unchanged.
         imageMergerSpy.reset()
         view.content = (
-            channel: groupChannel(cid: cid, memberImageURLs: [TestImages.vader.url, TestImages.yoda.url, TestImages.chewbacca.url]),
+            channel: groupChannel(cid: cid, members: [memberC, memberA, memberB]),
             currentUserId: currentUserId
         )
 
-        XCTAssertEqual(imageMergerSpy.mergeCallCount, 0, "The avatar should not be recomputed when the last active members change")
+        XCTAssertEqual(imageMergerSpy.mergeCallCount, 0, "The avatar should not be recomputed when the last active members are only reordered")
         XCTAssertTrue(view.presenceAvatarView.avatarView.imageView.image === renderedImage)
     }
 
@@ -234,6 +239,143 @@ import XCTest
         )
 
         XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0, "The avatar should be recomputed when bound to a different channel")
+    }
+
+    func test_loadMergedAvatars_recomputesAvatar_whenAShownMemberLeavesTheChannel() {
+        let cid = ChannelId.unique
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        let window = UIWindow()
+        window.addSubview(view)
+
+        let memberA: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url)
+        let memberB: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.chewbacca.url)
+        let memberC: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.r2.url)
+
+        view.content = (
+            channel: groupChannel(cid: cid, members: [memberA, memberB, memberC]),
+            currentUserId: currentUserId
+        )
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+
+        // Simulate a member that is shown in the avatar leaving the channel.
+        imageMergerSpy.reset()
+        view.content = (
+            channel: groupChannel(cid: cid, members: [memberA, memberB]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0, "The avatar should be recomputed when a member shown in it leaves the channel")
+    }
+
+    func test_loadMergedAvatars_recomputesAvatar_whenAShownMemberIsReplaced() {
+        let cid = ChannelId.unique
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        let window = UIWindow()
+        window.addSubview(view)
+
+        let memberA: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url)
+        let memberB: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.chewbacca.url)
+        let memberC: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.r2.url)
+        let memberD: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.vader.url)
+
+        view.content = (
+            channel: groupChannel(cid: cid, members: [memberA, memberB, memberC]),
+            currentUserId: currentUserId
+        )
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+
+        // Simulate a member shown in the avatar being replaced by another one. The member count
+        // stays the same, but the avatar must reflect the new membership.
+        imageMergerSpy.reset()
+        view.content = (
+            channel: groupChannel(cid: cid, members: [memberA, memberB, memberD]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0, "The avatar should be recomputed when a member shown in it is replaced even if the member count is unchanged")
+    }
+
+    func test_loadMergedAvatars_doesNotRecomputeAvatar_whenANonShownMemberLeavesTheChannel() {
+        let cid = ChannelId.unique
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        let window = UIWindow()
+        window.addSubview(view)
+
+        // The avatar shows at most four members, the four that joined earliest. The fifth member
+        // (latest `memberCreatedAt`) is therefore not shown in the avatar.
+        let shown1: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url, memberCreatedAt: Date(timeIntervalSince1970: 1))
+        let shown2: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.chewbacca.url, memberCreatedAt: Date(timeIntervalSince1970: 2))
+        let shown3: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.r2.url, memberCreatedAt: Date(timeIntervalSince1970: 3))
+        let shown4: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.vader.url, memberCreatedAt: Date(timeIntervalSince1970: 4))
+        let notShown: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url, memberCreatedAt: Date(timeIntervalSince1970: 5))
+
+        view.content = (
+            channel: groupChannel(cid: cid, members: [shown1, shown2, shown3, shown4, notShown]),
+            currentUserId: currentUserId
+        )
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+        let renderedImage = view.presenceAvatarView.avatarView.imageView.image
+
+        // Simulate the member that isn't shown in the avatar leaving the channel.
+        imageMergerSpy.reset()
+        view.content = (
+            channel: groupChannel(cid: cid, members: [shown1, shown2, shown3, shown4]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertEqual(imageMergerSpy.mergeCallCount, 0, "The avatar should not be recomputed when a member that isn't shown in it changes")
+        XCTAssertTrue(view.presenceAvatarView.avatarView.imageView.image === renderedImage)
+    }
+
+    func test_loadMergedAvatars_doesNotRecomputeAvatar_whenANonShownMemberIsAddedToTheChannel() {
+        let cid = ChannelId.unique
+        let imageMergerSpy = ImageMergerSpy()
+
+        let view = ChatChannelAvatarView().withoutAutoresizingMaskConstraints
+        view.components = .mock
+        view.imageProcessingQueue = nil
+        view.imageMerger = imageMergerSpy
+        let window = UIWindow()
+        window.addSubview(view)
+
+        let shown1: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url, memberCreatedAt: Date(timeIntervalSince1970: 1))
+        let shown2: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.chewbacca.url, memberCreatedAt: Date(timeIntervalSince1970: 2))
+        let shown3: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.r2.url, memberCreatedAt: Date(timeIntervalSince1970: 3))
+        let shown4: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.vader.url, memberCreatedAt: Date(timeIntervalSince1970: 4))
+
+        view.content = (
+            channel: groupChannel(cid: cid, members: [shown1, shown2, shown3, shown4]),
+            currentUserId: currentUserId
+        )
+        XCTAssertGreaterThan(imageMergerSpy.mergeCallCount, 0)
+        let renderedImage = view.presenceAvatarView.avatarView.imageView.image
+
+        // Simulate a new member joining. The four shown members joined earlier, so the new member
+        // isn't shown in the avatar and it stays unchanged.
+        imageMergerSpy.reset()
+        let newMember: ChatChannelMember = .mock(id: .unique, imageURL: TestImages.yoda.url, memberCreatedAt: Date(timeIntervalSince1970: 5))
+        view.content = (
+            channel: groupChannel(cid: cid, members: [shown1, shown2, shown3, shown4, newMember]),
+            currentUserId: currentUserId
+        )
+
+        XCTAssertEqual(imageMergerSpy.mergeCallCount, 0, "The avatar should not be recomputed when a newly added member isn't shown in it")
+        XCTAssertTrue(view.presenceAvatarView.avatarView.imageView.image === renderedImage)
     }
 
     func test_appearanceCustomization_usingAppearanceAndComponents() {
@@ -293,6 +435,14 @@ private extension ChatChannelAvatarView_Tests {
     func groupChannel(cid: ChannelId, memberImageURLs: [URL]) -> ChatChannel {
         var members: [ChatChannelMember] = [.mock(id: currentUserId, imageURL: TestImages.vader.url)]
         members += memberImageURLs.map { .mock(id: .unique, imageURL: $0) }
+        return .mock(cid: cid, lastActiveMembers: members, memberCount: members.count)
+    }
+
+    /// Creates a group channel from the given members (plus the current user) whose avatar is rendered
+    /// by merging member images. Lets tests control member identity to model reordering and membership changes.
+    func groupChannel(cid: ChannelId, members otherMembers: [ChatChannelMember]) -> ChatChannel {
+        let currentUserMember: ChatChannelMember = .mock(id: currentUserId, imageURL: TestImages.vader.url)
+        let members = [currentUserMember] + otherMembers
         return .mock(cid: cid, lastActiveMembers: members, memberCount: members.count)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1747/avatar-placeholders-change-locations.

### 🎯 Goal

Cache the avatar placeholder so it's not recreated when last active members change.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented group channel avatars from changing unexpectedly by caching merged avatars, reusing them when members are unchanged, and resetting the cache when appearance (light/dark) changes or the channel/members actually change.
* **Tests**
  * Added snapshot/unit tests to verify merged-avatar stability across member reordering, member additions/removals, and rebinding to a different channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->