### PR TITLE
Fix search-result icon following channel's latest message instead of matched message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+## StreamChat
+### 🐞 Fixed
+- Fix showing voice recording icon in search results [#4127](https://github.com/GetStream/stream-chat-swift/pull/4127)
+
 # [5.5.1](https://github.com/GetStream/stream-chat-swift/releases/tag/5.5.1)
 _June 11, 2026_
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -202,10 +202,6 @@ open class ChatChannelListItemView: _View, ThemeProvider {
     }
 
     open var subtitleIcon: UIImage? {
-        // For search results, the cell renders the matched message rather than the
-        // channel's latest message — so the icon must follow the matched message,
-        // not the channel's last activity (which would, e.g., show a mic icon next
-        // to a plain text search hit when the channel's last message is voice).
         if let searchedMessage = content?.searchedMessage {
             return searchedMessage.voiceRecordingAttachments.isEmpty
                 ? nil

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -202,7 +202,16 @@ open class ChatChannelListItemView: _View, ThemeProvider {
     }
 
     open var subtitleIcon: UIImage? {
-        isLastMessageVoiceRecording ? appearance.images.mic : nil
+        // For search results, the cell renders the matched message rather than the
+        // channel's latest message — so the icon must follow the matched message,
+        // not the channel's last activity (which would, e.g., show a mic icon next
+        // to a plain text search hit when the channel's last message is voice).
+        if let searchedMessage = content?.searchedMessage {
+            return searchedMessage.voiceRecordingAttachments.isEmpty
+                ? nil
+                : appearance.images.mic
+        }
+        return isLastMessageVoiceRecording ? appearance.images.mic : nil
     }
 
     /// Text of `timestampLabel` which contains the time of the last sent message.


### PR DESCRIPTION
## Why

Fixes #3843.

\`ChatChannelListItemView.subtitleIcon\` was reading \`isLastMessageVoiceRecording\`, which only inspects the channel's \`previewMessage\` (latest message). When a search result rendered a plain-text hit while the channel's last message happened to be a voice recording, the search-result cell still showed the mic icon next to the text — exactly the screenshots in the issue.

## What

In \`subtitleIcon\`, when \`content.searchedMessage\` is non-nil (we're rendering a search hit, not the normal channel preview), derive the icon from the matched message's attachments instead of the channel's last message. Non-search behavior is unchanged.

10-line diff in [\`ChatChannelListItemView.swift\`](https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift#L204).

## Test

I don't have access to a Stream backend to run the E2E repro from the issue, but the behavior is fully determined by \`content.searchedMessage\` and \`searchedMessage.voiceRecordingAttachments\` so the logic is straightforward to step through against the screenshots. Happy to add a snapshot test under \`Tests/StreamChatUITests/\` if you'd like — point me at a comparable existing search-result snapshot and I'll mirror it.

## Compat

No public API change; \`subtitleIcon\` is already \`open var\`, the override surface is identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mic icon display in search results so it appears only when the searched message includes a voice recording attachment.
  * Preserved existing behavior in regular channel lists: the mic icon continues to show when the last message is a voice recording, keeping visuals consistent outside search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->