### PR TITLE
[Enhanced Mentions 3/6] Add role search support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `all_mentions` and `direct_mentions` push notification preference levels [#4137](https://github.com/GetStream/stream-chat-swift/pull/4137)
 - Add user groups support [#4138](https://github.com/GetStream/stream-chat-swift/pull/4138)
+- Add support for searching roles [#4139](https://github.com/GetStream/stream-chat-swift/pull/4139)
 ### 🐞 Fixed
 - Fix sending typing events to channels without typing events capability [#4132](https://github.com/GetStream/stream-chat-swift/pull/4132)
 ### 🔄 Changed
@@ -40,8 +41,6 @@ _June 03, 2026_
 - Add `ChatClient.queryGroupedChannels(groups:limit:presence:watch:)` to fetch grouped channels with per-group unread counts [#4076](https://github.com/GetStream/stream-chat-swift/pull/4076)
 - Add `ChatClient.makeChannelList(with:)` overload for observing a single grouped channels group in the state layer [#4076](https://github.com/GetStream/stream-chat-swift/pull/4076)
 - Add `unreadChannelCountsByGroup` to `CurrentChatUser`, observable for changes via `ConnectedUser` [#4076](https://github.com/GetStream/stream-chat-swift/pull/4076)
-- Add `all_mentions` and `direct_mentions` push notification preference levels [#4137](https://github.com/GetStream/stream-chat-swift/pull/4137)
-- Add support for searching roles [#4139](https://github.com/GetStream/stream-chat-swift/pull/4139)
 
 # [4.101.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.101.0)
 _June 03, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _June 03, 2026_
 - Add `ChatClient.makeChannelList(with:)` overload for observing a single grouped channels group in the state layer [#4076](https://github.com/GetStream/stream-chat-swift/pull/4076)
 - Add `unreadChannelCountsByGroup` to `CurrentChatUser`, observable for changes via `ConnectedUser` [#4076](https://github.com/GetStream/stream-chat-swift/pull/4076)
 - Add `all_mentions` and `direct_mentions` push notification preference levels [#4137](https://github.com/GetStream/stream-chat-swift/pull/4137)
+- Add support for searching roles [#4139](https://github.com/GetStream/stream-chat-swift/pull/4139)
 
 # [4.101.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.101.0)
 _June 03, 2026_

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
@@ -16,7 +16,8 @@ extension EndpointPath {
              .callToken, .createCall, .deleteFile, .deleteImage, .og, .getApp, .threads, .thread, .markThreadRead, .markThreadUnread,
              .polls, .pollsQuery, .poll, .pollOption, .pollOptions, .pollVotes, .pollVoteInMessage, .pollVote,
              .unread, .blockUser, .unblockUser, .drafts, .reminders, .reminder, .liveLocations, .uploadAttachment, .pushPreferences,
-             .userGroups, .userGroupSearch, .userGroup, .userGroupMembers, .userGroupMembersDelete:
+             .userGroups, .userGroupSearch, .userGroup, .userGroupMembers, .userGroupMembersDelete,
+             .rolesSearch:
             return false
         }
     }

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RolePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RolePayloads.swift
@@ -1,0 +1,64 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object describing a role JSON payload.
+struct RolePayload: Decodable, Sendable {
+    let name: String
+    let custom: Bool
+    let scopes: [String]
+    let createdAt: Date?
+    let updatedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case custom
+        case scopes
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        custom = try container.decodeIfPresent(Bool.self, forKey: .custom) ?? false
+        scopes = try container.decodeIfPresent([String].self, forKey: .scopes) ?? []
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+    }
+
+    init(
+        name: String,
+        custom: Bool = false,
+        scopes: [String] = [],
+        createdAt: Date? = nil,
+        updatedAt: Date? = nil
+    ) {
+        self.name = name
+        self.custom = custom
+        self.scopes = scopes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    func asModel() -> Role {
+        Role(
+            name: name,
+            isCustom: custom,
+            scopes: scopes,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+/// A response containing a list of roles.
+struct RoleListPayload: Decodable, Sendable {
+    let roles: [RolePayload]
+
+    enum CodingKeys: String, CodingKey {
+        case roles
+    }
+}

--- a/Sources/StreamChat/APIClient/Endpoints/RoleEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/RoleEndpoints.swift
@@ -1,0 +1,17 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Endpoint {
+    static func searchRoles(query: RoleSearchQuery) -> Endpoint<RoleListPayload> {
+        .init(
+            path: .rolesSearch,
+            method: .get,
+            queryItems: query,
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+}

--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -198,6 +198,12 @@ extension ChatClient {
         ) -> UserGroupsRepository = {
             UserGroupsRepository(database: $0, apiClient: $1)
         }
+
+        var rolesRepositoryBuilder: @Sendable (
+            _ apiClient: APIClient
+        ) -> RolesRepository = {
+            RolesRepository(apiClient: $0)
+        }
         
         var channelListUpdaterBuilder: @Sendable (
             _ database: DatabaseContainer,

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -96,6 +96,11 @@ public class ChatClient: @unchecked Sendable {
         environment.userGroupsRepositoryBuilder(databaseContainer, apiClient)
     }()
 
+    /// Repository for searching roles.
+    lazy var rolesRepository: RolesRepository = {
+        environment.rolesRepositoryBuilder(apiClient)
+    }()
+
     let channelListUpdater: ChannelListUpdater
 
     /// Handler for watching channels and preventing duplicate watch requests.

--- a/Sources/StreamChat/Controllers/RoleSearchController/RoleSearchController+Combine.swift
+++ b/Sources/StreamChat/Controllers/RoleSearchController/RoleSearchController+Combine.swift
@@ -1,0 +1,44 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+extension RoleSearchController {
+    /// A publisher emitting a new value every time the state of the controller changes.
+    public var statePublisher: AnyPublisher<DataController.State, Never> {
+        basePublishers.state.keepAlive(self)
+    }
+
+    /// A publisher emitting a new value every time the list of roles changes.
+    public var rolesChangesPublisher: AnyPublisher<[Role], Never> {
+        basePublishers.rolesChanges.keepAlive(self)
+    }
+
+    class BasePublishers {
+        unowned let controller: RoleSearchController
+
+        let state: CurrentValueSubject<DataController.State, Never>
+        let rolesChanges: PassthroughSubject<[Role], Never> = .init()
+
+        init(controller: RoleSearchController) {
+            self.controller = controller
+            state = .init(controller.state)
+            controller.multicastDelegate.add(additionalDelegate: self)
+        }
+    }
+}
+
+extension RoleSearchController.BasePublishers: RoleSearchControllerDelegate {
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state.send(state)
+    }
+
+    func controller(
+        _ controller: RoleSearchController,
+        didChangeRoles roles: [Role]
+    ) {
+        rolesChanges.send(roles)
+    }
+}

--- a/Sources/StreamChat/Controllers/RoleSearchController/RoleSearchController.swift
+++ b/Sources/StreamChat/Controllers/RoleSearchController/RoleSearchController.swift
@@ -1,0 +1,118 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public extension ChatClient {
+    /// Creates a new `RoleSearchController`.
+    func roleSearchController() -> RoleSearchController {
+        .init(client: self)
+    }
+}
+
+/// A controller for searching roles.
+///
+/// Roles are not persisted locally. Results are kept in memory and
+/// replaced on every new search.
+public class RoleSearchController: DataController, DelegateCallable, DataStoreProvider, @unchecked Sendable {
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: ChatClient
+
+    /// The roles returned by the last search.
+    public private(set) var roles: [Role] = []
+
+    /// Set the delegate of `RoleSearchController` to observe changes.
+    public weak var delegate: RoleSearchControllerDelegate? {
+        get { multicastDelegate.mainDelegate }
+        set { multicastDelegate.set(mainDelegate: newValue) }
+    }
+
+    var multicastDelegate: MulticastDelegate<RoleSearchControllerDelegate> = .init() {
+        didSet {
+            stateMulticastDelegate.set(mainDelegate: multicastDelegate.mainDelegate)
+            stateMulticastDelegate.set(additionalDelegates: multicastDelegate.additionalDelegates)
+        }
+    }
+
+    var _basePublishers: Any?
+    var basePublishers: BasePublishers {
+        if let value = _basePublishers as? BasePublishers {
+            return value
+        }
+        _basePublishers = BasePublishers(controller: self)
+        return _basePublishers as? BasePublishers ?? .init(controller: self)
+    }
+
+    private let rolesRepository: RolesRepository
+
+    init(client: ChatClient) {
+        self.client = client
+        rolesRepository = client.rolesRepository
+        super.init()
+    }
+
+    /// Searches roles by name.
+    ///
+    /// The `roles` property is updated with the results on completion.
+    ///
+    /// - Parameters:
+    ///   - text: The search term used to match role names.
+    ///   - roleType: When set, restricts the search to roles of the given type.
+    ///   - completion: Called with the matching roles or an error.
+    public func searchRoles(
+        text: String,
+        roleType: RoleType? = nil,
+        completion: (@MainActor (Result<[Role], Error>) -> Void)? = nil
+    ) {
+        searchRoles(
+            query: RoleSearchQuery(query: text, roleType: roleType),
+            completion: completion
+        )
+    }
+
+    /// Searches roles using the provided query.
+    ///
+    /// The `roles` property is updated with the results on completion.
+    ///
+    /// - Parameters:
+    ///   - query: The query describing the search term and filters.
+    ///   - completion: Called with the matching roles or an error.
+    public func searchRoles(
+        query: RoleSearchQuery,
+        completion: (@MainActor (Result<[Role], Error>) -> Void)? = nil
+    ) {
+        rolesRepository.searchRoles(query: query) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let fetchedRoles):
+                self.roles = fetchedRoles
+                self.state = .remoteDataFetched
+                self.delegateCallback { [weak self] in
+                    guard let self else { return }
+                    $0.controller(self, didChangeRoles: self.roles)
+                }
+                self.callback { completion?(.success(fetchedRoles)) }
+            case .failure(let error):
+                self.state = .remoteDataFetchFailed(ClientError(with: error))
+                self.callback { completion?(.failure(error)) }
+            }
+        }
+    }
+}
+
+/// `RoleSearchController` uses this protocol to communicate changes to its delegate.
+public protocol RoleSearchControllerDelegate: DataControllerStateDelegate {
+    /// The controller updated its list of roles.
+    func controller(
+        _ controller: RoleSearchController,
+        didChangeRoles roles: [Role]
+    )
+}
+
+public extension RoleSearchControllerDelegate {
+    func controller(
+        _ controller: RoleSearchController,
+        didChangeRoles roles: [Role]
+    ) {}
+}

--- a/Sources/StreamChat/Controllers/RoleSearchController/RoleSearchController.swift
+++ b/Sources/StreamChat/Controllers/RoleSearchController/RoleSearchController.swift
@@ -13,8 +13,7 @@ public extension ChatClient {
 
 /// A controller for searching roles.
 ///
-/// Roles are not persisted locally. Results are kept in memory and
-/// replaced on every new search.
+/// Results are replaced on every new search.
 public class RoleSearchController: DataController, DelegateCallable, DataStoreProvider, @unchecked Sendable {
     /// The `ChatClient` instance this controller belongs to.
     public let client: ChatClient

--- a/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
@@ -94,6 +94,7 @@ enum EndpointPath: Codable {
     case userGroupMembersDelete(id: String)
 
     case getApp
+    case rolesSearch
 
     var value: String {
         switch self {
@@ -187,6 +188,7 @@ enum EndpointPath: Codable {
 
         case .getApp:
             return "/api/v2/app"
+        case .rolesSearch: return "roles/search"
         }
     }
 }

--- a/Sources/StreamChat/Models/Role.swift
+++ b/Sources/StreamChat/Models/Role.swift
@@ -4,7 +4,9 @@
 
 import Foundation
 
-/// A role that can be mentioned in a channel to notify all of its members.
+/// A role that can be mentioned in a channel to notify users assigned to it.
+///
+/// Roles can be either app-level (global) or channel-specific.
 public struct Role: Equatable, Identifiable, Sendable {
     /// The unique name of the role (e.g. `admin`, `moderator`). Also used as the identifier.
     public let name: String

--- a/Sources/StreamChat/Models/Role.swift
+++ b/Sources/StreamChat/Models/Role.swift
@@ -23,7 +23,7 @@ public struct Role: Equatable, Identifiable, Sendable {
 
     public var id: String { name }
 
-    public init(
+    init(
         name: String,
         isCustom: Bool = false,
         scopes: [String] = [],

--- a/Sources/StreamChat/Models/Role.swift
+++ b/Sources/StreamChat/Models/Role.swift
@@ -1,0 +1,39 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A role that can be mentioned in a channel to notify all of its members.
+public struct Role: Equatable, Identifiable, Sendable {
+    /// The unique name of the role (e.g. `admin`, `moderator`). Also used as the identifier.
+    public let name: String
+
+    /// Whether the role is a custom role defined for the application.
+    public let isCustom: Bool
+
+    /// The permission scopes the role applies to.
+    public let scopes: [String]
+
+    /// The date when the role was created, when available.
+    public let createdAt: Date?
+
+    /// The date when the role was last updated, when available.
+    public let updatedAt: Date?
+
+    public var id: String { name }
+
+    public init(
+        name: String,
+        isCustom: Bool = false,
+        scopes: [String] = [],
+        createdAt: Date? = nil,
+        updatedAt: Date? = nil
+    ) {
+        self.name = name
+        self.isCustom = isCustom
+        self.scopes = scopes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/Sources/StreamChat/Query/RoleSearchQuery.swift
+++ b/Sources/StreamChat/Query/RoleSearchQuery.swift
@@ -1,0 +1,63 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type of roles to include when searching.
+public enum RoleType: String, Sendable, Equatable {
+    /// Roles that can be assigned to users.
+    case user
+    /// Roles that can be assigned within a channel.
+    case channel
+}
+
+/// A query used for searching roles from the backend.
+public struct RoleSearchQuery: Encodable, Sendable, Equatable {
+    private enum CodingKeys: String, CodingKey {
+        case query
+        case limit
+        case includeGlobalRoles = "include_global_roles"
+        case nameGreaterThan = "name_gt"
+        case roleType = "role_type"
+    }
+
+    /// The search term used to match role names.
+    public let query: String
+
+    /// The maximum number of roles to return.
+    public var limit: Int?
+
+    /// Whether global (application-level) roles should be included in the results.
+    public var includeGlobalRoles: Bool?
+
+    /// Cursor: return roles with a name greater than this value.
+    public var nameGreaterThan: String?
+
+    /// When set, restricts the search to roles of the given type.
+    /// When `nil`, both user- and channel-assignable roles are searched.
+    public var roleType: RoleType?
+
+    public init(
+        query: String,
+        limit: Int? = nil,
+        includeGlobalRoles: Bool? = nil,
+        nameGreaterThan: String? = nil,
+        roleType: RoleType? = nil
+    ) {
+        self.query = query
+        self.limit = limit
+        self.includeGlobalRoles = includeGlobalRoles
+        self.nameGreaterThan = nameGreaterThan
+        self.roleType = roleType
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(query, forKey: .query)
+        try container.encodeIfPresent(limit, forKey: .limit)
+        try container.encodeIfPresent(includeGlobalRoles, forKey: .includeGlobalRoles)
+        try container.encodeIfPresent(nameGreaterThan, forKey: .nameGreaterThan)
+        try container.encodeIfPresent(roleType?.rawValue, forKey: .roleType)
+    }
+}

--- a/Sources/StreamChat/Query/RoleSearchQuery.swift
+++ b/Sources/StreamChat/Query/RoleSearchQuery.swift
@@ -31,7 +31,7 @@ public struct RoleSearchQuery: Encodable, Sendable, Equatable {
     /// Whether global (application-level) roles should be included in the results.
     public var includeGlobalRoles: Bool?
 
-    /// Cursor: return roles with a name greater than this value.
+    /// Return roles with a name greater than this value.
     public var nameGreaterThan: String?
 
     /// When set, restricts the search to roles of the given type.

--- a/Sources/StreamChat/Query/RoleSearchQuery.swift
+++ b/Sources/StreamChat/Query/RoleSearchQuery.swift
@@ -5,11 +5,23 @@
 import Foundation
 
 /// The type of roles to include when searching.
-public enum RoleType: String, Sendable, Equatable {
+public struct RoleType: RawRepresentable, Codable, Hashable, ExpressibleByStringLiteral, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)
+    }
+}
+
+public extension RoleType {
     /// Roles that can be assigned to users.
-    case user
+    static let user: Self = "user"
     /// Roles that can be assigned within a channel.
-    case channel
+    static let channel: Self = "channel"
 }
 
 /// A query used for searching roles from the backend.

--- a/Sources/StreamChat/Repositories/RolesRepository.swift
+++ b/Sources/StreamChat/Repositories/RolesRepository.swift
@@ -1,0 +1,39 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Repository for searching roles.
+///
+/// Roles are transient and not persisted locally, so results are returned only
+/// through the completion handler.
+class RolesRepository: @unchecked Sendable {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    func searchRoles(
+        query: RoleSearchQuery,
+        completion: @escaping @Sendable (Result<[Role], Error>) -> Void
+    ) {
+        apiClient.request(endpoint: .searchRoles(query: query)) { result in
+            switch result {
+            case .success(let response):
+                completion(.success(response.roles.map { $0.asModel() }))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func searchRoles(query: RoleSearchQuery) async throws -> [Role] {
+        try await withCheckedThrowingContinuation { continuation in
+            searchRoles(query: query) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -339,6 +339,19 @@ extension ChatClient {
     }
 }
 
+// MARK: - Factory Methods for Searching Roles
+
+extension ChatClient {
+    /// Creates an instance of ``RoleSearch`` which represents an array of roles matching to the specified ``RoleSearchQuery``.
+    ///
+    /// Use ``RoleSearch`` as a data source for role search UIs, such as role mentions in the composer.
+    ///
+    /// - Returns: An instance of ``RoleSearch`` which represents search actions and the search state.
+    public func makeRoleSearch() -> RoleSearch {
+        RoleSearch(client: self)
+    }
+}
+
 // MARK: - Factory Methods for Searching User Groups
 
 extension ChatClient {

--- a/Sources/StreamChat/StateLayer/RoleSearch.swift
+++ b/Sources/StreamChat/StateLayer/RoleSearch.swift
@@ -6,8 +6,7 @@ import Foundation
 
 /// An object which represents a list of `Role` for the specified search query.
 ///
-/// Roles are not persisted locally; results are kept in ``RoleSearchState`` and
-/// replaced on every new search.
+/// Results are kept in ``RoleSearchState`` and replaced on every new search.
 public class RoleSearch: @unchecked Sendable {
     @MainActor private var stateBuilder: StateBuilder<RoleSearchState>
     private let rolesRepository: RolesRepository

--- a/Sources/StreamChat/StateLayer/RoleSearch.swift
+++ b/Sources/StreamChat/StateLayer/RoleSearch.swift
@@ -1,0 +1,51 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object which represents a list of `Role` for the specified search query.
+///
+/// Roles are not persisted locally; results are kept in ``RoleSearchState`` and
+/// replaced on every new search.
+public class RoleSearch: @unchecked Sendable {
+    @MainActor private var stateBuilder: StateBuilder<RoleSearchState>
+    private let rolesRepository: RolesRepository
+
+    init(client: ChatClient) {
+        rolesRepository = client.rolesRepository
+        stateBuilder = StateBuilder { RoleSearchState() }
+    }
+
+    // MARK: - Accessing the State
+
+    /// An observable object representing the current state of the search.
+    @MainActor public var state: RoleSearchState { stateBuilder.state }
+
+    // MARK: - Search Results
+
+    /// Searches for roles with the specified search term and updates ``RoleSearchState/roles``.
+    ///
+    /// - Parameters:
+    ///   - text: The search term used to match role names.
+    ///   - roleType: When set, restricts the search to roles of the given type.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of roles for the search term.
+    @discardableResult public func search(text: String, roleType: RoleType? = nil) async throws -> [Role] {
+        try await search(query: RoleSearchQuery(query: text, roleType: roleType))
+    }
+
+    /// Searches for roles with the specified query and updates ``RoleSearchState/roles``.
+    ///
+    /// - Parameter query: The query describing the search term and filters.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of roles for the query.
+    @discardableResult public func search(query: RoleSearchQuery) async throws -> [Role] {
+        await state.setQuery(query)
+        let roles = try await rolesRepository.searchRoles(query: query)
+        await state.handleDidFetchQuery(query, roles: roles)
+        return roles
+    }
+}

--- a/Sources/StreamChat/StateLayer/RoleSearchState.swift
+++ b/Sources/StreamChat/StateLayer/RoleSearchState.swift
@@ -1,0 +1,33 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// Represents a list of role search results.
+@MainActor public final class RoleSearchState: ObservableObject {
+    /// The last initiated search query.
+    ///
+    /// - Note: If searching fails, this property points to the failing query.
+    @Published public internal(set) var query: RoleSearchQuery?
+
+    /// An array of search results for the specified query.
+    @Published public internal(set) var roles: [Role] = []
+}
+
+extension RoleSearchState {
+    /// Updates the query to point to the last query the user started.
+    func setQuery(_ query: RoleSearchQuery) {
+        self.query = query
+    }
+
+    /// Updates the state with the results of the completed query.
+    ///
+    /// Results from an outdated query are discarded so the state always
+    /// reflects the most recently initiated search.
+    func handleDidFetchQuery(_ completedQuery: RoleSearchQuery, roles: [Role]) {
+        guard query == completedQuery else { return }
+        self.roles = roles
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -937,6 +937,7 @@
 				StreamChatTests/Query/PinnedMessages/PinnedMessagesQuery_Tests.swift,
 				StreamChatTests/Query/PinnedMessages/PinnedMessagesSortingKey_Tests.swift,
 				StreamChatTests/Query/ReactionListQuery_Tests.swift,
+				StreamChatTests/Query/RoleSearchQuery_Tests.swift,
 				StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift,
 				StreamChatTests/Query/Sorting/ChannelMemberListSortingKey_Tests.swift,
 				"StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting_Tests.swift",

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -917,6 +917,7 @@
 				StreamChatTests/Models/MessageDeliveryCriteriaValidator_Tests.swift,
 				StreamChatTests/Models/MessageReactionType_Tests.swift,
 				StreamChatTests/Models/Poll_Tests.swift,
+				StreamChatTests/Models/Role_Tests.swift,
 				StreamChatTests/Models/User_Tests.swift,
 				StreamChatTests/Query/ChannelListFilterScope_Tests.swift,
 				StreamChatTests/Query/ChannelListQuery_PredefinedFilter_Tests.swift,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -967,6 +967,7 @@
 				StreamChatTests/StateLayer/MessageState_Tests.swift,
 				StreamChatTests/StateLayer/ReactionList_Tests.swift,
 				StreamChatTests/StateLayer/RoleSearch_Tests.swift,
+				StreamChatTests/StateLayer/RoleSearchState_Tests.swift,
 				StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift,
 				StreamChatTests/StateLayer/UserGroupSearchState_Tests.swift,
 				StreamChatTests/StateLayer/UserGroupSearch_Tests.swift,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -859,6 +859,7 @@
 				StreamChatTests/Controllers/PollsControllers/PollVoteListController_Tests.swift,
 				"StreamChatTests/Controllers/PollsControllers/PollVoteListController+Combine_Tests.swift",
 				StreamChatTests/Controllers/RoleSearchController/RoleSearchController_Tests.swift,
+				"StreamChatTests/Controllers/RoleSearchController/RoleSearchController+Combine_Tests.swift",
 				StreamChatTests/Controllers/SearchControllers/MessageSearchController/MessageSearchController_Tests.swift,
 				StreamChatTests/Controllers/SearchControllers/UserController/UserController_Tests.swift,
 				"StreamChatTests/Controllers/SearchControllers/UserController/UserController+Combine_Tests.swift",

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -966,6 +966,7 @@
 				StreamChatTests/StateLayer/MessageSearch_Tests.swift,
 				StreamChatTests/StateLayer/MessageState_Tests.swift,
 				StreamChatTests/StateLayer/ReactionList_Tests.swift,
+				StreamChatTests/StateLayer/RoleSearch_Tests.swift,
 				StreamChatTests/StateLayer/StateLayerDatabaseObserver_Tests.swift,
 				StreamChatTests/StateLayer/UserGroupSearchState_Tests.swift,
 				StreamChatTests/StateLayer/UserGroupSearch_Tests.swift,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -858,6 +858,7 @@
 				"StreamChatTests/Controllers/PollsControllers/PollController+Combine_Tests.swift",
 				StreamChatTests/Controllers/PollsControllers/PollVoteListController_Tests.swift,
 				"StreamChatTests/Controllers/PollsControllers/PollVoteListController+Combine_Tests.swift",
+				StreamChatTests/Controllers/RoleSearchController/RoleSearchController_Tests.swift,
 				StreamChatTests/Controllers/SearchControllers/MessageSearchController/MessageSearchController_Tests.swift,
 				StreamChatTests/Controllers/SearchControllers/UserController/UserController_Tests.swift,
 				"StreamChatTests/Controllers/SearchControllers/UserController/UserController+Combine_Tests.swift",

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -775,6 +775,7 @@
 				StreamChatTests/APIClient/Endpoints/Payloads/PollPayload_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Payloads/PushPreferencePayload_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Payloads/ReminderPayloads_Tests.swift,
+				StreamChatTests/APIClient/Endpoints/Payloads/RolePayloads_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Payloads/ThreadListPayload_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Payloads/UnknownChannelEvent_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Payloads/UnknownUserEvent_Tests.swift,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -793,6 +793,7 @@
 				StreamChatTests/APIClient/Endpoints/Requests/GuestUserTokenRequestPayload_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/Requests/MissingEventsRequestBody_Tests.swift,
+				StreamChatTests/APIClient/Endpoints/RoleEndpoints_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/SyncEndpoint_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/ThreadEndpoint_Tests.swift,
 				StreamChatTests/APIClient/Endpoints/UserEndpoints_Tests.swift,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@
 				StreamChatTests/Repositories/OfflineRequestsRepository_Tests.swift,
 				StreamChatTests/Repositories/PollsRepository_Tests.swift,
 				StreamChatTests/Repositories/RemindersRepository_Tests.swift,
+				StreamChatTests/Repositories/RolesRepository_Tests.swift,
 				StreamChatTests/Repositories/SyncOperations_Tests.swift,
 				StreamChatTests/Repositories/SyncRepository_Tests.swift,
 				StreamChatTests/Repositories/UserGroupsRepository_Tests.swift,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -279,6 +279,10 @@ extension ChatClient {
         userGroupsRepository as! UserGroupsRepository_Mock
     }
 
+    var mockRolesRepository: RolesRepository_Mock {
+        rolesRepository as! RolesRepository_Mock
+    }
+
     func simulateProvidedConnectionId(connectionId: ConnectionId?) {
         guard let connectionId = connectionId else {
             webSocketClient(
@@ -361,6 +365,7 @@ extension ChatClient.Environment {
             },
             remindersRepositoryBuilder: RemindersRepository_Mock.init,
             userGroupsRepositoryBuilder: UserGroupsRepository_Mock.init,
+            rolesRepositoryBuilder: RolesRepository_Mock.init,
             channelListUpdaterBuilder: {
                 ChannelListUpdater_Spy(
                     database: $0,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/RolesRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/RolesRepository_Mock.swift
@@ -1,0 +1,30 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+/// Mock implementation of `RolesRepository`.
+final class RolesRepository_Mock: RolesRepository, @unchecked Sendable {
+    var searchRoles_query: RoleSearchQuery?
+    var searchRoles_completion_result: Result<[Role], Error>?
+
+    override init(apiClient: APIClient) {
+        super.init(apiClient: apiClient)
+    }
+
+    init() {
+        super.init(apiClient: APIClient_Spy())
+    }
+
+    override func searchRoles(
+        query: RoleSearchQuery,
+        completion: @escaping @Sendable (Result<[Role], Error>) -> Void
+    ) {
+        searchRoles_query = query
+        if let result = searchRoles_completion_result {
+            completion(result)
+        }
+    }
+}

--- a/Tests/StreamChatTests/APIClient/Endpoints/EndpointPath_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/EndpointPath_Tests.swift
@@ -106,6 +106,14 @@ final class EndpointPathTests: XCTestCase {
         )
     }
 
+    func test_rolesSearch_shouldNOTBeQueuedOffline() {
+        XCTAssertFalse(EndpointPath.rolesSearch.shouldBeQueuedOffline)
+    }
+
+    func test_rolesSearch_value() {
+        XCTAssertEqual(EndpointPath.rolesSearch.value, "roles/search")
+    }
+
     func test_pushPreferences_value() {
         let path = EndpointPath.pushPreferences.value
         XCTAssertEqual(path, "push_preferences")
@@ -154,6 +162,7 @@ final class EndpointPathTests: XCTestCase {
         assertResultEncodingAndDecoding(.userGroup(id: "group"))
         assertResultEncodingAndDecoding(.userGroupMembers(id: "group"))
         assertResultEncodingAndDecoding(.userGroupMembersDelete(id: "group"))
+        assertResultEncodingAndDecoding(.rolesSearch)
 
         assertResultEncodingAndDecoding(.channels)
         assertResultEncodingAndDecoding(.createChannel("channel_idc"))

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/RolePayloads_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/RolePayloads_Tests.swift
@@ -1,0 +1,117 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RolePayloads_Tests: XCTestCase {
+    func test_rolePayload_isDecodedCorrectly() throws {
+        let json = """
+        {
+            "name": "admin",
+            "custom": true,
+            "scopes": ["user", "channel"],
+            "created_at": "2020-07-16T15:39:03.010717Z",
+            "updated_at": "2020-08-17T13:15:39.895109Z"
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder.stream.decode(RolePayload.self, from: json)
+
+        XCTAssertEqual(payload.name, "admin")
+        XCTAssertTrue(payload.custom)
+        XCTAssertEqual(payload.scopes, ["user", "channel"])
+        XCTAssertNotNil(payload.createdAt)
+        XCTAssertNotNil(payload.updatedAt)
+    }
+
+    func test_rolePayload_mapsCustomKeyToIsCustom() throws {
+        let json = """
+        {
+            "name": "admin",
+            "custom": true
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder.stream.decode(RolePayload.self, from: json)
+        let model = payload.asModel()
+
+        XCTAssertTrue(payload.custom)
+        XCTAssertTrue(model.isCustom)
+    }
+
+    func test_rolePayload_withMissingOptionalFields_usesDefaults() throws {
+        let json = """
+        {
+            "name": "admin"
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder.stream.decode(RolePayload.self, from: json)
+
+        XCTAssertEqual(payload.name, "admin")
+        XCTAssertFalse(payload.custom)
+        XCTAssertTrue(payload.scopes.isEmpty)
+        XCTAssertNil(payload.createdAt)
+        XCTAssertNil(payload.updatedAt)
+    }
+
+    func test_rolePayload_asModel_mapsAllFields() {
+        let createdAt = Date.unique
+        let updatedAt = Date.unique
+        let payload = RolePayload(
+            name: "admin",
+            custom: true,
+            scopes: ["user", "channel"],
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+
+        let model = payload.asModel()
+
+        XCTAssertEqual(model.name, "admin")
+        XCTAssertTrue(model.isCustom)
+        XCTAssertEqual(model.scopes, ["user", "channel"])
+        XCTAssertEqual(model.createdAt, createdAt)
+        XCTAssertEqual(model.updatedAt, updatedAt)
+    }
+
+    func test_roleListPayload_isDecodedCorrectly() throws {
+        let json = """
+        {
+            "roles": [
+                {
+                    "name": "admin",
+                    "custom": true,
+                    "scopes": ["user"]
+                },
+                {
+                    "name": "moderator",
+                    "custom": false,
+                    "scopes": ["channel"]
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder.stream.decode(RoleListPayload.self, from: json)
+
+        XCTAssertEqual(payload.roles.count, 2)
+        XCTAssertEqual(payload.roles.map(\.name), ["admin", "moderator"])
+        XCTAssertEqual(payload.roles.map(\.custom), [true, false])
+    }
+
+    func test_roleListPayload_whenEmpty_isDecodedCorrectly() throws {
+        let json = """
+        {
+            "roles": []
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder.stream.decode(RoleListPayload.self, from: json)
+
+        XCTAssertTrue(payload.roles.isEmpty)
+    }
+}

--- a/Tests/StreamChatTests/APIClient/Endpoints/RoleEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/RoleEndpoints_Tests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RoleEndpoints_Tests: XCTestCase {
+    func test_searchRoles_buildsCorrectly() {
+        let query = RoleSearchQuery(query: "adm", limit: 10, roleType: .user)
+
+        let expectedEndpoint = Endpoint<RoleListPayload>(
+            path: .rolesSearch,
+            method: .get,
+            queryItems: query,
+            requiresConnectionId: false,
+            requiresToken: true,
+            body: nil
+        )
+
+        let endpoint: Endpoint<RoleListPayload> = .searchRoles(query: query)
+
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("roles/search", endpoint.path.value)
+        XCTAssertEqual(.get, endpoint.method)
+        XCTAssertFalse(endpoint.requiresConnectionId)
+        XCTAssertTrue(endpoint.requiresToken)
+        XCTAssertNil(endpoint.body)
+    }
+}

--- a/Tests/StreamChatTests/Controllers/RoleSearchController/RoleSearchController+Combine_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/RoleSearchController/RoleSearchController+Combine_Tests.swift
@@ -1,0 +1,63 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RoleSearchController_Combine_Tests: iOS13TestCase {
+    var roleSearchController: RoleSearchController!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        roleSearchController = .init(client: .mock)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        AssertAsync.canBeReleased(&roleSearchController)
+        roleSearchController = nil
+        super.tearDown()
+    }
+
+    func test_statePublisher() {
+        var recording = Record<DataController.State, Never>.Recording()
+
+        roleSearchController
+            .statePublisher
+            .sink(receiveValue: { recording.receive($0) })
+            .store(in: &cancellables)
+
+        // Keep only the weak reference to the controller. The existing publisher should keep it alive.
+        weak var controller: RoleSearchController? = roleSearchController
+        roleSearchController = nil
+
+        controller?.delegateCallback { [controller] in $0.controller(controller!, didChangeState: .remoteDataFetched) }
+
+        XCTAssertEqual(recording.output, [.initialized, .remoteDataFetched])
+    }
+
+    func test_rolesChangesPublisher() {
+        var recording = Record<[Role], Never>.Recording()
+
+        roleSearchController
+            .rolesChangesPublisher
+            .sink(receiveValue: { recording.receive($0) })
+            .store(in: &cancellables)
+
+        // Keep only the weak reference to the controller. The existing publisher should keep it alive.
+        weak var controller: RoleSearchController? = roleSearchController
+        roleSearchController = nil
+
+        let roles = [Role(name: "admin")]
+        controller?.delegateCallback { [controller] in
+            $0.controller(controller!, didChangeRoles: roles)
+        }
+
+        XCTAssertEqual(recording.output.last, roles)
+    }
+}

--- a/Tests/StreamChatTests/Controllers/RoleSearchController/RoleSearchController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/RoleSearchController/RoleSearchController_Tests.swift
@@ -1,0 +1,129 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RoleSearchController_Tests: XCTestCase {
+    var client: ChatClient_Mock!
+    var repository: RolesRepository_Mock!
+    var controller: RoleSearchController!
+
+    override func setUp() {
+        super.setUp()
+        client = ChatClient.mock
+        repository = client.mockRolesRepository
+        controller = client.roleSearchController()
+    }
+
+    override func tearDown() {
+        controller = nil
+        repository = nil
+        client?.cleanUp()
+        client = nil
+        super.tearDown()
+    }
+
+    // MARK: - searchRoles(text:roleType:)
+
+    func test_searchRoles_withText_forwardsRequestToRepository() {
+        let role = Role(name: "admin", isCustom: true)
+        repository.searchRoles_completion_result = .success([role])
+
+        let exp = expectation(description: "search completes")
+        controller.searchRoles(text: "adm", roleType: .user) { result in
+            XCTAssertEqual(result.value?.map(\.name), ["admin"])
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertEqual(repository.searchRoles_query?.query, "adm")
+        XCTAssertEqual(repository.searchRoles_query?.roleType, .user)
+    }
+
+    func test_searchRoles_withText_whenRoleTypeIsNil_thenQueryHasNoRoleType() {
+        repository.searchRoles_completion_result = .success([])
+
+        let exp = expectation(description: "search completes")
+        controller.searchRoles(text: "adm") { _ in
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertEqual(repository.searchRoles_query?.query, "adm")
+        XCTAssertNil(repository.searchRoles_query?.roleType)
+    }
+
+    // MARK: - searchRoles(query:)
+
+    func test_searchRoles_withQuery_forwardsRequestToRepository() {
+        let role = Role(name: "admin")
+        repository.searchRoles_completion_result = .success([role])
+
+        let query = RoleSearchQuery(query: "adm", limit: 5, roleType: .channel)
+        let exp = expectation(description: "search completes")
+        controller.searchRoles(query: query) { result in
+            XCTAssertEqual(result.value?.map(\.name), ["admin"])
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertEqual(repository.searchRoles_query, query)
+    }
+
+    func test_searchRoles_whenRequestSucceeds_thenRolesAndStateAreUpdated() {
+        let roles = [Role(name: "admin"), Role(name: "moderator")]
+        repository.searchRoles_completion_result = .success(roles)
+
+        let exp = expectation(description: "search completes")
+        controller.searchRoles(text: "adm") { _ in
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertEqual(controller.roles.map(\.name), ["admin", "moderator"])
+        XCTAssertEqual(controller.state, .remoteDataFetched)
+    }
+
+    @MainActor func test_searchRoles_whenRequestSucceeds_thenDelegateIsNotified() {
+        class DelegateMock: RoleSearchControllerDelegate {
+            var roles: [Role] = []
+            let expectation = XCTestExpectation(description: "Did Change Roles")
+
+            func controller(_ controller: RoleSearchController, didChangeRoles roles: [Role]) {
+                self.roles = roles
+                expectation.fulfill()
+            }
+        }
+
+        let delegate = DelegateMock()
+        controller.delegate = delegate
+        repository.searchRoles_completion_result = .success([Role(name: "admin")])
+
+        controller.searchRoles(text: "adm")
+
+        wait(for: [delegate.expectation], timeout: defaultTimeout)
+        XCTAssertEqual(delegate.roles.map(\.name), ["admin"])
+    }
+
+    // MARK: - Failure path
+
+    func test_searchRoles_whenRequestFails_thenErrorIsForwardedAndStateIsFailed() {
+        let testError = TestError()
+        repository.searchRoles_completion_result = .failure(testError)
+
+        let exp = expectation(description: "search completes")
+        controller.searchRoles(text: "adm") { result in
+            XCTAssertEqual(result.error as? TestError, testError)
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeout)
+        XCTAssertTrue(controller.roles.isEmpty)
+        if case .remoteDataFetchFailed = controller.state {} else {
+            XCTFail("Expected remoteDataFetchFailed, got \(controller.state)")
+        }
+    }
+}

--- a/Tests/StreamChatTests/Models/Role_Tests.swift
+++ b/Tests/StreamChatTests/Models/Role_Tests.swift
@@ -1,0 +1,59 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class Role_Tests: XCTestCase {
+    func test_init_setsAllProperties() {
+        let createdAt = Date.unique
+        let updatedAt = Date.unique
+        let role = Role(
+            name: "admin",
+            isCustom: true,
+            scopes: ["user", "channel"],
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+
+        XCTAssertEqual(role.name, "admin")
+        XCTAssertTrue(role.isCustom)
+        XCTAssertEqual(role.scopes, ["user", "channel"])
+        XCTAssertEqual(role.createdAt, createdAt)
+        XCTAssertEqual(role.updatedAt, updatedAt)
+    }
+
+    func test_init_usesDefaultValues() {
+        let role = Role(name: "moderator")
+
+        XCTAssertEqual(role.name, "moderator")
+        XCTAssertFalse(role.isCustom)
+        XCTAssertTrue(role.scopes.isEmpty)
+        XCTAssertNil(role.createdAt)
+        XCTAssertNil(role.updatedAt)
+    }
+
+    func test_id_equalsName() {
+        let role = Role(name: "admin")
+        XCTAssertEqual(role.id, "admin")
+        XCTAssertEqual(role.id, role.name)
+    }
+
+    func test_equatable_whenSameValues_thenEqual() {
+        let createdAt = Date.unique
+        let role1 = Role(name: "admin", isCustom: true, scopes: ["user"], createdAt: createdAt)
+        let role2 = Role(name: "admin", isCustom: true, scopes: ["user"], createdAt: createdAt)
+
+        XCTAssertEqual(role1, role2)
+    }
+
+    func test_equatable_whenDifferentValues_thenNotEqual() {
+        let role = Role(name: "admin")
+
+        XCTAssertNotEqual(role, Role(name: "moderator"))
+        XCTAssertNotEqual(role, Role(name: "admin", isCustom: true))
+        XCTAssertNotEqual(role, Role(name: "admin", scopes: ["user"]))
+    }
+}

--- a/Tests/StreamChatTests/Query/RoleSearchQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/RoleSearchQuery_Tests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RoleSearchQuery_Tests: XCTestCase {
+    func test_init_setsAllProperties() {
+        let query = RoleSearchQuery(
+            query: "adm",
+            limit: 10,
+            includeGlobalRoles: true,
+            nameGreaterThan: "admin",
+            roleType: .user
+        )
+
+        XCTAssertEqual(query.query, "adm")
+        XCTAssertEqual(query.limit, 10)
+        XCTAssertEqual(query.includeGlobalRoles, true)
+        XCTAssertEqual(query.nameGreaterThan, "admin")
+        XCTAssertEqual(query.roleType, .user)
+    }
+
+    func test_init_usesDefaultValues() {
+        let query = RoleSearchQuery(query: "adm")
+
+        XCTAssertEqual(query.query, "adm")
+        XCTAssertNil(query.limit)
+        XCTAssertNil(query.includeGlobalRoles)
+        XCTAssertNil(query.nameGreaterThan)
+        XCTAssertNil(query.roleType)
+    }
+
+    func test_encode_whenAllFieldsAreSet_thenEncodesCorrectly() throws {
+        let query = RoleSearchQuery(
+            query: "adm",
+            limit: 10,
+            includeGlobalRoles: true,
+            nameGreaterThan: "admin",
+            roleType: .channel
+        )
+
+        let encodedJSON = try JSONEncoder.stream.encode(query)
+        let expected: [String: Any] = [
+            "query": "adm",
+            "limit": 10,
+            "include_global_roles": true,
+            "name_gt": "admin",
+            "role_type": "channel"
+        ]
+        let expectedJSON = try JSONSerialization.data(withJSONObject: expected, options: [])
+
+        AssertJSONEqual(encodedJSON, expectedJSON)
+    }
+
+    func test_encode_whenOptionalFieldsAreNil_thenTheyAreOmitted() throws {
+        let query = RoleSearchQuery(query: "adm")
+
+        let encodedJSON = try JSONEncoder.stream.encode(query)
+        let decoded = try JSONSerialization.jsonObject(with: encodedJSON) as? [String: Any]
+
+        XCTAssertEqual(decoded?["query"] as? String, "adm")
+        XCTAssertNil(decoded?["limit"])
+        XCTAssertNil(decoded?["include_global_roles"])
+        XCTAssertNil(decoded?["name_gt"])
+        XCTAssertNil(decoded?["role_type"])
+    }
+
+    func test_encode_encodesRoleTypeRawValue() throws {
+        let query = RoleSearchQuery(query: "adm", roleType: .user)
+
+        let encodedJSON = try JSONEncoder.stream.encode(query)
+        let decoded = try JSONSerialization.jsonObject(with: encodedJSON) as? [String: Any]
+
+        XCTAssertEqual(decoded?["role_type"] as? String, "user")
+    }
+
+    func test_roleType_rawValues() {
+        XCTAssertEqual(RoleType.user.rawValue, "user")
+        XCTAssertEqual(RoleType.channel.rawValue, "channel")
+    }
+}

--- a/Tests/StreamChatTests/Repositories/RolesRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/RolesRepository_Tests.swift
@@ -1,0 +1,108 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RolesRepository_Tests: XCTestCase {
+    var apiClient: APIClient_Spy!
+    var repository: RolesRepository!
+
+    override func setUp() {
+        super.setUp()
+        apiClient = APIClient_Spy()
+        repository = RolesRepository(apiClient: apiClient)
+    }
+
+    override func tearDown() {
+        apiClient.cleanUp()
+        apiClient = nil
+        repository = nil
+        super.tearDown()
+    }
+
+    func test_searchRoles_makesCorrectAPICall() {
+        let query = RoleSearchQuery(query: "adm", limit: 10, roleType: .user)
+        let exp = expectation(description: "completion is called")
+
+        repository.searchRoles(query: query) { _ in
+            exp.fulfill()
+        }
+
+        apiClient.test_simulateResponse(.success(RoleListPayload(roles: [])))
+        wait(for: [exp], timeout: defaultTimeout)
+
+        let expectedEndpoint: Endpoint<RoleListPayload> = .searchRoles(query: query)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+
+    func test_searchRoles_mapsPayloadsToDomainModels() {
+        let query = RoleSearchQuery(query: "adm")
+        let payload = RolePayload(
+            name: "admin",
+            custom: true,
+            scopes: ["user"]
+        )
+
+        nonisolated(unsafe) var result: Result<[Role], Error>?
+        let exp = expectation(description: "completion is called")
+        repository.searchRoles(query: query) { receivedResult in
+            result = receivedResult
+            exp.fulfill()
+        }
+
+        apiClient.test_simulateResponse(.success(RoleListPayload(roles: [payload])))
+        wait(for: [exp], timeout: defaultTimeout)
+
+        guard case .success(let roles) = result else {
+            XCTFail("Expected successful result")
+            return
+        }
+
+        XCTAssertEqual(roles.count, 1)
+        XCTAssertEqual(roles.first?.name, "admin")
+        XCTAssertEqual(roles.first?.isCustom, true)
+        XCTAssertEqual(roles.first?.scopes, ["user"])
+    }
+
+    func test_searchRoles_whenAPIFails_propagatesError() {
+        let query = RoleSearchQuery(query: "adm")
+        let testError = TestError()
+
+        nonisolated(unsafe) var result: Result<[Role], Error>?
+        let exp = expectation(description: "completion is called")
+        repository.searchRoles(query: query) { receivedResult in
+            result = receivedResult
+            exp.fulfill()
+        }
+
+        apiClient.test_simulateResponse(Result<RoleListPayload, Error>.failure(testError))
+        wait(for: [exp], timeout: defaultTimeout)
+
+        XCTAssertEqual(result?.error as? TestError, testError)
+    }
+
+    func test_searchRoles_asyncOverload_mapsPayloadsToDomainModels() async throws {
+        let query = RoleSearchQuery(query: "adm", limit: 10)
+        let payload = RolePayload(name: "admin", custom: true)
+
+        apiClient.test_mockResponseResult(.success(RoleListPayload(roles: [payload])))
+
+        let roles = try await repository.searchRoles(query: query)
+
+        let expectedEndpoint: Endpoint<RoleListPayload> = .searchRoles(query: query)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+        XCTAssertEqual(roles.map(\.name), ["admin"])
+    }
+
+    func test_searchRoles_asyncOverload_whenAPIFails_throwsError() async {
+        let query = RoleSearchQuery(query: "adm")
+        let testError = TestError()
+
+        apiClient.test_mockResponseResult(Result<RoleListPayload, Error>.failure(testError))
+
+        await XCTAssertAsyncFailure(try await repository.searchRoles(query: query), testError)
+    }
+}

--- a/Tests/StreamChatTests/StateLayer/RoleSearchState_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/RoleSearchState_Tests.swift
@@ -1,0 +1,68 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+@MainActor
+final class RoleSearchState_Tests: XCTestCase {
+    func test_initialState_isEmpty() {
+        let state = RoleSearchState()
+        XCTAssertNil(state.query)
+        XCTAssertTrue(state.roles.isEmpty)
+    }
+
+    func test_setQuery_updatesQuery() {
+        let state = RoleSearchState()
+        let query = RoleSearchQuery(query: "adm", roleType: .user)
+
+        state.setQuery(query)
+
+        XCTAssertEqual(query, state.query)
+        XCTAssertTrue(state.roles.isEmpty)
+    }
+
+    func test_handleDidFetchQuery_whenQueryMatches_thenRolesAreUpdated() {
+        let state = RoleSearchState()
+        let query = RoleSearchQuery(query: "adm")
+        let roles = [Role(name: "admin")]
+
+        state.setQuery(query)
+        state.handleDidFetchQuery(query, roles: roles)
+
+        XCTAssertEqual(["admin"], state.roles.map(\.name))
+    }
+
+    func test_handleDidFetchQuery_whenQueryDoesNotMatch_thenRolesAreDiscarded() {
+        let state = RoleSearchState()
+        let startedQuery = RoleSearchQuery(query: "adm")
+        let outdatedQuery = RoleSearchQuery(query: "mod")
+        let roles = [Role(name: "moderator")]
+
+        // The user started an "adm" search, but results for an outdated "mod" query arrive.
+        state.setQuery(startedQuery)
+        state.handleDidFetchQuery(outdatedQuery, roles: roles)
+
+        XCTAssertTrue(state.roles.isEmpty)
+    }
+
+    func test_handleDidFetchQuery_whenNewerQueryStarted_thenStaleResultsAreDiscarded() {
+        let state = RoleSearchState()
+        let firstQuery = RoleSearchQuery(query: "ad")
+        let secondQuery = RoleSearchQuery(query: "adm")
+
+        // Two searches start in sequence; the second one is the most recent.
+        state.setQuery(firstQuery)
+        state.setQuery(secondQuery)
+
+        // Results from the first (now stale) query should be ignored.
+        state.handleDidFetchQuery(firstQuery, roles: [Role(name: "stale")])
+        XCTAssertTrue(state.roles.isEmpty)
+
+        // Results from the most recent query are applied.
+        state.handleDidFetchQuery(secondQuery, roles: [Role(name: "admin")])
+        XCTAssertEqual(["admin"], state.roles.map(\.name))
+    }
+}

--- a/Tests/StreamChatTests/StateLayer/RoleSearch_Tests.swift
+++ b/Tests/StreamChatTests/StateLayer/RoleSearch_Tests.swift
@@ -1,0 +1,101 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class RoleSearch_Tests: XCTestCase {
+    var client: ChatClient_Mock!
+    var repository: RolesRepository_Mock!
+    var search: RoleSearch!
+
+    override func setUp() {
+        super.setUp()
+        client = ChatClient.mock
+        repository = client.mockRolesRepository
+        search = RoleSearch(client: client)
+    }
+
+    override func tearDown() {
+        search = nil
+        repository = nil
+        client?.cleanUp()
+        client = nil
+        super.tearDown()
+    }
+
+    // MARK: - search(text:roleType:)
+
+    func test_searchText_whenRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+        let role = Role(name: "admin", isCustom: true)
+        repository.searchRoles_completion_result = .success([role])
+
+        let result = try await search.search(text: "adm", roleType: .user)
+
+        XCTAssertEqual(["admin"], result.map(\.name))
+        XCTAssertEqual("adm", repository.searchRoles_query?.query)
+        XCTAssertEqual(.user, repository.searchRoles_query?.roleType)
+
+        try await MainActor.run {
+            XCTAssertEqual(["admin"], search.state.roles.map(\.name))
+            let stateQuery = try XCTUnwrap(search.state.query)
+            XCTAssertEqual("adm", stateQuery.query)
+            XCTAssertEqual(.user, stateQuery.roleType)
+        }
+    }
+
+    func test_searchText_whenRoleTypeIsNil_thenQueryHasNoRoleType() async throws {
+        repository.searchRoles_completion_result = .success([])
+
+        _ = try await search.search(text: "adm")
+
+        XCTAssertEqual("adm", repository.searchRoles_query?.query)
+        XCTAssertNil(repository.searchRoles_query?.roleType)
+    }
+
+    // MARK: - search(query:)
+
+    func test_searchQuery_whenRequestSucceeds_thenResultsAreReturnedAndStateUpdates() async throws {
+        let query = RoleSearchQuery(query: "adm", limit: 5, roleType: .channel)
+        let roles = [Role(name: "admin"), Role(name: "moderator")]
+        repository.searchRoles_completion_result = .success(roles)
+
+        let result = try await search.search(query: query)
+
+        XCTAssertEqual(["admin", "moderator"], result.map(\.name))
+        XCTAssertEqual(query, repository.searchRoles_query)
+
+        try await MainActor.run {
+            XCTAssertEqual(["admin", "moderator"], search.state.roles.map(\.name))
+            XCTAssertEqual(query, search.state.query)
+        }
+    }
+
+    // MARK: - Failure path
+
+    func test_search_whenRequestFails_thenErrorIsThrownAndResultsRemainEmpty() async throws {
+        let testError = TestError()
+        repository.searchRoles_completion_result = .failure(testError)
+
+        await XCTAssertAsyncFailure(try await search.search(text: "adm"), testError)
+
+        // Even on failure, the query the user started is kept in the state.
+        try await MainActor.run {
+            XCTAssertTrue(search.state.roles.isEmpty)
+            XCTAssertEqual("adm", search.state.query?.query)
+        }
+    }
+
+    // MARK: - Factory
+
+    func test_makeRoleSearch_returnsConfiguredRoleSearch() async throws {
+        let roleSearch = client.makeRoleSearch()
+        repository.searchRoles_completion_result = .success([Role(name: "admin")])
+
+        let result = try await roleSearch.search(text: "adm")
+
+        XCTAssertEqual(["admin"], result.map(\.name))
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1724](https://linear.app/stream/issue/IOS-1724/new-user-mentions-feature)

> **Stacked PR (3/6).** Base branch: `feature/user-groups` (#4138). Review/merge in stack order.

### 🎯 Goal

Add the ability to search roles in the low-level client, which powers `@role` mentions in the composer.

### 📝 Summary

- Add the `Role` model, `RoleSearchQuery`, endpoint and `RolesRepository`.
- Add a `RoleSearchController` and a `RoleSearch` state layer.

### 🛠 Implementation

Role search mirrors `MessageSearch`: a single non-paginated request returns the matching roles, exposed via both a controller and a state-layer object.

### 🧪 Manual Testing Notes

Covered by unit tests against a mock repository; no UI surface in this PR.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added role search functionality with support for filtering by role type and pagination options.
  * Introduced reactive state management for role search operations with observable properties for query and results.
  * Added offline support for role search requests to enable queuing when offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->