### PR TITLE
[v4] Fix: ChatClient.init crashes on Xcode 27 due to uncompiled CD model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
 ### 🔄 Changed
+- Process `StreamChatModel.xcdatamodeld` as a package resource so the compiled Core Data model is bundled instead of copying the raw model source
 
 # [4.101.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.101.0)
 _June 03, 2026_

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .target(
             name: "StreamChat",
             exclude: ["Info.plist", "Generated/PredefinedFilter.stencil"],
-            resources: [.copy("Database/StreamChatModel.xcdatamodeld")]
+            resources: [.process("Database/StreamChatModel.xcdatamodeld")]
         ),
         .target(
             name: "StreamChatUI",


### PR DESCRIPTION
### 🔗 Issue Links

None created yet (can if needed)

### 🎯 Goal

Xcode 27 Beta 1 changes the way that Core Data models are handled within Swift Package resources. `copy` is intended for embedding the resource untouched, but Xcode 26 & below still compile `xcdatamodeld` resources. Xcode 27 fixes this "bug" and embeds the uncompiled CD model, which results in a crash in `DatabaseContainer.swift`.

### 📝 Summary

Changes the CD model embed policy to `process`, which should compile the resource on all versions.

Note: our team is still on v4, but this would need to be cherry-picked onto `develop` as well.

### 🛠 Implementation

Self-explanatory

### 🎨 Showcase

<details>
<summary>Xcode 27 - Copy</summary>
<img width="388" height="146" alt="xcode27-copy" src="https://github.com/user-attachments/assets/3f872b57-b975-4998-a6fa-8c8b368ba1ba" />

</details>

<details>
<summary>Xcode 27 - Process</summary>
<img width="413" height="172" alt="xcode27-process" src="https://github.com/user-attachments/assets/1d9b0c8b-ec80-4d67-8086-fc844f7c6352" />
</details>

<details>
<summary>Xcode 26 - Copy</summary>
<img width="408" height="155" alt="xcode26-copy" src="https://github.com/user-attachments/assets/c47dca92-f439-48a3-946d-ab8532b2a2a7" />

</details>

<details>
<summary>Xcode 26 - Process</summary>
<img width="372" height="109" alt="xcode26-process" src="https://github.com/user-attachments/assets/a3e56648-2921-4b8d-9238-046efa7e98cf" />

</details>

### 🧪 Manual Testing Notes

In a consuming project, initialize a `ChatClient` with a valid config (perhaps a better way to test first-party)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
