### PR TITLE
OpenAPI: Generate immutable, internal models

### DIFF
--- a/Scripts/openapi_generate.sh
+++ b/Scripts/openapi_generate.sh
@@ -76,6 +76,7 @@ rename_generated() {
 rm -rf "$OUTPUT_DIR_CHAT"
 ( cd "$CHAT_DIR" ; make openapi ; \
   ./build/chat-manager openapi generate-client --language swift \
+    --opt immutable_models=true --opt access_modifier=internal \
     --spec ./releases/v2/chat-clientside-api.yaml --output "$OUTPUT_DIR_CHAT" )
 
 # 2. Drop the generated async API client — the SDK ships its own APIClient.
@@ -163,15 +164,10 @@ rename_generated Field AttachmentFieldPayload
 rename_generated ImageData GiphyImageData
 rename_generated Images GiphyImages
 
-# 5. Generated code is internal to the SDK — strip public/open.
-find "$OUTPUT_DIR_CHAT" -name '*.swift' -print0 | while IFS= read -r -d '' file; do
-  sed -i '' -E 's/^([[:space:]]*)(public|open) /\1/' "$file"
-done
-
-# 6. Format.
+# 5. Format.
 swiftformat --config "$REPO_ROOT/.swiftformat" "$OUTPUT_DIR_CHAT"
 
-# 7. Inject the existing v1 SDK endpoint paths into the generated EndpointPath enum.
+# 6. Inject the existing v1 SDK endpoint paths into the generated EndpointPath enum.
 #    The OpenAPI generator owns v2 paths; these v1 cases keep the hand-written
 #    endpoint factories compiling while each endpoint migrates incrementally.
 inject_v1_endpoint_paths() {

--- a/Sources/StreamChat/Generated/OpenAPI/models/AppResponseFields.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AppResponseFields.swift
@@ -4,14 +4,14 @@
 
 import Foundation
 
-final class AppResponseFields: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var asyncUrlEnrichEnabled: Bool
-    var autoTranslationEnabled: Bool
-    var fileUploadConfig: FileUploadConfig
-    var id: Int
-    var imageUploadConfig: FileUploadConfig
-    var name: String
-    var placement: String
+final class AppResponseFields: Sendable, Codable, JSONEncodable {
+    let asyncUrlEnrichEnabled: Bool
+    let autoTranslationEnabled: Bool
+    let fileUploadConfig: FileUploadConfig
+    let id: Int
+    let imageUploadConfig: FileUploadConfig
+    let name: String
+    let placement: String
 
     init(asyncUrlEnrichEnabled: Bool, autoTranslationEnabled: Bool, fileUploadConfig: FileUploadConfig, id: Int, imageUploadConfig: FileUploadConfig, name: String, placement: String) {
         self.asyncUrlEnrichEnabled = asyncUrlEnrichEnabled
@@ -31,25 +31,5 @@ final class AppResponseFields: @unchecked Sendable, Codable, JSONEncodable, Hash
         case imageUploadConfig = "image_upload_config"
         case name
         case placement
-    }
-
-    static func == (lhs: AppResponseFields, rhs: AppResponseFields) -> Bool {
-        lhs.asyncUrlEnrichEnabled == rhs.asyncUrlEnrichEnabled &&
-            lhs.autoTranslationEnabled == rhs.autoTranslationEnabled &&
-            lhs.fileUploadConfig == rhs.fileUploadConfig &&
-            lhs.id == rhs.id &&
-            lhs.imageUploadConfig == rhs.imageUploadConfig &&
-            lhs.name == rhs.name &&
-            lhs.placement == rhs.placement
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(asyncUrlEnrichEnabled)
-        hasher.combine(autoTranslationEnabled)
-        hasher.combine(fileUploadConfig)
-        hasher.combine(id)
-        hasher.combine(imageUploadConfig)
-        hasher.combine(name)
-        hasher.combine(placement)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/AttachmentActionPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AttachmentActionPayload.swift
@@ -4,12 +4,12 @@
 
 import Foundation
 
-final class AttachmentActionPayload: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var name: String
-    var style: String?
-    var text: String
-    var type: String
-    var value: String?
+final class AttachmentActionPayload: Sendable, Codable, JSONEncodable {
+    let name: String
+    let style: String?
+    let text: String
+    let type: String
+    let value: String?
 
     init(name: String, style: String? = nil, text: String, type: String, value: String? = nil) {
         self.name = name
@@ -25,21 +25,5 @@ final class AttachmentActionPayload: @unchecked Sendable, Codable, JSONEncodable
         case text
         case type
         case value
-    }
-
-    static func == (lhs: AttachmentActionPayload, rhs: AttachmentActionPayload) -> Bool {
-        lhs.name == rhs.name &&
-            lhs.style == rhs.style &&
-            lhs.text == rhs.text &&
-            lhs.type == rhs.type &&
-            lhs.value == rhs.value
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-        hasher.combine(style)
-        hasher.combine(text)
-        hasher.combine(type)
-        hasher.combine(value)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/AttachmentFieldPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AttachmentFieldPayload.swift
@@ -4,10 +4,10 @@
 
 import Foundation
 
-final class AttachmentFieldPayload: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var short: Bool
-    var title: String
-    var value: String
+final class AttachmentFieldPayload: Sendable, Codable, JSONEncodable {
+    let short: Bool
+    let title: String
+    let value: String
 
     init(short: Bool, title: String, value: String) {
         self.short = short
@@ -19,17 +19,5 @@ final class AttachmentFieldPayload: @unchecked Sendable, Codable, JSONEncodable,
         case short
         case title
         case value
-    }
-
-    static func == (lhs: AttachmentFieldPayload, rhs: AttachmentFieldPayload) -> Bool {
-        lhs.short == rhs.short &&
-            lhs.title == rhs.title &&
-            lhs.value == rhs.value
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(short)
-        hasher.combine(title)
-        hasher.combine(value)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/BlockUsersRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/BlockUsersRequest.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-final class BlockUsersRequest: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class BlockUsersRequest: Sendable, Codable, JSONEncodable {
     /// User id to block
-    var blockedUserId: String
+    let blockedUserId: String
 
     init(blockedUserId: String) {
         self.blockedUserId = blockedUserId
@@ -14,13 +14,5 @@ final class BlockUsersRequest: @unchecked Sendable, Codable, JSONEncodable, Hash
 
     enum CodingKeys: String, CodingKey, CaseIterable {
         case blockedUserId = "blocked_user_id"
-    }
-
-    static func == (lhs: BlockUsersRequest, rhs: BlockUsersRequest) -> Bool {
-        lhs.blockedUserId == rhs.blockedUserId
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(blockedUserId)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/BlockUsersResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/BlockUsersResponse.swift
@@ -4,15 +4,15 @@
 
 import Foundation
 
-final class BlockUsersResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class BlockUsersResponse: Sendable, Codable, JSONEncodable {
     /// User id who blocked another user
-    var blockedByUserId: String
+    let blockedByUserId: String
     /// User id who got blocked
-    var blockedUserId: String
+    let blockedUserId: String
     /// Timestamp when the user was blocked
-    var createdAt: Date
+    let createdAt: Date
     /// Duration of the request in milliseconds
-    var duration: String
+    let duration: String
 
     init(blockedByUserId: String, blockedUserId: String, createdAt: Date, duration: String) {
         self.blockedByUserId = blockedByUserId
@@ -26,19 +26,5 @@ final class BlockUsersResponse: @unchecked Sendable, Codable, JSONEncodable, Has
         case blockedUserId = "blocked_user_id"
         case createdAt = "created_at"
         case duration
-    }
-
-    static func == (lhs: BlockUsersResponse, rhs: BlockUsersResponse) -> Bool {
-        lhs.blockedByUserId == rhs.blockedByUserId &&
-            lhs.blockedUserId == rhs.blockedUserId &&
-            lhs.createdAt == rhs.createdAt &&
-            lhs.duration == rhs.duration
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(blockedByUserId)
-        hasher.combine(blockedUserId)
-        hasher.combine(createdAt)
-        hasher.combine(duration)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/BlockedUserResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/BlockedUserResponse.swift
@@ -4,14 +4,14 @@
 
 import Foundation
 
-final class BlockedUserResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var blockedUser: UserResponse
+final class BlockedUserResponse: Sendable, Codable, JSONEncodable {
+    let blockedUser: UserResponse
     /// ID of the user who got blocked
-    var blockedUserId: String
-    var createdAt: Date
-    var user: UserResponse
+    let blockedUserId: String
+    let createdAt: Date
+    let user: UserResponse
     /// ID of the user who blocked another user
-    var userId: String
+    let userId: String
 
     init(blockedUser: UserResponse, blockedUserId: String, createdAt: Date, user: UserResponse, userId: String) {
         self.blockedUser = blockedUser
@@ -27,21 +27,5 @@ final class BlockedUserResponse: @unchecked Sendable, Codable, JSONEncodable, Ha
         case createdAt = "created_at"
         case user
         case userId = "user_id"
-    }
-
-    static func == (lhs: BlockedUserResponse, rhs: BlockedUserResponse) -> Bool {
-        lhs.blockedUser == rhs.blockedUser &&
-            lhs.blockedUserId == rhs.blockedUserId &&
-            lhs.createdAt == rhs.createdAt &&
-            lhs.user == rhs.user &&
-            lhs.userId == rhs.userId
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(blockedUser)
-        hasher.combine(blockedUserId)
-        hasher.combine(createdAt)
-        hasher.combine(user)
-        hasher.combine(userId)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/CreateDeviceRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/CreateDeviceRequest.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-final class CreateDeviceRequest: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class CreateDeviceRequest: Sendable, Codable, JSONEncodable {
     enum CreateDeviceRequestPushProvider: String, Sendable, Codable, CaseIterable {
         case apn
         case firebase
@@ -24,15 +24,15 @@ final class CreateDeviceRequest: @unchecked Sendable, Codable, JSONEncodable, Ha
     }
 
     /// Stable physical device identifier used to deduplicate pushes across push providers (e.g. APNs VoIP and Firebase on the same iOS device). Distinct from 'id', which is the push token.
-    var hardwareId: String?
+    let hardwareId: String?
     /// Device ID
-    var id: String
+    let id: String
     /// Push provider
-    var pushProvider: CreateDeviceRequestPushProvider
+    let pushProvider: CreateDeviceRequestPushProvider
     /// Push provider name
-    var pushProviderName: String?
+    let pushProviderName: String?
     /// When true the token is for Apple VoIP push notifications
-    var voipToken: Bool?
+    let voipToken: Bool?
 
     init(hardwareId: String? = nil, id: String, pushProvider: CreateDeviceRequestPushProvider, pushProviderName: String? = nil, voipToken: Bool? = nil) {
         self.hardwareId = hardwareId
@@ -48,21 +48,5 @@ final class CreateDeviceRequest: @unchecked Sendable, Codable, JSONEncodable, Ha
         case pushProvider = "push_provider"
         case pushProviderName = "push_provider_name"
         case voipToken = "voip_token"
-    }
-
-    static func == (lhs: CreateDeviceRequest, rhs: CreateDeviceRequest) -> Bool {
-        lhs.hardwareId == rhs.hardwareId &&
-            lhs.id == rhs.id &&
-            lhs.pushProvider == rhs.pushProvider &&
-            lhs.pushProviderName == rhs.pushProviderName &&
-            lhs.voipToken == rhs.voipToken
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(hardwareId)
-        hasher.combine(id)
-        hasher.combine(pushProvider)
-        hasher.combine(pushProviderName)
-        hasher.combine(voipToken)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/DeviceResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/DeviceResponse.swift
@@ -4,25 +4,25 @@
 
 import Foundation
 
-final class DeviceResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class DeviceResponse: Sendable, Codable, JSONEncodable {
     /// Date/time of creation
-    var createdAt: Date
+    let createdAt: Date
     /// Whether device is disabled or not
-    var disabled: Bool?
+    let disabled: Bool?
     /// Reason explaining why device had been disabled
-    var disabledReason: String?
+    let disabledReason: String?
     /// Stable physical device identifier used to deduplicate pushes across push providers
-    var hardwareId: String?
+    let hardwareId: String?
     /// Device ID
-    var id: String
+    let id: String
     /// Push provider
-    var pushProvider: String
+    let pushProvider: String
     /// Push provider name
-    var pushProviderName: String?
+    let pushProviderName: String?
     /// User ID
-    var userId: String
+    let userId: String
     /// When true the token is for Apple VoIP push notifications
-    var voip: Bool?
+    let voip: Bool?
 
     init(createdAt: Date, disabled: Bool? = nil, disabledReason: String? = nil, hardwareId: String? = nil, id: String, pushProvider: String, pushProviderName: String? = nil, userId: String, voip: Bool? = nil) {
         self.createdAt = createdAt
@@ -46,29 +46,5 @@ final class DeviceResponse: @unchecked Sendable, Codable, JSONEncodable, Hashabl
         case pushProviderName = "push_provider_name"
         case userId = "user_id"
         case voip
-    }
-
-    static func == (lhs: DeviceResponse, rhs: DeviceResponse) -> Bool {
-        lhs.createdAt == rhs.createdAt &&
-            lhs.disabled == rhs.disabled &&
-            lhs.disabledReason == rhs.disabledReason &&
-            lhs.hardwareId == rhs.hardwareId &&
-            lhs.id == rhs.id &&
-            lhs.pushProvider == rhs.pushProvider &&
-            lhs.pushProviderName == rhs.pushProviderName &&
-            lhs.userId == rhs.userId &&
-            lhs.voip == rhs.voip
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(createdAt)
-        hasher.combine(disabled)
-        hasher.combine(disabledReason)
-        hasher.combine(hardwareId)
-        hasher.combine(id)
-        hasher.combine(pushProvider)
-        hasher.combine(pushProviderName)
-        hasher.combine(userId)
-        hasher.combine(voip)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/FileUploadConfig.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/FileUploadConfig.swift
@@ -4,12 +4,12 @@
 
 import Foundation
 
-final class FileUploadConfig: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var allowedFileExtensions: [String]
-    var allowedMimeTypes: [String]
-    var blockedFileExtensions: [String]
-    var blockedMimeTypes: [String]
-    var sizeLimit: Int
+final class FileUploadConfig: Sendable, Codable, JSONEncodable {
+    let allowedFileExtensions: [String]
+    let allowedMimeTypes: [String]
+    let blockedFileExtensions: [String]
+    let blockedMimeTypes: [String]
+    let sizeLimit: Int
 
     init(allowedFileExtensions: [String], allowedMimeTypes: [String], blockedFileExtensions: [String], blockedMimeTypes: [String], sizeLimit: Int) {
         self.allowedFileExtensions = allowedFileExtensions
@@ -25,21 +25,5 @@ final class FileUploadConfig: @unchecked Sendable, Codable, JSONEncodable, Hasha
         case blockedFileExtensions = "blocked_file_extensions"
         case blockedMimeTypes = "blocked_mime_types"
         case sizeLimit = "size_limit"
-    }
-
-    static func == (lhs: FileUploadConfig, rhs: FileUploadConfig) -> Bool {
-        lhs.allowedFileExtensions == rhs.allowedFileExtensions &&
-            lhs.allowedMimeTypes == rhs.allowedMimeTypes &&
-            lhs.blockedFileExtensions == rhs.blockedFileExtensions &&
-            lhs.blockedMimeTypes == rhs.blockedMimeTypes &&
-            lhs.sizeLimit == rhs.sizeLimit
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(allowedFileExtensions)
-        hasher.combine(allowedMimeTypes)
-        hasher.combine(blockedFileExtensions)
-        hasher.combine(blockedMimeTypes)
-        hasher.combine(sizeLimit)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GetApplicationResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GetApplicationResponse.swift
@@ -4,10 +4,10 @@
 
 import Foundation
 
-final class GetApplicationResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var app: AppResponseFields
+final class GetApplicationResponse: Sendable, Codable, JSONEncodable {
+    let app: AppResponseFields
     /// Duration of the request in milliseconds
-    var duration: String
+    let duration: String
 
     init(app: AppResponseFields, duration: String) {
         self.app = app
@@ -17,15 +17,5 @@ final class GetApplicationResponse: @unchecked Sendable, Codable, JSONEncodable,
     enum CodingKeys: String, CodingKey, CaseIterable {
         case app
         case duration
-    }
-
-    static func == (lhs: GetApplicationResponse, rhs: GetApplicationResponse) -> Bool {
-        lhs.app == rhs.app &&
-            lhs.duration == rhs.duration
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(app)
-        hasher.combine(duration)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GetBlockedUsersResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GetBlockedUsersResponse.swift
@@ -4,11 +4,11 @@
 
 import Foundation
 
-final class GetBlockedUsersResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class GetBlockedUsersResponse: Sendable, Codable, JSONEncodable {
     /// Array of blocked user object
-    var blocks: [BlockedUserResponse]
+    let blocks: [BlockedUserResponse]
     /// Duration of the request in milliseconds
-    var duration: String
+    let duration: String
 
     init(blocks: [BlockedUserResponse], duration: String) {
         self.blocks = blocks
@@ -18,15 +18,5 @@ final class GetBlockedUsersResponse: @unchecked Sendable, Codable, JSONEncodable
     enum CodingKeys: String, CodingKey, CaseIterable {
         case blocks
         case duration
-    }
-
-    static func == (lhs: GetBlockedUsersResponse, rhs: GetBlockedUsersResponse) -> Bool {
-        lhs.blocks == rhs.blocks &&
-            lhs.duration == rhs.duration
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(blocks)
-        hasher.combine(duration)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GetOGResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GetOGResponse.swift
@@ -4,42 +4,42 @@
 
 import Foundation
 
-final class GetOGResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var actions: [AttachmentActionPayload]?
+final class GetOGResponse: Sendable, Codable, JSONEncodable {
+    let actions: [AttachmentActionPayload]?
     /// URL of detected video or audio
-    var assetUrl: String?
-    var authorIcon: String?
+    let assetUrl: String?
+    let authorIcon: String?
     /// og:site
-    var authorLink: String?
+    let authorLink: String?
     /// og:site_name
-    var authorName: String?
-    var color: String?
-    var custom: [String: RawJSON]
-    var duration: String
-    var fallback: String?
-    var fields: [AttachmentFieldPayload]?
-    var footer: String?
-    var footerIcon: String?
-    var giphy: GiphyImages?
+    let authorName: String?
+    let color: String?
+    let custom: [String: RawJSON]
+    let duration: String
+    let fallback: String?
+    let fields: [AttachmentFieldPayload]?
+    let footer: String?
+    let footerIcon: String?
+    let giphy: GiphyImages?
     /// URL of detected image
-    var imageUrl: String?
+    let imageUrl: String?
     /// extracted url from the text
-    var ogScrapeUrl: String?
-    var originalHeight: Int?
-    var originalWidth: Int?
-    var pretext: String?
+    let ogScrapeUrl: String?
+    let originalHeight: Int?
+    let originalWidth: Int?
+    let pretext: String?
     /// og:description
-    var text: String?
+    let text: String?
     /// URL of detected thumb image
-    var thumbUrl: String?
+    let thumbUrl: String?
     /// og:title
-    var title: String?
+    let title: String?
     /// og:url
-    var titleLink: String?
+    let titleLink: String?
     /// Attachment type, could be empty, image, audio or video
-    var type: String?
+    let type: String?
 
-    init(actions: [AttachmentActionPayload]? = nil, assetUrl: String? = nil, authorIcon: String? = nil, authorLink: String? = nil, authorName: String? = nil, color: String? = nil, custom: [String: RawJSON], duration: String, fallback: String? = nil, fields: [AttachmentFieldPayload]? = nil, footer: String? = nil, footerIcon: String? = nil, giphy: GiphyImages? = nil, imageUrl: String? = nil, ogScrapeUrl: String? = nil, originalHeight: Int? = nil, originalWidth: Int? = nil, pretext: String? = nil, text: String? = nil, thumbUrl: String? = nil, title: String? = nil, titleLink: String? = nil) {
+    init(actions: [AttachmentActionPayload]? = nil, assetUrl: String? = nil, authorIcon: String? = nil, authorLink: String? = nil, authorName: String? = nil, color: String? = nil, custom: [String: RawJSON], duration: String, fallback: String? = nil, fields: [AttachmentFieldPayload]? = nil, footer: String? = nil, footerIcon: String? = nil, giphy: GiphyImages? = nil, imageUrl: String? = nil, ogScrapeUrl: String? = nil, originalHeight: Int? = nil, originalWidth: Int? = nil, pretext: String? = nil, text: String? = nil, thumbUrl: String? = nil, title: String? = nil, titleLink: String? = nil, type: String? = nil) {
         self.actions = actions
         self.assetUrl = assetUrl
         self.authorIcon = authorIcon
@@ -62,6 +62,7 @@ final class GetOGResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable
         self.thumbUrl = thumbUrl
         self.title = title
         self.titleLink = titleLink
+        self.type = type
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {
@@ -88,57 +89,5 @@ final class GetOGResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable
         case title
         case titleLink = "title_link"
         case type
-    }
-
-    static func == (lhs: GetOGResponse, rhs: GetOGResponse) -> Bool {
-        lhs.actions == rhs.actions &&
-            lhs.assetUrl == rhs.assetUrl &&
-            lhs.authorIcon == rhs.authorIcon &&
-            lhs.authorLink == rhs.authorLink &&
-            lhs.authorName == rhs.authorName &&
-            lhs.color == rhs.color &&
-            lhs.custom == rhs.custom &&
-            lhs.duration == rhs.duration &&
-            lhs.fallback == rhs.fallback &&
-            lhs.fields == rhs.fields &&
-            lhs.footer == rhs.footer &&
-            lhs.footerIcon == rhs.footerIcon &&
-            lhs.giphy == rhs.giphy &&
-            lhs.imageUrl == rhs.imageUrl &&
-            lhs.ogScrapeUrl == rhs.ogScrapeUrl &&
-            lhs.originalHeight == rhs.originalHeight &&
-            lhs.originalWidth == rhs.originalWidth &&
-            lhs.pretext == rhs.pretext &&
-            lhs.text == rhs.text &&
-            lhs.thumbUrl == rhs.thumbUrl &&
-            lhs.title == rhs.title &&
-            lhs.titleLink == rhs.titleLink &&
-            lhs.type == rhs.type
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(actions)
-        hasher.combine(assetUrl)
-        hasher.combine(authorIcon)
-        hasher.combine(authorLink)
-        hasher.combine(authorName)
-        hasher.combine(color)
-        hasher.combine(custom)
-        hasher.combine(duration)
-        hasher.combine(fallback)
-        hasher.combine(fields)
-        hasher.combine(footer)
-        hasher.combine(footerIcon)
-        hasher.combine(giphy)
-        hasher.combine(imageUrl)
-        hasher.combine(ogScrapeUrl)
-        hasher.combine(originalHeight)
-        hasher.combine(originalWidth)
-        hasher.combine(pretext)
-        hasher.combine(text)
-        hasher.combine(thumbUrl)
-        hasher.combine(title)
-        hasher.combine(titleLink)
-        hasher.combine(type)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GiphyImageData.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GiphyImageData.swift
@@ -4,12 +4,12 @@
 
 import Foundation
 
-final class GiphyImageData: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var frames: String
-    var height: String
-    var size: String
-    var url: String
-    var width: String
+final class GiphyImageData: Sendable, Codable, JSONEncodable {
+    let frames: String
+    let height: String
+    let size: String
+    let url: String
+    let width: String
 
     init(frames: String, height: String, size: String, url: String, width: String) {
         self.frames = frames
@@ -25,21 +25,5 @@ final class GiphyImageData: @unchecked Sendable, Codable, JSONEncodable, Hashabl
         case size
         case url
         case width
-    }
-
-    static func == (lhs: GiphyImageData, rhs: GiphyImageData) -> Bool {
-        lhs.frames == rhs.frames &&
-            lhs.height == rhs.height &&
-            lhs.size == rhs.size &&
-            lhs.url == rhs.url &&
-            lhs.width == rhs.width
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(frames)
-        hasher.combine(height)
-        hasher.combine(size)
-        hasher.combine(url)
-        hasher.combine(width)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GiphyImages.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GiphyImages.swift
@@ -4,14 +4,14 @@
 
 import Foundation
 
-final class GiphyImages: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var fixedHeight: GiphyImageData
-    var fixedHeightDownsampled: GiphyImageData
-    var fixedHeightStill: GiphyImageData
-    var fixedWidth: GiphyImageData
-    var fixedWidthDownsampled: GiphyImageData
-    var fixedWidthStill: GiphyImageData
-    var original: GiphyImageData
+final class GiphyImages: Sendable, Codable, JSONEncodable {
+    let fixedHeight: GiphyImageData
+    let fixedHeightDownsampled: GiphyImageData
+    let fixedHeightStill: GiphyImageData
+    let fixedWidth: GiphyImageData
+    let fixedWidthDownsampled: GiphyImageData
+    let fixedWidthStill: GiphyImageData
+    let original: GiphyImageData
 
     init(fixedHeight: GiphyImageData, fixedHeightDownsampled: GiphyImageData, fixedHeightStill: GiphyImageData, fixedWidth: GiphyImageData, fixedWidthDownsampled: GiphyImageData, fixedWidthStill: GiphyImageData, original: GiphyImageData) {
         self.fixedHeight = fixedHeight
@@ -31,25 +31,5 @@ final class GiphyImages: @unchecked Sendable, Codable, JSONEncodable, Hashable {
         case fixedWidthDownsampled = "fixed_width_downsampled"
         case fixedWidthStill = "fixed_width_still"
         case original
-    }
-
-    static func == (lhs: GiphyImages, rhs: GiphyImages) -> Bool {
-        lhs.fixedHeight == rhs.fixedHeight &&
-            lhs.fixedHeightDownsampled == rhs.fixedHeightDownsampled &&
-            lhs.fixedHeightStill == rhs.fixedHeightStill &&
-            lhs.fixedWidth == rhs.fixedWidth &&
-            lhs.fixedWidthDownsampled == rhs.fixedWidthDownsampled &&
-            lhs.fixedWidthStill == rhs.fixedWidthStill &&
-            lhs.original == rhs.original
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(fixedHeight)
-        hasher.combine(fixedHeightDownsampled)
-        hasher.combine(fixedHeightStill)
-        hasher.combine(fixedWidth)
-        hasher.combine(fixedWidthDownsampled)
-        hasher.combine(fixedWidthStill)
-        hasher.combine(original)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/ListDevicesResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/ListDevicesResponse.swift
@@ -4,10 +4,10 @@
 
 import Foundation
 
-final class ListDevicesResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class ListDevicesResponse: Sendable, Codable, JSONEncodable {
     /// List of devices
-    var devices: [DeviceResponse]
-    var duration: String
+    let devices: [DeviceResponse]
+    let duration: String
 
     init(devices: [DeviceResponse], duration: String) {
         self.devices = devices
@@ -17,15 +17,5 @@ final class ListDevicesResponse: @unchecked Sendable, Codable, JSONEncodable, Ha
     enum CodingKeys: String, CodingKey, CaseIterable {
         case devices
         case duration
-    }
-
-    static func == (lhs: ListDevicesResponse, rhs: ListDevicesResponse) -> Bool {
-        lhs.devices == rhs.devices &&
-            lhs.duration == rhs.duration
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(devices)
-        hasher.combine(duration)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/Response.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/Response.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-final class Response: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class Response: Sendable, Codable, JSONEncodable {
     /// Duration of the request in milliseconds
-    var duration: String
+    let duration: String
 
     init(duration: String) {
         self.duration = duration
@@ -14,13 +14,5 @@ final class Response: @unchecked Sendable, Codable, JSONEncodable, Hashable {
 
     enum CodingKeys: String, CodingKey, CaseIterable {
         case duration
-    }
-
-    static func == (lhs: Response, rhs: Response) -> Bool {
-        lhs.duration == rhs.duration
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(duration)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UnblockUsersRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UnblockUsersRequest.swift
@@ -4,8 +4,8 @@
 
 import Foundation
 
-final class UnblockUsersRequest: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var blockedUserId: String
+final class UnblockUsersRequest: Sendable, Codable, JSONEncodable {
+    let blockedUserId: String
 
     init(blockedUserId: String) {
         self.blockedUserId = blockedUserId
@@ -13,13 +13,5 @@ final class UnblockUsersRequest: @unchecked Sendable, Codable, JSONEncodable, Ha
 
     enum CodingKeys: String, CodingKey, CaseIterable {
         case blockedUserId = "blocked_user_id"
-    }
-
-    static func == (lhs: UnblockUsersRequest, rhs: UnblockUsersRequest) -> Bool {
-        lhs.blockedUserId == rhs.blockedUserId
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(blockedUserId)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UnblockUsersResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UnblockUsersResponse.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-final class UnblockUsersResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
+final class UnblockUsersResponse: Sendable, Codable, JSONEncodable {
     /// Duration of the request in milliseconds
-    var duration: String
+    let duration: String
 
     init(duration: String) {
         self.duration = duration
@@ -14,13 +14,5 @@ final class UnblockUsersResponse: @unchecked Sendable, Codable, JSONEncodable, H
 
     enum CodingKeys: String, CodingKey, CaseIterable {
         case duration
-    }
-
-    static func == (lhs: UnblockUsersResponse, rhs: UnblockUsersResponse) -> Bool {
-        lhs.duration == rhs.duration
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(duration)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UserResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UserResponse.swift
@@ -4,39 +4,39 @@
 
 import Foundation
 
-final class UserResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable {
-    var avgResponseTime: Int?
+final class UserResponse: Sendable, Codable, JSONEncodable {
+    let avgResponseTime: Int?
     /// Whether a user is banned or not
-    var banned: Bool
-    var blockedUserIds: [String]
+    let banned: Bool
+    let blockedUserIds: [String]
     /// Date/time of creation
-    var createdAt: Date
+    let createdAt: Date
     /// Custom data for this object
-    var custom: [String: RawJSON]
+    let custom: [String: RawJSON]
     /// Date of deactivation
-    var deactivatedAt: Date?
+    let deactivatedAt: Date?
     /// Date/time of deletion
-    var deletedAt: Date?
+    let deletedAt: Date?
     /// Unique user identifier
-    var id: String
-    var image: String?
+    let id: String
+    let image: String?
     /// Preferred language of a user
-    var language: String
+    let language: String
     /// Date of last activity
-    var lastActive: Date?
+    let lastActive: Date?
     /// Optional name of user
-    var name: String?
+    let name: String?
     /// Whether a user online or not
-    var online: Bool
+    let online: Bool
     /// Revocation date for tokens
-    var revokeTokensIssuedBefore: Date?
+    let revokeTokensIssuedBefore: Date?
     /// Determines the set of user permissions
-    var role: String
+    let role: String
     /// List of teams user is a part of
-    var teams: [String]
-    var teamsRole: [String: String]?
+    let teams: [String]
+    let teamsRole: [String: String]?
     /// Date/time of the last update
-    var updatedAt: Date
+    let updatedAt: Date
 
     init(avgResponseTime: Int? = nil, banned: Bool, blockedUserIds: [String], createdAt: Date, custom: [String: RawJSON], deactivatedAt: Date? = nil, deletedAt: Date? = nil, id: String, image: String? = nil, language: String, lastActive: Date? = nil, name: String? = nil, online: Bool, revokeTokensIssuedBefore: Date? = nil, role: String, teams: [String], teamsRole: [String: String]? = nil, updatedAt: Date) {
         self.avgResponseTime = avgResponseTime
@@ -78,47 +78,5 @@ final class UserResponse: @unchecked Sendable, Codable, JSONEncodable, Hashable 
         case teams
         case teamsRole = "teams_role"
         case updatedAt = "updated_at"
-    }
-
-    static func == (lhs: UserResponse, rhs: UserResponse) -> Bool {
-        lhs.avgResponseTime == rhs.avgResponseTime &&
-            lhs.banned == rhs.banned &&
-            lhs.blockedUserIds == rhs.blockedUserIds &&
-            lhs.createdAt == rhs.createdAt &&
-            lhs.custom == rhs.custom &&
-            lhs.deactivatedAt == rhs.deactivatedAt &&
-            lhs.deletedAt == rhs.deletedAt &&
-            lhs.id == rhs.id &&
-            lhs.image == rhs.image &&
-            lhs.language == rhs.language &&
-            lhs.lastActive == rhs.lastActive &&
-            lhs.name == rhs.name &&
-            lhs.online == rhs.online &&
-            lhs.revokeTokensIssuedBefore == rhs.revokeTokensIssuedBefore &&
-            lhs.role == rhs.role &&
-            lhs.teams == rhs.teams &&
-            lhs.teamsRole == rhs.teamsRole &&
-            lhs.updatedAt == rhs.updatedAt
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(avgResponseTime)
-        hasher.combine(banned)
-        hasher.combine(blockedUserIds)
-        hasher.combine(createdAt)
-        hasher.combine(custom)
-        hasher.combine(deactivatedAt)
-        hasher.combine(deletedAt)
-        hasher.combine(id)
-        hasher.combine(image)
-        hasher.combine(language)
-        hasher.combine(lastActive)
-        hasher.combine(name)
-        hasher.combine(online)
-        hasher.combine(revokeTokensIssuedBefore)
-        hasher.combine(role)
-        hasher.combine(teams)
-        hasher.combine(teamsRole)
-        hasher.combine(updatedAt)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1620](https://linear.app/stream/issue/IOS-1620/openapi-generation-in-llc)

### 🎯 Goal

Generate immutable, internal OpenAPI models straight from the generator instead of stripping `public`/mutability afterwards.

### 📝 Summary

- Enable `immutable_models=true` and `access_modifier=internal` in OpenAPI client generation.
- Rename `Scripts/generate.sh` → `Scripts/openapi_generate.sh`.
- Regenerate models: properties are now `let`, types are `internal` and conform to checked `Sendable`.

### 🛠 Implementation

The generator now emits the desired shape directly, so the previous post-processing that downgraded access and mutability is no longer needed.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

N/A — generated code, covered by the build.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Swift API client generation process to produce immutable models and use internal access by default.
  * Streamlined the post-generation formatting step for generated Swift code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->