### PR TITLE
Call attachment download completion even when the controller is not retained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix sending typing events to channels without typing events capability [#4132](https://github.com/GetStream/stream-chat-swift/pull/4132)
 - Fix `typing.stop` being sent unconditionally on every message send [#4146](https://github.com/GetStream/stream-chat-swift/pull/4146)
+- Fix attachment download completion handler not being called when the message controller is not retained until the download finishes [#4149](https://github.com/GetStream/stream-chat-swift/pull/4149)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -807,8 +807,8 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
         request: URLRequest? = nil,
         completion: @escaping @MainActor (Result<ChatMessageAttachment<Payload>, Error>) -> Void
     ) where Payload: DownloadableAttachmentPayload {
-        messageUpdater.downloadAttachment(attachment, request: request) { [weak self] result in
-            self?.callback {
+        messageUpdater.downloadAttachment(attachment, request: request) { result in
+            self.callback {
                 completion(result)
             }
         }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -20,7 +20,8 @@ final class MessageUpdater_Mock: MessageUpdater, @unchecked Sendable {
     @Atomic var downloadAttachment_attachmentId: AttachmentId?
     @Atomic var downloadAttachment_request: URLRequest?
     @Atomic var downloadAttachment_completion_result: Result<AnyChatMessageAttachment, Error>?
-    
+    @Atomic var downloadAttachment_completion: ((Result<AnyChatMessageAttachment, Error>) -> Void)?
+
     @Atomic var deleteLocalAttachmentDownload_attachmentId: AttachmentId?
     @Atomic var deleteLocalAttachmentDownload_completion_result: Result<Void, Error>?
 
@@ -173,7 +174,8 @@ final class MessageUpdater_Mock: MessageUpdater, @unchecked Sendable {
         downloadAttachment_attachmentId = nil
         downloadAttachment_request = nil
         downloadAttachment_completion_result = nil
-        
+        downloadAttachment_completion = nil
+
         editMessage_messageId = nil
         editMessage_text = nil
         editMessage_skipPush = nil
@@ -317,6 +319,18 @@ final class MessageUpdater_Mock: MessageUpdater, @unchecked Sendable {
     ) where Payload: DownloadableAttachmentPayload {
         downloadAttachment_attachmentId = attachment.id
         downloadAttachment_request = request
+        downloadAttachment_completion = { result in
+            switch result {
+            case .success(let anyAttachment):
+                if let result = anyAttachment.attachment(payloadType: Payload.self) {
+                    completion(.success(result))
+                } else {
+                    completion(.failure(TestError()))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
         switch downloadAttachment_completion_result {
         case .success(let anyAttachment):
             if let result = anyAttachment.attachment(payloadType: Payload.self) {

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -728,6 +728,33 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.downloadAttachment_attachmentId, attachmentId)
     }
 
+    func test_downloadAttachment_callsCompletion_evenWhenControllerIsNotRetained() {
+        let attachmentId = AttachmentId.unique
+        let expected = ChatMessageFileAttachment.mock(id: attachmentId)
+
+        // Simulate `downloadAttachment` call and catch the completion
+        nonisolated(unsafe) var completionResult: Result<ChatMessageFileAttachment, Error>?
+        controller.downloadAttachment(expected) { completionResult = $0 }
+
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+
+        // Simulate the network response after the controller reference is dropped
+        env.messageUpdater.downloadAttachment_completion?(.success(expected.asAnyAttachment))
+        // Release reference of completion so we can deallocate stuff
+        env.messageUpdater.downloadAttachment_completion = nil
+
+        // Assert completion is still called even though the controller was not retained
+        AssertAsync.willBeTrue(completionResult != nil)
+        XCTAssertEqual(try? completionResult?.get(), expected)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+
     func test_downloadAttachment_propagatesError() {
         let attachmentId = AttachmentId.unique
         let attachment = ChatMessageFileAttachment.mock(id: attachmentId)
@@ -1575,7 +1602,7 @@ final class MessageController_Tests: XCTestCase {
         let firstPage = MessagesPagination(pageSize: 25, parameter: nil)
 
         let exp = expectation(description: "load first page completes")
-        controller.loadFirstPage() { error in
+        controller.loadFirstPage { error in
             XCTAssertNil(error)
             exp.fulfill()
         }
@@ -1593,7 +1620,7 @@ final class MessageController_Tests: XCTestCase {
     func test_loadFirstPage_whenError() throws {
         let exp = expectation(description: "load first page completes")
         nonisolated(unsafe) var expectedError: Error?
-        controller.loadFirstPage() { error in
+        controller.loadFirstPage { error in
             expectedError = error
             exp.fulfill()
         }
@@ -2352,7 +2379,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadRead_whenSuccess() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadRead() { error in
+        controller.markThreadRead { error in
             XCTAssertNil(error)
             exp.fulfill()
         }
@@ -2366,7 +2393,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadRead_whenFailure() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadRead() { error in
+        controller.markThreadRead { error in
             XCTAssertNotNil(error)
             exp.fulfill()
         }
@@ -2382,7 +2409,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadUnread_whenSuccess() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadUnread() { error in
+        controller.markThreadUnread { error in
             XCTAssertNil(error)
             exp.fulfill()
         }
@@ -2396,7 +2423,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadUnread_whenFailure() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadUnread() { error in
+        controller.markThreadUnread { error in
             XCTAssertNotNil(error)
             exp.fulfill()
         }

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -1602,7 +1602,7 @@ final class MessageController_Tests: XCTestCase {
         let firstPage = MessagesPagination(pageSize: 25, parameter: nil)
 
         let exp = expectation(description: "load first page completes")
-        controller.loadFirstPage { error in
+        controller.loadFirstPage() { error in
             XCTAssertNil(error)
             exp.fulfill()
         }
@@ -1620,7 +1620,7 @@ final class MessageController_Tests: XCTestCase {
     func test_loadFirstPage_whenError() throws {
         let exp = expectation(description: "load first page completes")
         nonisolated(unsafe) var expectedError: Error?
-        controller.loadFirstPage { error in
+        controller.loadFirstPage() { error in
             expectedError = error
             exp.fulfill()
         }
@@ -2379,7 +2379,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadRead_whenSuccess() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadRead { error in
+        controller.markThreadRead() { error in
             XCTAssertNil(error)
             exp.fulfill()
         }
@@ -2393,7 +2393,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadRead_whenFailure() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadRead { error in
+        controller.markThreadRead() { error in
             XCTAssertNotNil(error)
             exp.fulfill()
         }
@@ -2409,7 +2409,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadUnread_whenSuccess() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadUnread { error in
+        controller.markThreadUnread() { error in
             XCTAssertNil(error)
             exp.fulfill()
         }
@@ -2423,7 +2423,7 @@ final class MessageController_Tests: XCTestCase {
 
     func test_markThreadUnread_whenFailure() {
         let exp = expectation(description: "mark read completion")
-        controller.markThreadUnread { error in
+        controller.markThreadUnread() { error in
             XCTAssertNotNil(error)
             exp.fulfill()
         }


### PR DESCRIPTION
### 🔗 Issue Links

Fixes: [IOS-1802](https://linear.app/stream/issue/IOS-1802/)

### 🎯 Goal

Ensure `ChatMessageController.downloadAttachment` always calls its completion handler, even when the controller is not externally retained until the download finishes.

### 📝 Summary

- `ChatMessageController.downloadAttachment(_:request:completion:)` now captures `self` strongly in its one-shot completion closure, so the completion handler is always called even when the controller is not retained by the caller.
- Scope is intentionally limited to this single function for now; the remaining controller methods will be addressed in follow-up changes.

### 🛠 Implementation

A root cause behind IOS-1802 is `[weak self]` callback handling in the controllers. `downloadAttachment` captured `self` weakly when forwarding the download response to the user's completion handler (`self?.callback { completion(...) }`). The `callback` helper does not retain the controller, so if the controller was deallocated before the response arrived, the completion was silently never called — forcing callers to manually retain the controller and breaking the "create controller → call method → throw it away" usage.

Capturing `self` strongly only extends the controller's lifetime until the download completes (the updater releases the closure after the response) — it is not a permanent retain cycle. A unit test asserts the completion still fires after the only external reference to the controller is dropped, and that the controller is then deallocated.

### 🧪 Manual Testing Notes

Try the download button on the attachment preview view in the SwiftUI SDK.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment download completion so it’s still called even if the message controller is released before the download finishes.
  * Added a changelog entry documenting the attachment download completion issue.

* **Tests**
  * Added a new test covering the completion callback behavior when the controller is not retained.
  * Updated/extended mocks and tests to record and validate the download completion callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->