### PR TITLE
Fix SwiftUI Spacer resolution conflict when building with Xcode 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
-
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix `Spacer()` conflicting with SwiftUI's `Spacer` when building with Xcode 27 [#4131](https://github.com/GetStream/stream-chat-swift/pull/4131)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix `Spacer()` conflicting with SwiftUI's `Spacer` when building with Xcode 27 [#4131](https://github.com/GetStream/stream-chat-swift/pull/4131)
+
 # [5.5.1](https://github.com/GetStream/stream-chat-swift/releases/tag/5.5.1)
 _June 11, 2026_
 

--- a/Sources/StreamChatUI/ViewContainerBuilder/ViewContainerBuilder.swift
+++ b/Sources/StreamChatUI/ViewContainerBuilder/ViewContainerBuilder.swift
@@ -112,7 +112,11 @@ public func HContainer(
 }
 
 /// A flexible space that expands along the major axis of its containing stack layout.
+///
+/// - Note: `@_disfavoredOverload` keeps SwiftUI's `Spacer` the preferred candidate in
+///   `ViewBuilder` contexts when both StreamChatUI and SwiftUI are imported.
 @MainActor
+@_disfavoredOverload
 public func Spacer() -> UIView {
     let view = UIStackView()
     view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1751/xcode-27-compatibility-for-chat

### 🎯 Goal

Make the SDK and the demo apps compile with Xcode 27 (beta).

### 📝 Summary

- Added `@_disfavoredOverload` to StreamChatUI's public `func Spacer() -> UIView` so SwiftUI's `Spacer` remains the preferred overload in `ViewBuilder` contexts.

### 🛠 Implementation

The iOS 27 SDK's `ViewBuilder` produces variadic `TupleContent` values whose `View` requirement is a conditional conformance checked *after* overload resolution. In files importing both StreamChatUI and SwiftUI, `Spacer()` inside a `ViewBuilder` therefore started resolving to StreamChatUI's UIKit DSL function and failed to compile (`generic struct 'HStack' requires that 'UIView' conform to 'View'`) — e.g. in `DemoShareView`, and equally in any customer app mixing both imports.

With `@_disfavoredOverload`, `SwiftUI.Spacer` wins whenever it type-checks (matching the pre-Xcode 27 behavior), while UIKit `VContainer`/`HContainer` builders still pick the UIKit function because `SwiftUI.Spacer` never type-checks as a `UIView` there.

Verified:
- DemoApp scheme builds with Xcode 27 beta (27A5194q) and with Xcode 26.5.
- Snapshot tests for all DSL-using components pass: `ChatMessageContentView_Tests`, `PollAttachmentView_Tests`, `PollResultsVC_Tests`, `PollResultsVoteListVC_Tests`.

### 🎨 Showcase

N/A — compile-level fix, no visual changes.

### 🧪 Manual Testing Notes

Build the DemoApp scheme with Xcode 27 beta without changing the global Xcode selection:

```
DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild \
  -project StreamChat.xcodeproj -scheme DemoApp \
  -destination 'generic/platform=iOS Simulator' \
  IPHONEOS_DEPLOYMENT_TARGET=15.0 build
```

The deployment-target override is unrelated to this fix: Xcode 27 raised the minimum supported deployment target to iOS 15.0 while the project targets are still iOS 13/14.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved conflict between StreamChatUI's `Spacer()` component and SwiftUI's native `Spacer` when building with Xcode 27, enabling seamless integration of SwiftUI components in StreamChatUI projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->