### PR TITLE
Respect channel capabilities before sending typing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Stop sending typing events on channels whose capabilities don't allow them [#4132](https://github.com/GetStream/stream-chat-swift/pull/4132)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix `Spacer()` conflicting with SwiftUI's `Spacer` when building with Xcode 27 [#4131](https://github.com/GetStream/stream-chat-swift/pull/4131)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Stop sending typing events on channels whose capabilities don't allow them [#4132](https://github.com/GetStream/stream-chat-swift/pull/4132)
+- Fix sending typing events to channels without typing events capability [#4132](https://github.com/GetStream/stream-chat-swift/pull/4132)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -151,7 +151,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// A boolean value indicating if it should send typing events.
     /// It is `true` if the channel typing events are enabled as well as the user privacy settings.
     func shouldSendTypingEvents(completion: @escaping @Sendable (Bool) -> Void) {
-        guard channel?.canSendTypingEvents ?? true else {
+        guard channel?.canSendTypingEvents ?? false else {
             completion(false)
             return
         }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -1356,6 +1356,7 @@ public class Chat: @unchecked Sendable {
     ///
     /// - Throws: An error while communicating with the Stream API.
     public func keystroke(parentMessageId: MessageId? = nil) async throws {
+        guard await state.channel?.canSendTypingEvents ?? false else { return }
         try await typingEventsSender.keystroke(in: cid, parentMessageId: parentMessageId)
     }
     
@@ -1367,6 +1368,7 @@ public class Chat: @unchecked Sendable {
     ///
     /// - Throws: An error while communicating with the Stream API.
     public func stopTyping(parentMessageId: MessageId? = nil) async throws {
+        guard await state.channel?.canSendTypingEvents ?? false else { return }
         try await typingEventsSender.stopTyping(in: cid, parentMessageId: parentMessageId)
     }
     

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -5333,7 +5333,7 @@ final class ChannelController_Tests: XCTestCase {
         }
 
         let isEnabled = try waitFor { controller.shouldSendTypingEvents(completion: $0) }
-        XCTAssertEqual(isEnabled, true)
+        XCTAssertEqual(isEnabled, false)
     }
 
     func test_shouldSendTypingEvents_whenChannelEnabled_whenUserEnabled() throws {

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -3230,6 +3230,55 @@ final class ChannelController_Tests: XCTestCase {
         XCTAssertEqual(channelFeatureError.localizedDescription, "Channel feature: typing events is disabled for this channel.")
     }
 
+    func test_sendKeystrokeEvent_whenChannelIsNotLoaded_doesNotSend() throws {
+        // Do not save a channel, so the controller's channel is `nil` and capabilities are unknown.
+        nonisolated(unsafe) var completionCalled = false
+
+        let error: Error? = try waitFor { completion in
+            controller.sendKeystrokeEvent {
+                completionCalled = true
+                completion($0)
+            }
+        }
+
+        XCTAssertTrue(completionCalled)
+        XCTAssertNil(error)
+        // The event sender is built lazily only when an event is actually sent, so a `nil` sender confirms no send happened.
+        XCTAssertNil(env.eventSender?.keystroke_cid)
+    }
+
+    func test_sendStartTypingEvent_whenChannelIsNotLoaded_errors() throws {
+        // Do not save a channel, so the controller's channel is `nil` and capabilities are unknown.
+        nonisolated(unsafe) var completionCalled = false
+
+        let error: Error? = try waitFor { completion in
+            controller.sendStartTypingEvent {
+                completionCalled = true
+                completion($0)
+            }
+        }
+
+        XCTAssertTrue(completionCalled)
+        XCTAssertTrue(error is ClientError.ChannelFeatureDisabled)
+        XCTAssertNil(env.eventSender?.startTyping_cid)
+    }
+
+    func test_sendStopTypingEvent_whenChannelIsNotLoaded_errors() throws {
+        // Do not save a channel, so the controller's channel is `nil` and capabilities are unknown.
+        nonisolated(unsafe) var completionCalled = false
+
+        let error: Error? = try waitFor { completion in
+            controller.sendStopTypingEvent {
+                completionCalled = true
+                completion($0)
+            }
+        }
+
+        XCTAssertTrue(completionCalled)
+        XCTAssertTrue(error is ClientError.ChannelFeatureDisabled)
+        XCTAssertNil(env.eventSender?.stopTyping_cid)
+    }
+
     func test_keystroke_keepsControllerAlive() throws {
         // Save channel with typing events enabled to database
         writeAndWaitForMessageUpdates(count: 1, channelChanges: true) {

--- a/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/Chat_Tests.swift
@@ -245,7 +245,45 @@ final class Chat_Tests: XCTestCase {
         XCTAssertEqual(channelId, env.channelUpdaterMock.freezeChannel_cid)
         XCTAssertEqual(false, env.channelUpdaterMock.freezeChannel_freeze)
     }
-    
+
+    // MARK: - Typing Indicators
+
+    func test_keystroke_whenChannelCannotSendTypingEvents_doesNotMakeAPIRequest() async throws {
+        try await setUpChatWithLoadedChannel(ownCapabilities: [])
+
+        try await chat.keystroke()
+
+        XCTAssertNil(env.client.mockAPIClient.request_endpoint)
+    }
+
+    func test_stopTyping_whenChannelCannotSendTypingEvents_doesNotMakeAPIRequest() async throws {
+        try await setUpChatWithLoadedChannel(ownCapabilities: [])
+
+        try await chat.stopTyping()
+
+        XCTAssertNil(env.client.mockAPIClient.request_endpoint)
+    }
+
+    func test_keystroke_whenChannelCanSendTypingEvents_makesAPIRequest() async throws {
+        try await setUpChatWithLoadedChannel(ownCapabilities: [ChannelCapability.sendTypingEvents.rawValue])
+        env.client.mockAPIClient.test_mockResponseResult(Result<EmptyResponse, Error>.success(EmptyResponse()))
+
+        try await chat.keystroke()
+
+        let expectedEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: channelId, parentMessageId: nil)
+        XCTAssertEqual(env.client.mockAPIClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
+    func test_stopTyping_whenChannelCanSendTypingEvents_makesAPIRequest() async throws {
+        try await setUpChatWithLoadedChannel(ownCapabilities: [ChannelCapability.sendTypingEvents.rawValue])
+        env.client.mockAPIClient.test_mockResponseResult(Result<EmptyResponse, Error>.success(EmptyResponse()))
+
+        try await chat.stopTyping()
+
+        let expectedEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: channelId, parentMessageId: nil)
+        XCTAssertEqual(env.client.mockAPIClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
     // MARK: - Invites
     
     func test_acceptInvite_whenChannelUpdaterSucceeds_thenAcceptInviteSucceeds() async throws {
@@ -1955,6 +1993,15 @@ final class Chat_Tests: XCTestCase {
         }
     }
     
+    /// Sets up a chat backed by real updaters and loads a channel with the given capabilities into the state.
+    @MainActor private func setUpChatWithLoadedChannel(ownCapabilities: [String]) async throws {
+        let payload = ChannelPayload.dummy(channel: .dummy(cid: channelId, ownCapabilities: ownCapabilities))
+        env.client.mockAPIClient.test_mockResponseResult(.success(payload))
+        try await setUpChat(usesMockedUpdaters: false)
+        try await chat.get(watch: false)
+        env.client.mockAPIClient.cleanUp()
+    }
+
     private func makeChannelPayload(
         cid: ChannelId? = nil,
         messageCount: Int,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1766](https://linear.app/stream/issue/IOS-1766/)

### 🎯 Goal

Stop sending `typing.start` / `typing.stop` events to channels whose `own_capabilities` don't include `send-typing-events` (e.g. livestream channels).

### 📝 Summary

- `ChatChannelController` no longer sends typing events when the channel model isn't loaded yet, instead of optimistically assuming typing is allowed.
- The async `Chat` state layer now also respects the channel's typing capability before sending typing events.

### 🛠 Implementation

The capability gate in `ChannelController.shouldSendTypingEvents` fell back to `true` when the channel had not yet been loaded from the local store (`channel == nil`). In that window, keystroke/start/stop events were sent regardless of `own_capabilities`, so a livestream channel (which lacks `send-typing-events`) still received them and the backend rejected them. The fallback is now `false`, matching `LivestreamChannelController`, `LivestreamChat`, and the typing-indicator display path.

The async `Chat.keystroke` / `Chat.stopTyping` had no capability check at all; they now guard on `canSendTypingEvents`, mirroring `LivestreamChat`.

**Backend verification:** Confirmed against the backend that this is config-driven, not role-driven. The `livestream` channel type defaults to `TypingEvents: false`, and the `send-typing-events` own-capability is derived directly from that flag. The server rejects `typing.start` / `typing.stop` for such channels before any permission check (event-support validation), which is the error this fixes client-side. The backend also folds the user's typing-indicator privacy setting into the same capability, so the SDK's existing `canSendTypingEvents` check already covers both the channel-config and privacy cases.

### 🧪 Manual Testing Notes

Connect to a channel whose type has typing events disabled (or a livestream channel) and type in the composer. No `typing.start` / `typing.stop` request should be issued.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped typing indicators from being sent when the channel doesn’t support typing events.
  * Updated typing behavior so typing actions no longer proceed when the channel is missing or typing events are disabled.
* **Tests**
  * Added/expanded tests covering keystroke/start/stop typing behavior for nil (not loaded) channels and for enabled vs. disabled typing capabilities.
* **Documentation**
  * Updated the changelog with the new “Upcoming → StreamChat → 🐞 Fixed” entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
