### PR TITLE
Fix unread messages banner disappearing too early after mark-as-unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix `Spacer()` conflicting with SwiftUI's `Spacer` when building with Xcode 27 [#4131](https://github.com/GetStream/stream-chat-swift/pull/4131)
 - Fix showing voice recording icon in search results [#4127](https://github.com/GetStream/stream-chat-swift/pull/4127)
+- Fix unread messages banner disappearing instantly after marking a message as unread and reopening the channel [#4154](https://github.com/GetStream/stream-chat-swift/pull/4154)
 
 # [5.5.1](https://github.com/GetStream/stream-chat-swift/releases/tag/5.5.1)
 _June 11, 2026_

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -443,7 +443,7 @@ open class ChatChannelVC: _ViewController,
             dismiss(animated: true) { [weak self] in
                 self?.channelController.markUnread(from: message.id) { result in
                     if case let .success(channel) = result {
-                        self?.updateAllUnreadMessagesRelatedComponents(channel: channel)
+                        self?.updateAllUnreadMessagesRelatedComponents(channel: channel, forceUpdateBanner: true)
                     }
                 }
             }
@@ -606,7 +606,7 @@ open class ChatChannelVC: _ViewController,
         }
         
         if let event = event as? NotificationMarkUnreadEvent, let channel = channelController.channel, event.cid == channelController.cid, !messages.isEmpty {
-            updateAllUnreadMessagesRelatedComponents(channel: channel)
+            updateAllUnreadMessagesRelatedComponents(channel: channel, forceUpdateBanner: true)
         }
     }
 
@@ -647,10 +647,10 @@ private extension ChatChannelVC {
         )
     }
 
-    func updateAllUnreadMessagesRelatedComponents(channel: ChatChannel? = nil) {
+    func updateAllUnreadMessagesRelatedComponents(channel: ChatChannel? = nil, forceUpdateBanner: Bool = false) {
         updateScrollToBottomButtonCount(channel: channel)
         updateJumpToUnreadRelatedComponents(channel: channel)
-        updateUnreadMessagesBannerRelatedComponents(channel: channel)
+        updateUnreadMessagesBannerRelatedComponents(channel: channel, forceUpdate: forceUpdateBanner)
     }
 
     func updateScrollToBottomButtonCount(channel: ChatChannel? = nil) {
@@ -669,7 +669,19 @@ private extension ChatChannelVC {
         messageListVC.updateJumpToUnreadButtonVisibility()
     }
 
-    func updateUnreadMessagesBannerRelatedComponents(channel: ChatChannel? = nil) {
+    /// Updates the anchor message id used to render the unread messages banner.
+    ///
+    /// Once anchored for the current channel screen session, the banner is intentionally left in
+    /// place even if a subsequent `markRead()` call (e.g. triggered by the last message becoming
+    /// visible, or by scrolling) resets the channel's unread count in the background: it's only
+    /// recalculated the next time the channel is opened, or when `forceUpdate` is passed because the
+    /// unread boundary genuinely moved (e.g. a new mark-as-unread action). This mirrors the SwiftUI
+    /// SDK's `ChatChannelViewModel`, which keeps `firstUnreadMessageId` set after calling `markRead()`.
+    func updateUnreadMessagesBannerRelatedComponents(channel: ChatChannel? = nil, forceUpdate: Bool = false) {
+        guard forceUpdate || firstUnreadMessageId == nil else { return }
+        if forceUpdate {
+            hasSeenFirstUnreadMessage = false
+        }
         let resolvedChannel = channel ?? channelController.channel
         let hasUnreadMessages = (resolvedChannel?.unreadCount.messages ?? 0) > 0
         let firstUnreadMessageId = hasUnreadMessages

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -671,12 +671,10 @@ private extension ChatChannelVC {
 
     /// Updates the anchor message id used to render the unread messages banner.
     ///
-    /// Once anchored for the current channel screen session, the banner is intentionally left in
-    /// place even if a subsequent `markRead()` call (e.g. triggered by the last message becoming
-    /// visible, or by scrolling) resets the channel's unread count in the background: it's only
-    /// recalculated the next time the channel is opened, or when `forceUpdate` is passed because the
-    /// unread boundary genuinely moved (e.g. a new mark-as-unread action). This mirrors the SwiftUI
-    /// SDK's `ChatChannelViewModel`, which keeps `firstUnreadMessageId` set after calling `markRead()`.
+    /// Once anchored for the current channel screen session, the banner stays in place even if a
+    /// subsequent `markRead()` call resets the channel's unread count in the background. It's only
+    /// recalculated on the next channel open, or when `forceUpdate` is passed because the unread
+    /// boundary genuinely moved (e.g. a new mark-as-unread action).
     func updateUnreadMessagesBannerRelatedComponents(channel: ChatChannel? = nil, forceUpdate: Bool = false) {
         guard forceUpdate || firstUnreadMessageId == nil else { return }
         if forceUpdate {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -1377,6 +1377,55 @@ import XCTest
         AssertSnapshot(vc, variants: [.defaultLight])
     }
 
+    func test_didUpdateChannel_whenChannelBecomesReadInBackground_unreadMessagesBannerRemainsVisible() throws {
+        // Regression test: opening a channel that was previously marked as unread should keep
+        // showing the unread messages banner for that session, even if `markRead()` is triggered
+        // automatically (e.g. because the last message is immediately visible) and resets the
+        // channel's unread count in the background. The banner should only disappear the next
+        // time the channel is opened. See `ChatChannelViewModel` in the SwiftUI SDK for the
+        // equivalent, intentional behavior (`markRead()` explicitly keeps `firstUnreadMessageId` set).
+        var components = Components.mock
+        components.channelHeaderView = ChatChannelHeaderViewMock.self
+        components.messageComposerVC = ComposerVC_Mock.self
+        components.isUnreadMessagesSeparatorEnabled = true
+        vc.components = components
+        vc.messageListVC.components = components
+        vc.messageListVC.dataSource = vc
+
+        let firstMessageId = MessageId.unique
+        channelControllerMock.mockFirstUnreadMessageId = firstMessageId
+        vc.messages = [
+            .mock(id: firstMessageId, text: "First unread message", createdAt: Date(timeIntervalSince1970: 0)),
+            .mock(text: "Newer message", createdAt: Date(timeIntervalSince1970: 1))
+        ]
+
+        // The channel opens with an unread message (e.g. it was previously marked as unread).
+        let unreadChannel = ChatChannel.mock(cid: .unique, unreadCount: ChannelUnreadCount(messages: 1, mentions: 0))
+        channelControllerMock.simulateInitial(channel: unreadChannel, messages: vc.messages, state: .remoteDataFetched)
+        vc.channelController(vc.channelController, didUpdateChannel: .update(unreadChannel))
+
+        func shouldShowUnreadMessages() throws -> Bool {
+            let header = vc.chatMessageListVC(
+                vc.messageListVC,
+                headerViewForMessage: .mock(id: firstMessageId, createdAt: Date(timeIntervalSince1970: 0)),
+                at: .init(row: 0, section: 0)
+            )
+            let headerDecorationView = try XCTUnwrap(header as? ChatChannelMessageHeaderDecoratorView)
+            return try XCTUnwrap(headerDecorationView.content).shouldShowUnreadMessages
+        }
+
+        XCTAssertTrue(try shouldShowUnreadMessages())
+
+        // Simulate the channel being auto-marked-as-read in the background (e.g. a `markRead()`
+        // triggered by `viewDidAppear`/scrolling completing), which resets the unread count to 0
+        // and triggers a new `didUpdateChannel` callback, just like it would right after opening.
+        let readChannel = ChatChannel.mock(cid: unreadChannel.cid, unreadCount: .noUnread)
+        channelControllerMock.channel_mock = readChannel
+        vc.channelController(vc.channelController, didUpdateChannel: .update(readChannel))
+
+        XCTAssertTrue(try shouldShowUnreadMessages())
+    }
+
     func test_headerViewForMessage_whenUnreadSeparatorIsDisabled_whenMessageShouldShowDateSeparator_AndIsMarkedAsUnread() throws {
         var components = Components.mock
         components.channelHeaderView = ChatChannelHeaderViewMock.self

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -1378,12 +1378,9 @@ import XCTest
     }
 
     func test_didUpdateChannel_whenChannelBecomesReadInBackground_unreadMessagesBannerRemainsVisible() throws {
-        // Regression test: opening a channel that was previously marked as unread should keep
-        // showing the unread messages banner for that session, even if `markRead()` is triggered
-        // automatically (e.g. because the last message is immediately visible) and resets the
-        // channel's unread count in the background. The banner should only disappear the next
-        // time the channel is opened. See `ChatChannelViewModel` in the SwiftUI SDK for the
-        // equivalent, intentional behavior (`markRead()` explicitly keeps `firstUnreadMessageId` set).
+        // Regression test: the unread messages banner should keep showing for the session even if
+        // `markRead()` is triggered automatically in the background and resets the channel's unread
+        // count. It should only disappear the next time the channel is opened.
         var components = Components.mock
         components.channelHeaderView = ChatChannelHeaderViewMock.self
         components.messageComposerVC = ComposerVC_Mock.self


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1817](https://linear.app/stream/issue/IOS-1817/regression-uikit-unread-seperator-disappears-on-channel-open)

### 🎯 Goal

Fix a regression where, after marking a message as unread, leaving the channel, and reopening it, the unread messages banner disappeared instantly instead of staying visible until the channel is opened again.

Regression caused by this PR: https://github.com/GetStream/stream-chat-swiftui/pull/1501

### 📝 Summary

- `ChatChannelVC.didUpdateChannel(_:)` recomputed the unread messages banner anchor (`firstUnreadMessageId`) on every channel update, including the local optimistic DB write triggered by the screen's own `markRead()` call. As soon as `markRead()` succeeded (which can happen almost immediately on open, since the newest message is typically already visible), the channel's unread count dropped to `0` and the banner was force-hidden within the same session.
- `updateUnreadMessagesBannerRelatedComponents(channel:forceUpdate:)` now keeps the banner anchored once set for the current channel screen session, and only recalculates it on a fresh channel open, or when `forceUpdate` is passed because the unread boundary genuinely moved (a new mark-as-unread action, locally or from a remote `NotificationMarkUnreadEvent`).
- Added a regression test that reproduces the exact scenario (verified it fails on the previous implementation).

### 🛠 Implementation

This mirrors the equivalent, intentional behavior already present in the SwiftUI SDK's `ChatChannelViewModel`, which explicitly keeps `firstUnreadMessageId` set after calling `channelController.markRead()`:

```swift
throttler.execute { [weak self] in
    self?.channelController.markRead()
    // We keep `firstUnreadMessageId` value set which keeps showing the new messages header in the channel view
}
```

`updateAllUnreadMessagesRelatedComponents(channel:forceUpdateBanner:)` threads a `forceUpdateBanner` flag through to `updateUnreadMessagesBannerRelatedComponents`, used only by the two call sites where the unread boundary actually changes (mark-as-unread action, remote mark-unread event).

### 🧪 Manual Testing Notes

1. Mark a message as unread in a channel.
2. Leave the channel (go back to the channel list).
3. Reopen the channel.
4. The unread messages banner should stay visible for this session, and only disappear the next time the channel is opened.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the unread messages banner could disappear instantly after marking a message as unread and reopening a channel.
  * Ensured the unread banner stays visible when a channel’s unread state is updated in the background.

* **Tests**
  * Added a regression snapshot test to verify unread banner visibility persists after background channel updates.

* **Documentation**
  * Updated the upcoming changelog entry with the unread banner fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->