### PR TITLE
OpenAPI: Reuse generated AppSettings model in the public API layer

### DIFF
--- a/Scripts/openapi_generate.sh
+++ b/Scripts/openapi_generate.sh
@@ -160,11 +160,25 @@ prune_models
 #     pollution / collisions with hand-written SDK types. Runs AFTER prune_models
 #     so allowed_models above still matches the generator's original names.
 rename_generated Action AttachmentActionPayload
+rename_generated AppResponseFields AppSettings
 rename_generated Field AttachmentFieldPayload
+rename_generated FileUploadConfig UploadConfig
 rename_generated ImageData GiphyImageData
 rename_generated Images GiphyImages
 
 rename_generated_type Response EmptyResponse
+
+# 4c. Expose selected generated models as public API. The class and its stored
+#     properties become public; the memberwise init and CodingKeys stay internal.
+publicize_model() {
+  local file="$OUTPUT_DIR_CHAT/models/$1.swift"
+  sed -i '' -E \
+    -e 's/^final class /public final class /' \
+    -e 's/^    let /    public let /' \
+    "$file"
+}
+publicize_model AppSettings
+publicize_model UploadConfig
 
 # 5. Format.
 swiftformat --config "$REPO_ROOT/.swiftformat" "$OUTPUT_DIR_CHAT"

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -639,7 +639,7 @@ public class ChatClient: @unchecked Sendable {
         apiClient.request(endpoint: .getApp()) { [weak self] result in
             switch result {
             case let .success(payload):
-                let appSettings = payload.asModel()
+                let appSettings = payload.app
                 self?.appSettings = appSettings
                 try? self?.backgroundWorker(of: AttachmentQueueUploader.self)
                     .setAppSettings(appSettings)

--- a/Sources/StreamChat/Generated/OpenAPI/models/AppSettings.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AppSettings.swift
@@ -4,16 +4,16 @@
 
 import Foundation
 
-final class AppResponseFields: Sendable, Codable, JSONEncodable {
-    let asyncUrlEnrichEnabled: Bool
-    let autoTranslationEnabled: Bool
-    let fileUploadConfig: FileUploadConfig
-    let id: Int
-    let imageUploadConfig: FileUploadConfig
-    let name: String
-    let placement: String
+public final class AppSettings: Sendable, Codable, JSONEncodable {
+    public let asyncUrlEnrichEnabled: Bool
+    public let autoTranslationEnabled: Bool
+    public let fileUploadConfig: UploadConfig
+    public let id: Int
+    public let imageUploadConfig: UploadConfig
+    public let name: String
+    public let placement: String
 
-    init(asyncUrlEnrichEnabled: Bool, autoTranslationEnabled: Bool, fileUploadConfig: FileUploadConfig, id: Int, imageUploadConfig: FileUploadConfig, name: String, placement: String) {
+    init(asyncUrlEnrichEnabled: Bool, autoTranslationEnabled: Bool, fileUploadConfig: UploadConfig, id: Int, imageUploadConfig: UploadConfig, name: String, placement: String) {
         self.asyncUrlEnrichEnabled = asyncUrlEnrichEnabled
         self.autoTranslationEnabled = autoTranslationEnabled
         self.fileUploadConfig = fileUploadConfig

--- a/Sources/StreamChat/Generated/OpenAPI/models/GetApplicationResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GetApplicationResponse.swift
@@ -5,11 +5,11 @@
 import Foundation
 
 final class GetApplicationResponse: Sendable, Codable, JSONEncodable {
-    let app: AppResponseFields
+    let app: AppSettings
     /// Duration of the request in milliseconds
     let duration: String
 
-    init(app: AppResponseFields, duration: String) {
+    init(app: AppSettings, duration: String) {
         self.app = app
         self.duration = duration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UploadConfig.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UploadConfig.swift
@@ -4,12 +4,12 @@
 
 import Foundation
 
-final class FileUploadConfig: Sendable, Codable, JSONEncodable {
-    let allowedFileExtensions: [String]
-    let allowedMimeTypes: [String]
-    let blockedFileExtensions: [String]
-    let blockedMimeTypes: [String]
-    let sizeLimit: Int
+public final class UploadConfig: Sendable, Codable, JSONEncodable {
+    public let allowedFileExtensions: [String]
+    public let allowedMimeTypes: [String]
+    public let blockedFileExtensions: [String]
+    public let blockedMimeTypes: [String]
+    public let sizeLimit: Int
 
     init(allowedFileExtensions: [String], allowedMimeTypes: [String], blockedFileExtensions: [String], blockedMimeTypes: [String], sizeLimit: Int) {
         self.allowedFileExtensions = allowedFileExtensions

--- a/Sources/StreamChat/Models/AppSettings+Extensions.swift
+++ b/Sources/StreamChat/Models/AppSettings+Extensions.swift
@@ -5,82 +5,40 @@
 import CoreServices
 import Foundation
 
-/// A type representing the app settings.
-public struct AppSettings: Sendable {
-    /// The name of the app.
-    public let name: String
-    /// The the file uploading configuration.
-    public let fileUploadConfig: UploadConfig
-    /// The the image uploading configuration.
-    public let imageUploadConfig: UploadConfig
-    /// A boolean value determining if auto translation is enabled.
-    public let autoTranslationEnabled: Bool
-    /// A boolean value determining if async url enrichment is enabled.
-    public let asyncUrlEnrichEnabled: Bool
-
-    public struct UploadConfig: Sendable {
-        /// The allowed file extensions.
-        public let allowedFileExtensions: [String]
-        /// The blocked file extensions.
-        public let blockedFileExtensions: [String]
-        /// The allowed mime types.
-        public let allowedMimeTypes: [String]
-        /// The blocked mime types.
-        public let blockedMimeTypes: [String]
-        /// The file size limit allowed in Bytes.
-        /// This value is configurable from Stream's Dashboard App Settings.
-        public let sizeLimitInBytes: Int64?
-    }
+extension AppSettings {
+    /// The upload configuration.
+    public typealias UploadConfig = StreamChat.UploadConfig
 }
 
-// MARK: - Response -> Model
-
-extension GetApplicationResponse {
-    func asModel() -> AppSettings {
-        .init(
-            name: app.name,
-            fileUploadConfig: app.fileUploadConfig.asModel(),
-            imageUploadConfig: app.imageUploadConfig.asModel(),
-            autoTranslationEnabled: app.autoTranslationEnabled,
-            asyncUrlEnrichEnabled: app.asyncUrlEnrichEnabled
-        )
-    }
-}
-
-extension FileUploadConfig {
-    func asModel() -> AppSettings.UploadConfig {
-        .init(
-            allowedFileExtensions: allowedFileExtensions,
-            blockedFileExtensions: blockedFileExtensions,
-            allowedMimeTypes: allowedMimeTypes,
-            blockedMimeTypes: blockedMimeTypes,
-            sizeLimitInBytes: Int64(sizeLimit)
-        )
-    }
+extension AppSettings.UploadConfig {
+    /// The file size limit allowed in Bytes.
+    /// This value is configurable from Stream's Dashboard App Settings.
+    @available(*, deprecated, renamed: "sizeLimit")
+    public var sizeLimitInBytes: Int64? { Int64(sizeLimit) }
 }
 
 // MARK: - Validation
 
 extension AppSettings.UploadConfig {
     // MARK: - UTI Validation
-    
+
     /// Returns an array of allowed UTI identifiers based on allowed mime types and file extensions.
     public var allowedUTITypes: [String] {
         allowedMimeTypes.compactMap { $0.utiType(mime: true) } +
             allowedFileExtensions.compactMap { $0.utiType(mime: false) }
     }
-    
+
     /// Returns an array of blocked UTI identifiers based on allowed mime types and file extensions.
     public var blockedUTITypes: [String] {
         blockedMimeTypes.compactMap { $0.utiType(mime: true) } +
             blockedFileExtensions.compactMap { $0.utiType(mime: false) }
     }
-    
+
     // MARK: - URL Validation
-    
+
     func isAllowed(localURL: URL) -> Bool {
         guard !localURL.pathExtension.isEmpty else { return true }
-        
+
         if !allowedFileExtensions.isEmpty || !blockedFileExtensions.isEmpty {
             if !isAllowed(pathExtension: localURL.pathExtension.lowercased()) {
                 return false
@@ -94,7 +52,7 @@ extension AppSettings.UploadConfig {
         }
         return true
     }
-    
+
     private func isAllowed(pathExtension: String) -> Bool {
         let isBlocked = blockedFileExtensions.contains { blocked in
             blocked.drop(while: { $0 == Character(".") }).caseInsensitiveCompare(pathExtension) == .orderedSame
@@ -105,7 +63,7 @@ extension AppSettings.UploadConfig {
             allowed.drop(while: { $0 == Character(".") }).caseInsensitiveCompare(pathExtension) == .orderedSame
         }
     }
-    
+
     private func isAllowed(mimeType: String) -> Bool {
         let isBlocked = blockedMimeTypes.contains { blocked in
             blocked.caseInsensitiveCompare(mimeType) == .orderedSame

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1505,19 +1505,19 @@ open class ComposerVC: _ViewController,
             return Components.default.maxAttachmentSize
         }
 
-        let maxAttachmentSize: Int64?
+        let maxAttachmentSize: Int
         switch attachmentType {
         case .image:
-            maxAttachmentSize = client.appSettings?.imageUploadConfig.sizeLimitInBytes
+            maxAttachmentSize = client.appSettings?.imageUploadConfig.sizeLimit ?? 0
         default:
-            maxAttachmentSize = client.appSettings?.fileUploadConfig.sizeLimitInBytes
+            maxAttachmentSize = client.appSettings?.fileUploadConfig.sizeLimit ?? 0
         }
 
-        guard let maxSize = maxAttachmentSize, maxSize > 0 else {
+        guard maxAttachmentSize > 0 else {
             return Components.default.maxAttachmentSize
         }
 
-        return maxSize
+        return Int64(maxAttachmentSize)
     }
 
     /// Shows an alert for the error thrown when adding attachment to a composer.

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -425,11 +425,13 @@ extension AppSettings {
         asyncUrlEnrichEnabled: Bool = false
     ) -> AppSettings {
         .init(
-            name: name,
-            fileUploadConfig: fileUploadConfig ?? .mock(),
-            imageUploadConfig: imageUploadConfig ?? .mock(),
+            asyncUrlEnrichEnabled: asyncUrlEnrichEnabled,
             autoTranslationEnabled: autoTranslationEnabled,
-            asyncUrlEnrichEnabled: asyncUrlEnrichEnabled
+            fileUploadConfig: fileUploadConfig ?? .mock(),
+            id: 1,
+            imageUploadConfig: imageUploadConfig ?? .mock(),
+            name: name,
+            placement: ""
         )
     }
 }
@@ -444,10 +446,10 @@ extension AppSettings.UploadConfig {
     ) -> AppSettings.UploadConfig {
         .init(
             allowedFileExtensions: allowedFileExtensions,
-            blockedFileExtensions: blockedFileExtensions,
             allowedMimeTypes: allowedMimeTypes,
+            blockedFileExtensions: blockedFileExtensions,
             blockedMimeTypes: blockedMimeTypes,
-            sizeLimitInBytes: sizeLimitInBytes
+            sizeLimit: sizeLimitInBytes.map(Int.init) ?? 0
         )
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1620](https://linear.app/stream/issue/IOS-1620/openapi-generation-in-llc)

### 🎯 Goal

Reuse the OpenAPI-generated model for the public API layer instead of maintaining a duplicated hand-written `AppSettings` model with a mapping layer.

### 📝 Summary

- Rename the generated `AppResponseFields` to `AppSettings` and `FileUploadConfig` to `UploadConfig`, and generate both as public via a new `publicize_model` post-processing step (the memberwise init and `CodingKeys` stay internal).
- Delete the hand-written `AppSettings` struct and its `asModel()` mappings; `ChatClient.loadAppSettings` now returns the generated model directly.
- Keep the public API source-compatible: the `AppSettings.UploadConfig` typealias and the existing UTI/URL validation helpers are preserved in `AppSettings+Extensions.swift`; `sizeLimitInBytes` is kept as a computed property and deprecated in favor of the generated `sizeLimit`.
- `AppSettings` is now a `final class` (previously a struct) and exposes new `id` and `placement` properties.

### 🧪 Manual Testing Notes

Connect a user and confirm attachment upload validation in the composer still respects the dashboard upload configuration (allowed/blocked file types and size limits fetched from `/api/v2/app`).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App and upload settings are now exposed more consistently in the SDK, making attachment-related configuration available to apps.
* **Bug Fixes**
  * Improved attachment size handling so limits are calculated more reliably from app settings.
  * Fixed app settings loading to use the returned app data directly, reducing mismatches in configuration.
* **Chores**
  * Updated generated SDK models and test mocks to match the latest settings structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->