### PR TITLE
Fix highlighting of message interruptions on subsequent opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix the poll comments button showing "1 comments" instead of "1 comment" for a single comment [#4123](https://github.com/GetStream/stream-chat-swift/pull/4123)
+- Fix the message highlight sometimes only blinking when jumping to a message [#4125](https://github.com/GetStream/stream-chat-swift/pull/4125)
 
 # [5.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.5.0)
 _June 03, 2026_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -184,6 +184,13 @@ open class ChatMessageListVC: _ViewController,
     /// A closure that will be performed when a message is scrolled to it and appears on the screen.
     private(set) var onMessageHighlight: ((IndexPath) -> Void)?
 
+    /// The id of the message that is currently highlighted (while jumping to it). Used to re-apply
+    /// the highlight when the cell is reconfigured, so it survives cell reloads/reuse.
+    private(set) var highlightedMessageId: MessageId?
+
+    /// Work item used to fade out the message highlight after the hold duration.
+    private var highlightFadeOutWorkItem: DispatchWorkItem?
+
     /// A boolean value that determines whether date separators should be shown between each message.
     open var isDateSeparatorEnabled: Bool {
         components.messageListDateSeparatorEnabled
@@ -718,16 +725,46 @@ open class ChatMessageListVC: _ViewController,
     }
 
     /// Highlight the the message cell, for example, when jumping to a message.
+    ///
+    /// The highlight is tracked by message id and re-applied whenever the cell is (re)configured,
+    /// so it survives the cell reloads/reuse that can happen while jumping to a message (otherwise
+    /// the highlight could flash and instantly vanish). It is then faded out after a short hold.
     open func highlightCell(at indexPath: IndexPath) {
-        guard let cell = listView.cellForRow(at: indexPath) as? ChatMessageCell else {
+        guard let messageId = dataSource?.chatMessageListVC(self, messageAt: indexPath)?.id else {
             return
         }
-        let previousBackgroundColor = cell.messageContentView?.backgroundColor
-        let highlightColor = appearance.colorPalette.backgroundCoreHighlight
-        cell.messageContentView?.backgroundColor = highlightColor
-        UIView.animate(withDuration: 0.2, delay: 0.6) {
-            cell.messageContentView?.backgroundColor = previousBackgroundColor
+
+        // If a different message was being highlighted, clear it so it doesn't stay highlighted.
+        if let previousId = highlightedMessageId, previousId != messageId {
+            updateHighlightBackgroundColor(nil, forMessageId: previousId)
         }
+
+        highlightedMessageId = messageId
+        updateHighlightBackgroundColor(appearance.colorPalette.backgroundCoreHighlight, forMessageId: messageId)
+
+        // Fade the highlight out after the hold. Driven by a work item independent of the cell
+        // instance, and cancelled/rescheduled if the same message is highlighted again, so
+        // repeated or overlapping highlights always show for their full duration.
+        highlightFadeOutWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.highlightedMessageId == messageId else { return }
+            self.highlightedMessageId = nil
+            UIView.animate(withDuration: 0.2) {
+                self.updateHighlightBackgroundColor(nil, forMessageId: messageId)
+            }
+        }
+        highlightFadeOutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: workItem)
+    }
+
+    /// Sets the background color of the message content view of the cell currently displaying the
+    /// given message id, if it is on screen.
+    private func updateHighlightBackgroundColor(_ color: UIColor?, forMessageId messageId: MessageId) {
+        guard let indexPath = getIndexPath(forMessageId: messageId),
+              let cell = listView.cellForRow(at: indexPath) as? ChatMessageCell else {
+            return
+        }
+        cell.messageContentView?.backgroundColor = color
     }
 
     /// Jump to the first page of the message list.
@@ -802,6 +839,12 @@ open class ChatMessageListVC: _ViewController,
         cell.messageContentView?.channel = channel
         cell.messageContentView?.content = message
         cell.messageContentView?.currentUserId = client.currentUserId
+
+        // Re-apply the highlight if this message is currently being highlighted, so it is not
+        // lost when the cell is reloaded/reused while jumping to the message.
+        if message.id == highlightedMessageId {
+            cell.messageContentView?.backgroundColor = appearance.colorPalette.backgroundCoreHighlight
+        }
 
         /// Process cell decorations
         cell.setDecoration(for: .header, decorationView: delegate?.chatMessageListVC(self, headerViewForMessage: message, at: indexPath))


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1745/uikit-message-highlighting-animation-is-sometimes-really-short.

### 🎯 Goal

Fix highlighting of message interruptions on subsequent opens.

### 📝 Summary

Update the highlighting logic.

### 🛠 Implementation

  The highlight is now tracked by message id, not pinned to a cell:

  1. highlightCell records highlightedMessageId, applies the color, and schedules a fade-out via a DispatchWorkItem after the 0.6s hold — independent of any cell
  instance.
  2. cellForRowAt re-applies the highlight whenever the cell for that message is (re)configured, so it survives reloads/reuse during the jump.
  3. The work item is cancelled/rescheduled on repeat triggers (kills the double-trigger blink too), and a switch to a different message clears the old one.

  So the highlight reliably shows for its full hold + fade regardless of how many times the list reloads while settling.

  It builds and lints clean. Since this is timing/reload behavior that isn't reliably unit-testable, please give it a go in the app — open/close the thread quickly
  and tap quoted replies. I'm fairly confident this one holds, because it's no longer fighting the reload; it rides along with it. If anything's still off, tell me
  exactly what you see and I'll dig in rather than guess.
  

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message highlighting when jumping to a message—the highlight now persists for the full duration instead of briefly blinking, providing better visual feedback during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->