### PR TITLE
Fix ChatClient.init crash on Xcode 27 due to uncompiled Core Data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🔄 Changed
-- Process `StreamChatModel.xcdatamodeld` as a package resource so the compiled Core Data model is bundled instead of copying the raw model source
+- Process `StreamChatModel.xcdatamodeld` as a package resource so the compiled Core Data model is bundled instead of copying the raw model source [#4128](https://github.com/GetStream/stream-chat-swift/pull/4128)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🔄 Changed
+- Process `StreamChatModel.xcdatamodeld` as a package resource so the compiled Core Data model is bundled instead of copying the raw model source
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix the poll comments button showing "1 comments" instead of "1 comment" for a single comment [#4123](https://github.com/GetStream/stream-chat-swift/pull/4123)

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
                 .product(name: "StreamCore", package: "stream-core-swift")
             ],
             exclude: ["Info.plist", "Generated/PredefinedFilter.stencil"],
-            resources: [.copy("Database/StreamChatModel.xcdatamodeld")]
+            resources: [.process("Database/StreamChatModel.xcdatamodeld")]
         ),
         .target(
             name: "StreamChatUI",


### PR DESCRIPTION
### 🔗 Issue Links

Cherry-pick of #4126 from `v4`.

[IOS-1751](https://linear.app/stream/issue/IOS-1751/xcode-27-compatibility-for-chat)

### 🎯 Goal

Bring the Xcode 27 fix from `v4` to `develop`. Xcode 27 Beta 1 no longer compiles `xcdatamodeld` resources declared with `.copy`, so the raw model source gets bundled and `ChatClient.init` crashes when loading the Core Data model.

### 📝 Summary

- Declare `StreamChatModel.xcdatamodeld` with `.process` instead of `.copy` in `Package.swift` so the compiled Core Data model is bundled on all Xcode versions

### 🛠 Implementation

Clean cherry-pick of 403719a from `v4`, with the CHANGELOG entry moved to the `# Upcoming` section on `develop`.

### 🎨 Showcase

See #4126 for Xcode 26/27 before/after screenshots.

### 🧪 Manual Testing Notes

In a consuming SPM project built with Xcode 27, initialize a `ChatClient` with a valid config.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Core Data model bundling in package build configuration for improved resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->