### PR TITLE
Update StreamCore to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🔄 Changed
 - Process `StreamChatModel.xcdatamodeld` as a package resource so the compiled Core Data model is bundled instead of copying the raw model source [#4128](https://github.com/GetStream/stream-chat-swift/pull/4128)
+- Update StreamCore to 0.7.0, which fixes `Sendable` errors when building with Xcode 27 [#4129](https://github.com/GetStream/stream-chat-swift/pull/4129)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", exact: "1.0.0"),
-        .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.6.4")
+        .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.7.0")
     ],
     targets: [
         .target(

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -5422,7 +5422,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-core-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.4;
+				minimumVersion = 0.7.0;
 			};
 		};
 		A3BD4869281FD4500090D511 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1751/xcode-27-compatibility-for-chat

### 🎯 Goal

Update StreamCore to 0.7.0, which fixes `Sendable` errors in `Sort` when building with Xcode 27.

### 📝 Summary

- Bump the `stream-core-swift` minimum version from 0.6.4 to 0.7.0 in `Package.swift` and the Xcode project

### 🛠 Implementation

Dependency version bump only, no code changes.

### 🎨 Showcase

_Not applicable._

### 🧪 Manual Testing Notes

Build the SDK with Xcode 27 and verify there are no `Sendable` errors coming from StreamCore.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved build compatibility issues with Xcode 27 by updating core dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->