### PR TITLE
[WIP] Convert channel and message models to reference types

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiableModel.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiableModel.swift
@@ -59,8 +59,8 @@ extension MemberDTO: IdentifiableModel {
 
 extension ChannelReadDTO: IdentifiableModel {
     static let className: DatabaseType = _className
-    static let idKeyPath: String? = nil
-    static func id(for model: NSManagedObject) -> DatabaseId? { nil } // Does not have id
+    static let idKeyPath: String? = #keyPath(ChannelReadDTO.id)
+    static func id(for model: NSManagedObject) -> DatabaseId? { (model as? Self)?.id }
 }
 
 extension ThreadDTO: IdentifiableModel {

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiablePayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiablePayload.swift
@@ -143,7 +143,13 @@ extension ChannelPayload: IdentifiablePayloadProxy {
         membership?.fillIds(cache: &cache)
         messages.fillIds(cache: &cache)
         pinnedMessages.fillIds(cache: &cache)
-        channelReads.fillIds(cache: &cache)
+        // A channel read's id is composed of the channel cid and the user id, so it can only be
+        // resolved here where the parent cid is known.
+        channelReads.forEach { read in
+            read.fillIds(cache: &cache)
+            let readId = ChannelReadDTO.createId(cid: channel.cid, userId: read.user.id)
+            cache[ChannelReadDTO.className, default: []].insert(readId)
+        }
     }
 }
 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiablePayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiablePayload.swift
@@ -140,7 +140,10 @@ extension ChannelPayload: IdentifiablePayloadProxy {
         addId(cache: &cache)
         channel.fillIds(cache: &cache)
         watchers?.fillIds(cache: &cache)
-        membership?.fillIds(cache: &cache)
+        // A member's id is composed of the channel cid and the user id, so it can only be
+        // resolved here where the parent cid is known.
+        members.forEach { $0.fillIds(cache: &cache, cid: channel.cid) }
+        membership?.fillIds(cache: &cache, cid: channel.cid)
         messages.fillIds(cache: &cache)
         pinnedMessages.fillIds(cache: &cache)
         // A channel read's id is composed of the channel cid and the user id, so it can only be
@@ -160,8 +163,10 @@ extension ChannelDetailPayload: IdentifiablePayload {
     func fillIds(cache: inout [DatabaseType: Set<DatabaseId>]) {
         addId(cache: &cache)
         createdBy?.fillIds(cache: &cache)
-        members?.fillIds(cache: &cache)
-        invitedMembers.fillIds(cache: &cache)
+        // A member's id is composed of the channel cid and the user id, so it can only be
+        // resolved here where the parent cid is known.
+        members?.forEach { $0.fillIds(cache: &cache, cid: cid) }
+        invitedMembers.forEach { $0.fillIds(cache: &cache, cid: cid) }
     }
 }
 
@@ -243,6 +248,12 @@ extension MemberPayload: IdentifiablePayload {
     func fillIds(cache: inout [DatabaseType: Set<DatabaseId>]) {
         addId(cache: &cache)
         user?.fillIds(cache: &cache)
+    }
+
+    /// Resolves the composed `MemberDTO` id using the parent channel's `cid` and adds it to the cache.
+    func fillIds(cache: inout [DatabaseType: Set<DatabaseId>], cid: ChannelId) {
+        fillIds(cache: &cache)
+        cache[MemberDTO.className, default: []].insert(MemberDTO.createId(userId: userId, channeldId: cid))
     }
 }
 

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -2072,7 +2072,8 @@ private extension ChatChannelController {
                 fetchRequest: ChannelDTO.fetchRequest(for: cid),
                 itemCreator: {
                     try $0.asModel() as ChatChannel
-                }
+                },
+                itemReuseKeyPaths: (\ChatChannel.cid.rawValue, \ChannelDTO.cid)
             ).onChange { [weak self] change in
                 self?.delegateCallback { [weak self] in
                     guard let self = self else {

--- a/Sources/StreamChat/Controllers/ChannelController/LivestreamChatHandler.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/LivestreamChatHandler.swift
@@ -360,18 +360,16 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
             members.removeAll(where: { $0.id == notificationRemovedFromChannelEvent.user.id })
             let memberCount = channel?.memberCount ?? 0
 
-            channel = channel?.changing(members: members, memberCount: memberCount - 1)
-            channel?.membership = nil
+            channel = channel?.changing(members: members, membership: .some(nil), memberCount: memberCount - 1)
 
         case let memberAddedEvent as MemberAddedEvent:
             var members = Set(channel?.lastActiveMembers ?? [])
             members.insert(memberAddedEvent.member)
             let memberCount = channel?.memberCount ?? 0
 
-            var membership: ChatChannelMember?
-            if memberAddedEvent.member.id == currentUserId {
-                membership = memberAddedEvent.member
-            }
+            let membership: ChatChannelMember?? = memberAddedEvent.member.id == currentUserId
+                ? .some(memberAddedEvent.member)
+                : nil
             channel = channel?.changing(
                 members: Array(members),
                 membership: membership,
@@ -383,12 +381,8 @@ final class LivestreamChatHandler: LivestreamChatHandling, DataStoreProvider, @u
             members.removeAll(where: { $0.id == memberRemovedEvent.user.id })
             let memberCount = channel?.memberCount ?? 0
 
-            var membership: ChatChannelMember? = channel?.membership
-            if memberRemovedEvent.user.id == currentUserId {
-                membership = nil
-            }
-            channel = channel?.changing(members: members, memberCount: memberCount - 1)
-            channel?.membership = membership
+            let membership: ChatChannelMember? = memberRemovedEvent.user.id == currentUserId ? nil : channel?.membership
+            channel = channel?.changing(members: members, membership: .some(membership), memberCount: memberCount - 1)
 
         case let userWatchingEvent as UserWatchingEvent:
             var watchers = channel?.lastActiveWatchers ?? []

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -600,7 +600,15 @@ extension CurrentChatUserController {
             _ fetchRequest: NSFetchRequest<CurrentUserDTO>,
             _ itemCreator: @escaping (CurrentUserDTO) throws -> CurrentChatUser,
             _ fetchedResultsControllerType: NSFetchedResultsController<CurrentUserDTO>.Type
-        ) -> BackgroundEntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> = BackgroundEntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> = {
+            BackgroundEntityDatabaseObserver(
+                database: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                itemReuseKeyPaths: (\CurrentChatUser.id, \CurrentUserDTO.user.id),
+                fetchedResultsControllerType: $3
+            )
+        }
 
         var currentUserActiveLiveLocationMessagesObserverBuilder: (
             _ database: DatabaseContainer,

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundEntityDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundEntityDatabaseObserver.swift
@@ -27,18 +27,22 @@ class BackgroundEntityDatabaseObserver<Item: Sendable, DTO: NSManagedObject>: Ba
     ///   - database: The `DatabaseContainer` the observer observes.
     ///   - fetchRequest: The `NSFetchRequest` that specifies the elements of the list.
     ///   - itemCreator: A closure the observer uses to convert DTO objects into Model objects.
+    ///   - itemReuseKeyPaths: A pair of keypaths used to reuse the item that `changeAggregator` already built for a change,
+    ///   instead of running `itemCreator` a second time when refreshing the cached snapshot.
     ///   - fetchedResultsControllerType: The `NSFetchedResultsController` subclass the observer uses to create its FRC. You can
     ///    inject your custom subclass if needed, i.e. when testing.
     init(
         database: DatabaseContainer,
         fetchRequest: NSFetchRequest<DTO>,
         itemCreator: @escaping (DTO) throws -> Item,
+        itemReuseKeyPaths: (item: KeyPath<Item, String>, dto: KeyPath<DTO, String>)? = nil,
         fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type = NSFetchedResultsController<DTO>.self
     ) {
         super.init(
             context: database.backgroundReadOnlyContext,
             fetchRequest: fetchRequest,
             itemCreator: itemCreator,
+            itemReuseKeyPaths: itemReuseKeyPaths,
             sorting: [],
             fetchedResultsControllerType: fetchedResultsControllerType
         )

--- a/Sources/StreamChat/Controllers/MemberController/MemberController.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController.swift
@@ -255,7 +255,15 @@ extension ChatChannelMemberController {
             _ fetchRequest: NSFetchRequest<MemberDTO>,
             _ itemCreator: @escaping (MemberDTO) throws -> ChatChannelMember,
             _ fetchedResultsControllerType: NSFetchedResultsController<MemberDTO>.Type
-        ) -> BackgroundEntityDatabaseObserver<ChatChannelMember, MemberDTO> = BackgroundEntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<ChatChannelMember, MemberDTO> = {
+            BackgroundEntityDatabaseObserver(
+                database: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                itemReuseKeyPaths: (\ChatChannelMember.id, \MemberDTO.id),
+                fetchedResultsControllerType: $3
+            )
+        }
     }
 }
 

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -1126,7 +1126,15 @@ extension ChatMessageController {
             _ fetchRequest: NSFetchRequest<MessageDTO>,
             _ itemCreator: @escaping (MessageDTO) throws -> ChatMessage,
             _ fetchedResultsControllerType: NSFetchedResultsController<MessageDTO>.Type
-        ) -> BackgroundEntityDatabaseObserver<ChatMessage, MessageDTO> = BackgroundEntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<ChatMessage, MessageDTO> = {
+            BackgroundEntityDatabaseObserver(
+                database: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                itemReuseKeyPaths: (\ChatMessage.id, \MessageDTO.id),
+                fetchedResultsControllerType: $3
+            )
+        }
 
         var repliesObserverBuilder: (
             _ database: DatabaseContainer,

--- a/Sources/StreamChat/Controllers/PollController/PollController.swift
+++ b/Sources/StreamChat/Controllers/PollController/PollController.swift
@@ -300,6 +300,7 @@ extension PollController {
                 database: $0,
                 fetchRequest: $1,
                 itemCreator: $2,
+                itemReuseKeyPaths: (\Poll.id, \PollDTO.id),
                 fetchedResultsControllerType: $3
             )
         }

--- a/Sources/StreamChat/Controllers/PollController/PollVoteListController.swift
+++ b/Sources/StreamChat/Controllers/PollController/PollVoteListController.swift
@@ -275,6 +275,7 @@ extension PollVoteListController {
                 database: $0,
                 fetchRequest: $1,
                 itemCreator: $2,
+                itemReuseKeyPaths: (\Poll.id, \PollDTO.id),
                 fetchedResultsControllerType: $3
             )
         }

--- a/Sources/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController.swift
@@ -224,7 +224,15 @@ extension ChatUserController {
             _ fetchRequest: NSFetchRequest<UserDTO>,
             _ itemCreator: @escaping (UserDTO) throws -> ChatUser,
             _ fetchedResultsControllerType: NSFetchedResultsController<UserDTO>.Type
-        ) -> BackgroundEntityDatabaseObserver<ChatUser, UserDTO> = BackgroundEntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<ChatUser, UserDTO> = {
+            BackgroundEntityDatabaseObserver(
+                database: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                itemReuseKeyPaths: (\ChatUser.id, \UserDTO.id),
+                fetchedResultsControllerType: $3
+            )
+        }
     }
 }
 

--- a/Sources/StreamChat/Controllers/UserGroupController/UserGroupController.swift
+++ b/Sources/StreamChat/Controllers/UserGroupController/UserGroupController.swift
@@ -189,7 +189,15 @@ extension UserGroupController {
             _ fetchRequest: NSFetchRequest<UserGroupDTO>,
             _ itemCreator: @escaping (UserGroupDTO) -> UserGroup,
             _ fetchedResultsControllerType: NSFetchedResultsController<UserGroupDTO>.Type
-        ) -> BackgroundEntityDatabaseObserver<UserGroup, UserGroupDTO> = BackgroundEntityDatabaseObserver.init
+        ) -> BackgroundEntityDatabaseObserver<UserGroup, UserGroupDTO> = {
+            BackgroundEntityDatabaseObserver(
+                database: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                itemReuseKeyPaths: (\UserGroup.id, \UserGroupDTO.id),
+                fetchedResultsControllerType: $3
+            )
+        }
     }
 }
 

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -586,16 +586,18 @@ extension ChatChannel {
         }()
 
         let latestMessages: [ChatMessage] = {
-            var messages = channelMessageDTOs
+            // channelMessageDTOs is sorted descending by createdAt, and both bounds below are
+            // simple thresholds, so the first message that fails one of them guarantees every
+            // following (older) message fails too — prefix(while:) can stop there instead of
+            // scanning the rest, and we never build a model we'd discard.
+            let lowerBound = max(
+                dto.oldestMessageAt?.bridgeDate ?? .distantPast,
+                dto.truncatedAt?.bridgeDate ?? .distantPast
+            )
+            return channelMessageDTOs
                 .prefix(clientConfig.localCaching.chatChannel.latestMessagesLimit)
+                .prefix(while: { $0.createdAt.bridgeDate >= lowerBound })
                 .compactMap { try? $0.relationshipAsModel(depth: depth) }
-            if let oldest = dto.oldestMessageAt?.bridgeDate {
-                messages = messages.filter { $0.createdAt >= oldest }
-            }
-            if let truncated = dto.truncatedAt?.bridgeDate {
-                messages = messages.filter { $0.createdAt >= truncated }
-            }
-            return messages
         }()
 
         let latestMessageFromUser: ChatMessage? = {

--- a/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
@@ -7,6 +7,10 @@ import Foundation
 
 @objc(ChannelReadDTO)
 class ChannelReadDTO: NSManagedObject {
+    /// A composed identifier (`channel cid` + `user id`) used to look up a read without a compound predicate.
+    ///
+    /// Optional because reads persisted before this attribute existed have no value until they are next saved.
+    @NSManaged private(set) var id: String?
     @NSManaged var lastReadAt: DBDate
     @NSManaged var lastReadMessageId: MessageId?
     @NSManaged var unreadMessageCount: Int32
@@ -17,6 +21,10 @@ class ChannelReadDTO: NSManagedObject {
 
     @NSManaged var channel: ChannelDTO
     @NSManaged var user: UserDTO
+
+    static func createId(cid: ChannelId, userId: String) -> String {
+        [cid.rawValue, userId].joined(separator: "/")
+    }
 
     override func willSave() {
         super.willSave()
@@ -53,18 +61,35 @@ class ChannelReadDTO: NSManagedObject {
         load(by: fetchRequest(for: cid, userId: userId), context: context).first
     }
 
+    static func load(id: String, context: NSManagedObjectContext) -> ChannelReadDTO? {
+        load(by: id, context: context).first as? Self
+    }
+
     static func loadOrCreate(
         cid: ChannelId,
         userId: String,
         context: NSManagedObjectContext,
         cache: PreWarmedCache?
     ) -> ChannelReadDTO {
-        let request = fetchRequest(for: cid, userId: userId)
-        if let existing = load(by: request, context: context).first {
+        let readId = createId(cid: cid, userId: userId)
+        if let cached = cache?.model(for: readId, context: context, type: ChannelReadDTO.self) {
+            return cached
+        }
+
+        if let existing = load(id: readId, context: context) {
             return existing
         }
 
+        // Fallback for reads persisted before the `id` attribute existed: look them up by the
+        // compound predicate and backfill the identifier so subsequent lookups can use the id.
+        if let legacy = load(cid: cid, userId: userId, context: context) {
+            legacy.id = readId
+            return legacy
+        }
+
+        let request = fetchRequest(id: readId)
         let new = NSEntityDescription.insertNewObject(into: context, for: request)
+        new.id = readId
         new.channel = ChannelDTO.loadOrCreate(cid: cid, context: context, cache: cache)
         new.user = UserDTO.loadOrCreate(id: userId, context: context, cache: cache)
         return new

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -35,7 +35,7 @@ class MemberDTO: NSManagedObject {
     @NSManaged var queries: Set<ChannelMemberListQueryDTO>
     @NSManaged var channel: ChannelDTO
 
-    private static func createId(userId: String, channeldId: ChannelId) -> String {
+    static func createId(userId: String, channeldId: ChannelId) -> String {
         channeldId.rawValue + userId
     }
 }
@@ -75,6 +75,22 @@ extension MemberDTO {
 
     static func load(memberId: String, context: NSManagedObjectContext) -> MemberDTO? {
         load(by: memberId, context: context).first as? Self
+    }
+
+    /// Batch-fetches existing `MemberDTO`s for the given `userId`s within a single channel, keyed by
+    /// their composed id. Used to pre-warm a cache and avoid one fetch per member during a batch save.
+    static func prewarmedIds(
+        forUserIds userIds: [String],
+        channelId: ChannelId,
+        context: NSManagedObjectContext
+    ) -> [DatabaseId: NSManagedObjectID] {
+        guard !userIds.isEmpty else { return [:] }
+        let ids = userIds.map { createId(userId: $0, channeldId: channelId) }
+        let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
+        request.predicate = NSPredicate(format: "id IN %@", ids)
+        var mapping: [DatabaseId: NSManagedObjectID] = [:]
+        load(by: request, context: context).forEach { mapping[$0.id] = $0.objectID }
+        return mapping
     }
 
     /// If a User with the given id exists in the context, fetches and returns it. Otherwise create a new
@@ -166,7 +182,14 @@ extension NSManagedObjectContext {
             queryDTO?.members = []
         }
 
-        let cache = payload.getPayloadToModelIdMappings(context: self)
+        var cache = payload.getPayloadToModelIdMappings(context: self)
+        // `ChannelMemberListPayload` doesn't carry the channel id, so the composed `MemberDTO` id
+        // cannot be resolved by the generic payload-id mechanism. Pre-warm it here instead.
+        cache[MemberDTO.className] = MemberDTO.prewarmedIds(
+            forUserIds: payload.members.map(\.userId),
+            channelId: channelId,
+            context: self
+        )
         return payload.members.compactMapLoggingError {
             try saveMember(payload: $0, channelId: channelId, query: query, cache: cache)
         }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -1586,13 +1586,13 @@ extension MessageDTO {
 
 extension MessageDTO {
     /// Snapshots the current state of `MessageDTO` and returns an immutable model object from it.
-    func asModel() throws -> ChatMessage { try .init(fromDTO: self, depth: 0) }
+    func asModel() throws -> ChatMessage { try .create(fromDTO: self, depth: 0) }
 
     /// Snapshots the current state of `MessageDTO` and returns an immutable model object from it if the dependency depth
     /// limit has not been reached
     func relationshipAsModel(depth: Int) throws -> ChatMessage? {
         do {
-            return try ChatMessage(fromDTO: self, depth: depth + 1)
+            return try ChatMessage.create(fromDTO: self, depth: depth + 1)
         } catch {
             if error is RecursionLimitError { return nil }
             throw error
@@ -1706,7 +1706,7 @@ extension MessageDTO {
 
 private extension ChatMessage {
     // swiftlint:disable function_body_length
-    init(fromDTO dto: MessageDTO, depth: Int) throws {
+    static func create(fromDTO dto: MessageDTO, depth: Int) throws -> ChatMessage {
         guard StreamRuntimeCheck._canFetchRelationship(currentDepth: depth) else {
             throw RecursionLimitError()
         }
@@ -1815,7 +1815,7 @@ private extension ChatMessage {
             return dto.replies
                 .sorted(by: { $0.createdAt.bridgeDate > $1.createdAt.bridgeDate })
                 .prefix(5)
-                .compactMap { try? ChatMessage(fromDTO: $0, depth: depth) }
+                .compactMap { try? ChatMessage.create(fromDTO: $0, depth: depth) }
         }()
 
         let quotedMessage = try? dto.quotedMessage?.relationshipAsModel(depth: depth)
@@ -1884,11 +1884,10 @@ private extension ChatMessage {
         )
 
         if let transformer = chatClientConfig?.modelsTransformer {
-            self = transformer.transform(message: message)
-            return
+            return transformer.transform(message: message)
         }
 
-        self = message
+        return message
     }
 
     // swiftlint:enable function_body_length

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -7,12 +7,14 @@ import CoreData
 extension NSManagedObjectContext: DatabaseSession {
     private static let chatClientConfigKey = "io.getStream.StreamChat.config.key"
 
+    /// `chatClientConfig` is written once right after the context is created (see `setChatClientConfig`),
+    /// before the context is ever handed out, and is never mutated afterwards. Every read of it happens
+    /// from code that is already executing on this context's queue (e.g. DTO -> model conversion), so
+    /// wrapping the read in `performAndWait` only adds a redundant queue-confinement check. This getter
+    /// is called very frequently (once per model created while decoding a channel/message/member), so
+    /// avoiding that overhead matters.
     var chatClientConfig: ChatClientConfig? {
-        nonisolated(unsafe) var config: ChatClientConfig?
-        performAndWait {
-            config = userInfo[Self.chatClientConfigKey] as? ChatClientConfig
-        }
-        return config
+        userInfo[Self.chatClientConfigKey] as? ChatClientConfig
     }
 
     func setChatClientConfig(_ config: ChatClientConfig) {

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -149,6 +149,7 @@
         <relationship name="currentUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="channelMutes" inverseEntity="CurrentUserDTO"/>
     </entity>
     <entity name="ChannelReadDTO" representedClassName="ChannelReadDTO" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="lastDeliveredAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastDeliveredMessageId" optional="YES" attributeType="String"/>
         <attribute name="lastReadAt" attributeType="Date" defaultDateTimeInterval="0" usesScalarValueType="NO"/>
@@ -157,6 +158,9 @@
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="reads" inverseEntity="ChannelDTO"/>
         <relationship name="readMessagesFromCurrentUser" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="reads" inverseEntity="MessageDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelReads" inverseEntity="UserDTO"/>
+        <fetchIndex name="id">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="CommandDTO" representedClassName="CommandDTO" syncable="YES">
         <attribute name="args" attributeType="String" defaultValueString=""/>

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A type representing a chat channel. `ChatChannel` is an immutable snapshot of a channel entity at the given time.
 ///
-public struct ChatChannel: Sendable {
+public final class ChatChannel: @unchecked Sendable {
     /// The `ChannelId` of the channel.
     public let cid: ChannelId
 
@@ -84,7 +84,7 @@ public struct ChatChannel: Sendable {
     public let currentlyTypingUsers: Set<ChatUser>
 
     /// If the current user is a member of the channel, this variable contains the details about the membership.
-    public internal(set) var membership: ChatChannelMember?
+    public let membership: ChatChannelMember?
 
     /// Returns `true`, if the channel is archived.
     public var isArchived: Bool {
@@ -317,7 +317,7 @@ public struct ChatChannel: Sendable {
         isBlocked: Bool? = nil,
         reads: [ChatChannelRead]? = nil,
         members: [ChatChannelMember]? = nil,
-        membership: ChatChannelMember? = nil,
+        membership: ChatChannelMember?? = nil,
         memberCount: Int? = nil,
         watchers: [ChatUser]? = nil,
         watcherCount: Int? = nil,

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -9,7 +9,7 @@ import Foundation
 public typealias MessageId = String
 
 /// A type representing a chat message. `ChatMessage` is an immutable snapshot of a chat message entity at the given time.
-public struct ChatMessage: Identifiable, Sendable {
+public final class ChatMessage: Identifiable, @unchecked Sendable {
     /// A unique identifier of the message.
     public let id: MessageId
 
@@ -623,11 +623,11 @@ public extension ChatMessage {
 }
 
 extension ChatMessage: Hashable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: ChatMessage, rhs: ChatMessage) -> Bool {
         lhs.hasEqualContent(to: rhs) && lhs.hasEqualMetadata(to: rhs)
     }
 
-    private func hasEqualContent(to other: Self) -> Bool {
+    private func hasEqualContent(to other: ChatMessage) -> Bool {
         guard id == other.id else { return false }
         guard localState == other.localState else { return false }
         guard updatedAt == other.updatedAt else { return false }
@@ -648,7 +648,7 @@ extension ChatMessage: Hashable {
         return true
     }
 
-    private func hasEqualMetadata(to other: Self) -> Bool {
+    private func hasEqualMetadata(to other: ChatMessage) -> Bool {
         guard threadParticipantsCount == other.threadParticipantsCount else { return false }
         guard arguments == other.arguments else { return false }
         guard command == other.command else { return false }

--- a/Sources/StreamChat/Models/DraftMessage.swift
+++ b/Sources/StreamChat/Models/DraftMessage.swift
@@ -122,53 +122,51 @@ extension DraftMessage: Equatable {
 extension ChatMessage {
     /// Converts the draft message to a regular message so that it
     /// can be easily used in existing UI components.
-    public init(_ draft: DraftMessage) {
-        id = draft.id
-        cid = draft.cid
-        text = draft.text
-        type = .regular
-        command = draft.command
-        createdAt = draft.createdAt
-        locallyCreatedAt = draft.createdAt
-        updatedAt = draft.createdAt
-        deletedAt = nil
-        arguments = draft.arguments
-        parentMessageId = draft.threadId
-        showReplyInChannel = draft.showReplyInChannel
-        replyCount = 0
-        extraData = draft.extraData
-        _quotedMessage = BoxedAny(draft.quotedMessage)
-        isBounced = false
-        isSilent = false
-        isShadowed = false
-        reactionScores = [:]
-        reactionCounts = [:]
-        reactionGroups = [:]
-        author = draft.currentUser
-        mentionedUsers = draft.mentionedUsers
-        mentionedHere = false
-        mentionedChannel = false
-        mentionedGroups = []
-        mentionedRoles = []
-        threadParticipants = []
-        _attachments = draft.attachments
-        latestReplies = []
-        localState = nil
-        isFlaggedByCurrentUser = false
-        latestReactions = []
-        currentUserReactions = []
-        isSentByCurrentUser = true
-        pinDetails = nil
-        translations = nil
-        originalLanguage = nil
-        moderationDetails = nil
-        readBy = []
-        poll = nil
-        textUpdatedAt = nil
-        draftReply = nil
-        reminder = nil
-        sharedLocation = nil
-        channelRole = nil
-        deletedForMe = false
+    public convenience init(_ draft: DraftMessage) {
+        self.init(
+            id: draft.id,
+            cid: draft.cid,
+            text: draft.text,
+            type: .regular,
+            command: draft.command,
+            createdAt: draft.createdAt,
+            locallyCreatedAt: draft.createdAt,
+            updatedAt: draft.createdAt,
+            deletedAt: nil,
+            arguments: draft.arguments,
+            parentMessageId: draft.threadId,
+            showReplyInChannel: draft.showReplyInChannel,
+            replyCount: 0,
+            extraData: draft.extraData,
+            quotedMessage: draft.quotedMessage,
+            isBounced: false,
+            isSilent: false,
+            isShadowed: false,
+            deletedForMe: false,
+            reactionScores: [:],
+            reactionCounts: [:],
+            reactionGroups: [:],
+            author: draft.currentUser,
+            mentionedUsers: draft.mentionedUsers,
+            threadParticipants: [],
+            attachments: draft.attachments,
+            latestReplies: [],
+            localState: nil,
+            isFlaggedByCurrentUser: false,
+            latestReactions: [],
+            currentUserReactions: [],
+            isSentByCurrentUser: true,
+            pinDetails: nil,
+            translations: nil,
+            originalLanguage: nil,
+            moderationDetails: nil,
+            readBy: [],
+            poll: nil,
+            textUpdatedAt: nil,
+            draftReply: nil,
+            reminder: nil,
+            sharedLocation: nil,
+            channelRole: nil
+        )
     }
 }

--- a/Sources/StreamChat/Utils/Codable+Extensions.swift
+++ b/Sources/StreamChat/Utils/Codable+Extensions.swift
@@ -6,10 +6,18 @@ import Foundation
 
 // MARK: - JSONDecoder Stream
 
+/// The bytes `JSONEncoder` produces for an empty `[String: RawJSON]` dictionary. Extra data is re-encoded with
+/// this encoder before being persisted, so this is the exact (and by far the most common) representation of
+/// "no custom fields" stored on disk.
+private let emptyRawJSONObjectData = Data("{}".utf8)
+
 extension JSONDecoder {
     /// A convenience method returning RawJSON dictionary.
     func decodeRawJSON(from data: Data?) throws -> [String: RawJSON] {
         guard let data, !data.isEmpty else { return [:] }
+        // Avoid paying for a full `Decodable` pass (container allocation, key iteration, etc.) for the
+        // overwhelmingly common case where an entity simply has no custom fields.
+        if data == emptyRawJSONObjectData { return [:] }
         let rawJSON = try decode([String: RawJSON].self, from: data)
         return rawJSON
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -822,6 +822,7 @@
 				StreamChatTests/Audio/StreamAudioWaveformAnalyser_Tests.swift,
 				StreamChatTests/Audio/StreamPlayerObserver_Tests.swift,
 				"StreamChatTests/Audio/StreamΑudioRecorderMeterNormaliser_Tests.swift",
+				StreamChatTests/BackgroundEntityDatabaseObserver_Tests.swift,
 				StreamChatTests/BackgroundListDatabaseObserver_Tests.swift,
 				StreamChatTests/ChatClient_Tests.swift,
 				StreamChatTests/ChatClientFactory_Tests.swift,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -987,6 +987,7 @@
 				StreamChatTests/StreamChatTests.swift,
 				StreamChatTests/TestsEnvironmentSetup.swift,
 				StreamChatTests/Utils/ArraySampling_Tests.swift,
+				"StreamChatTests/Utils/Codable+Extensions_Tests.swift",
 				StreamChatTests/Utils/CooldownTracker_Tests.swift,
 				StreamChatTests/Utils/Database/NSManagedObject_Tests.swift,
 				StreamChatTests/Utils/Debouncer_Tests.swift,

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiableModel_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiableModel_Tests.swift
@@ -99,7 +99,8 @@ final class IdentifiableModel_Tests: XCTestCase {
         let dto = type.init(context: database.viewContext)
 
         XCTAssertEqual(type.className, "ChannelReadDTO")
-        XCTAssertNil(type.idKeyPath)
+        XCTAssertEqual(type.idKeyPath, "id")
+        // A freshly-inserted read has no composed id assigned yet.
         XCTAssertNil(type.id(for: dto))
 
         XCTAssertNil(type.id(for: deviceDTO))

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiablePayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiablePayload_Tests.swift
@@ -98,11 +98,12 @@ final class IdentifiablePayload_Tests: XCTestCase {
         }
         
         for cache in caches {
-            XCTAssertEqual(cache.keys.count, 4)
+            XCTAssertEqual(cache.keys.count, 5)
             XCTAssertEqual(cache["\(ChannelDTO.self)"]?.count, 5)
             XCTAssertEqual(cache["\(MessageDTO.self)"]?.count, 50)
             XCTAssertEqual(cache["\(UserDTO.self)"]?.count, 7)
             XCTAssertEqual(cache["\(MessageReactionDTO.self)"]?.count, 200)
+            XCTAssertEqual(cache["\(ChannelReadDTO.self)"]?.count, 10)
         }
     }
 

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiablePayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/IdentifiablePayload_Tests.swift
@@ -51,11 +51,12 @@ final class IdentifiablePayload_Tests: XCTestCase {
             cache = channelList.recursivelyGetAllIds()
         }
 
-        XCTAssertEqual(cache.keys.count, 4)
+        XCTAssertEqual(cache.keys.count, 5)
         XCTAssertEqual(cache["\(ChannelDTO.self)"]?.count, 25)
         XCTAssertEqual(cache["\(MessageDTO.self)"]?.count, 500)
         XCTAssertEqual(cache["\(UserDTO.self)"]?.count, 50)
         XCTAssertEqual(cache["\(MessageReactionDTO.self)"]?.count, 1000)
+        XCTAssertEqual(cache["\(MemberDTO.self)"]?.count, 625)
     }
 
     func test_measureBigPayload_getPayloadToModelIdMappings() {
@@ -68,11 +69,12 @@ final class IdentifiablePayload_Tests: XCTestCase {
             cache = channelList.getPayloadToModelIdMappings(context: database.viewContext)
         }
 
-        XCTAssertEqual(cache.keys.count, 4)
+        XCTAssertEqual(cache.keys.count, 5)
         XCTAssertEqual(cache["\(ChannelDTO.self)"]?.count, 25)
         XCTAssertEqual(cache["\(MessageDTO.self)"]?.count, 500)
         XCTAssertEqual(cache["\(UserDTO.self)"]?.count, 50)
         XCTAssertEqual(cache["\(MessageReactionDTO.self)"]?.count, 1000)
+        XCTAssertEqual(cache["\(MemberDTO.self)"]?.count, 625)
     }
     
     func test_concurrentPerform_getPayloadToModelIdMappings() {
@@ -98,12 +100,13 @@ final class IdentifiablePayload_Tests: XCTestCase {
         }
         
         for cache in caches {
-            XCTAssertEqual(cache.keys.count, 5)
+            XCTAssertEqual(cache.keys.count, 6)
             XCTAssertEqual(cache["\(ChannelDTO.self)"]?.count, 5)
             XCTAssertEqual(cache["\(MessageDTO.self)"]?.count, 50)
             XCTAssertEqual(cache["\(UserDTO.self)"]?.count, 7)
             XCTAssertEqual(cache["\(MessageReactionDTO.self)"]?.count, 200)
             XCTAssertEqual(cache["\(ChannelReadDTO.self)"]?.count, 10)
+            XCTAssertEqual(cache["\(MemberDTO.self)"]?.count, 25)
         }
     }
 
@@ -277,7 +280,7 @@ final class IdentifiablePayload_Tests: XCTestCase {
         let userIds = try XCTUnwrap(cache[UserDTO.className])
         let reactionIds = try XCTUnwrap(cache[MessageReactionDTO.className])
 
-        XCTAssertEqual(cache.keys.count, 4)
+        XCTAssertEqual(cache.keys.count, 5)
         // Channels
         XCTAssertEqual(channelIds, ["messaging:channel-0", "messaging:channel-1", "messaging:channel-2", "messaging:channel-3"])
         // Messages
@@ -309,6 +312,14 @@ final class IdentifiablePayload_Tests: XCTestCase {
             }
         }
         XCTAssertEqual(reactionIds, Set(expectedReactionIds))
+        // Members
+        let memberIds = try XCTUnwrap(cache[MemberDTO.className])
+        let expectedMemberIds = (0..<channelsCount).flatMap { channelId in
+            (0..<userCount).map {
+                MemberDTO.createId(userId: "user-\($0)", channeldId: ChannelId(type: .messaging, id: "channel-\(channelId)"))
+            }
+        }
+        XCTAssertEqual(memberIds, Set(expectedMemberIds))
     }
 
     func createChannelList(

--- a/Tests/StreamChatTests/BackgroundEntityDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/BackgroundEntityDatabaseObserver_Tests.swift
@@ -1,0 +1,142 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class BackgroundEntityDatabaseObserver_Tests: XCTestCase {
+    private struct TestItem: Equatable {
+        let id: String
+        let value: String?
+    }
+
+    var fetchRequest: NSFetchRequest<TestManagedObject>!
+    var database: DatabaseContainer!
+
+    override func setUp() {
+        super.setUp()
+
+        fetchRequest = NSFetchRequest(entityName: "TestManagedObject")
+        fetchRequest.sortDescriptors = [.init(key: "testId", ascending: true)]
+        database = DatabaseContainer_Spy(
+            kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
+            modelName: "TestDataModel",
+            bundle: .testTools
+        )
+    }
+
+    override func tearDown() {
+        fetchRequest = nil
+        database = nil
+        super.tearDown()
+    }
+
+    func test_item_returnsFirstFetchedItem() throws {
+        try insertTestObject(id: "1", value: "value1")
+
+        let observer = BackgroundEntityDatabaseObserver<TestItem, TestManagedObject>(
+            database: database,
+            fetchRequest: fetchRequest,
+            itemCreator: { TestItem(id: $0.testId, value: $0.testValue) }
+        )
+        try observer.startObserving()
+
+        XCTAssertEqual(observer.item, TestItem(id: "1", value: "value1"))
+    }
+
+    /// Without `itemReuseKeyPaths`, the observer has no way of knowing an item produced while aggregating an FRC
+    /// change can be reused, so it asks `itemCreator` to rebuild it a second time when refreshing its cached snapshot.
+    func test_withoutItemReuseKeyPaths_itemCreatorIsInvokedTwicePerChange() throws {
+        try insertTestObject(id: "1", value: "initial")
+
+        nonisolated(unsafe) var itemCreatorCallCount = 0
+        let observer = BackgroundEntityDatabaseObserver<TestItem, TestManagedObject>(
+            database: database,
+            fetchRequest: fetchRequest,
+            itemCreator: {
+                itemCreatorCallCount += 1
+                return TestItem(id: $0.testId, value: $0.testValue)
+            }
+        )
+
+        try waitForChange(on: observer) {
+            try observer.startObserving()
+        }
+        // The initial fetch builds the item once.
+        XCTAssertEqual(itemCreatorCallCount, 1)
+
+        try waitForChange(on: observer) {
+            try self.updateTestObject(id: "1", value: "updated")
+        }
+        // The change aggregator builds the item once to report the change, and `updateItems` rebuilds it a
+        // second time because there's no key path to look it up and reuse it from that change.
+        XCTAssertEqual(itemCreatorCallCount, 3)
+    }
+
+    /// With `itemReuseKeyPaths` set, the item already produced for a reported change is reused when the observer
+    /// refreshes its cached snapshot, instead of running `itemCreator` a second time for the same DTO.
+    func test_withItemReuseKeyPaths_itemCreatorIsInvokedOncePerChange() throws {
+        try insertTestObject(id: "1", value: "initial")
+
+        nonisolated(unsafe) var itemCreatorCallCount = 0
+        let observer = BackgroundEntityDatabaseObserver<TestItem, TestManagedObject>(
+            database: database,
+            fetchRequest: fetchRequest,
+            itemCreator: {
+                itemCreatorCallCount += 1
+                return TestItem(id: $0.testId, value: $0.testValue)
+            },
+            itemReuseKeyPaths: (\TestItem.id, \TestManagedObject.testId)
+        )
+
+        try waitForChange(on: observer) {
+            try observer.startObserving()
+        }
+        // The initial fetch builds the item once.
+        XCTAssertEqual(itemCreatorCallCount, 1)
+
+        try waitForChange(on: observer) {
+            try self.updateTestObject(id: "1", value: "updated")
+        }
+        // Only the change aggregator builds the item; `updateItems` reuses it instead of rebuilding it.
+        XCTAssertEqual(itemCreatorCallCount, 2)
+        XCTAssertEqual(observer.item, TestItem(id: "1", value: "updated"))
+    }
+
+    // MARK: -
+
+    private func insertTestObject(id: String, value: String) throws {
+        try database.writeSynchronously { session in
+            let context = try XCTUnwrap(session as? NSManagedObjectContext)
+            let item = try XCTUnwrap(NSEntityDescription.insertNewObject(forEntityName: "TestManagedObject", into: context) as? TestManagedObject)
+            item.testId = id
+            item.testValue = value
+        }
+    }
+
+    private func updateTestObject(id: String, value: String) throws {
+        try database.writeSynchronously { session in
+            let context = try XCTUnwrap(session as? NSManagedObjectContext)
+            let request = NSFetchRequest<TestManagedObject>(entityName: "TestManagedObject")
+            request.predicate = NSPredicate(format: "testId == %@", id)
+            let item = try XCTUnwrap(context.fetch(request).first)
+            item.testValue = value
+        }
+    }
+
+    /// Waits for exactly one `onDidChange` callback triggered by running `action`.
+    private func waitForChange(
+        on observer: BackgroundEntityDatabaseObserver<TestItem, TestManagedObject>,
+        perform action: () throws -> Void
+    ) throws {
+        let changeExpectation = expectation(description: "onDidChange is called")
+        observer.onDidChange = { _ in changeExpectation.fulfill() }
+
+        try action()
+
+        waitForExpectations(timeout: defaultTimeout)
+    }
+}

--- a/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
@@ -842,6 +842,152 @@ final class ChannelReadDTO_Tests: XCTestCase {
         ChannelReadDTO.load(cid: cid, userId: userId, context: database.viewContext)
     }
 
+    // MARK: - Composed identifier & pre-warming
+
+    func test_createId_composesCidAndUserId() {
+        let cid = ChannelId(type: .messaging, id: "the-channel")
+        let userId = "the-user"
+
+        let id = ChannelReadDTO.createId(cid: cid, userId: userId)
+
+        XCTAssertEqual(id, "messaging:the-channel/the-user")
+    }
+
+    func test_recursivelyGetAllIds_includesComposedChannelReadId() {
+        // GIVEN
+        let cid = ChannelId.unique
+        let read = ChannelReadPayload(
+            user: .dummy(userId: .unique),
+            lastReadAt: .unique,
+            lastReadMessageId: .unique,
+            unreadMessagesCount: 3
+        )
+        let channel: ChannelPayload = .dummy(channel: .dummy(cid: cid), channelReads: [read])
+
+        // WHEN
+        let ids = channel.recursivelyGetAllIds()
+
+        // THEN
+        let expectedReadId = ChannelReadDTO.createId(cid: cid, userId: read.user.id)
+        XCTAssertEqual(ids[ChannelReadDTO.className]?.contains(expectedReadId), true)
+    }
+
+    func test_loadOrCreate_assignsComposedId() throws {
+        // GIVEN a persisted channel with a member but no read yet.
+        let cid = ChannelId.unique
+        let member: MemberPayload = .dummy()
+        let channel: ChannelPayload = .dummy(channel: .dummy(cid: cid), members: [member], channelReads: [])
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+
+        // WHEN
+        try database.writeSynchronously { session in
+            let context = session as! NSManagedObjectContext
+            _ = ChannelReadDTO.loadOrCreate(cid: cid, userId: member.userId, context: context, cache: nil)
+        }
+
+        // THEN
+        let readDTO = try XCTUnwrap(readDTO(cid: cid, userId: member.userId))
+        XCTAssertEqual(readDTO.id, ChannelReadDTO.createId(cid: cid, userId: member.userId))
+    }
+
+    func test_loadOrCreate_usesPrewarmedCache() throws {
+        // GIVEN
+        let cid = ChannelId.unique
+        let read = ChannelReadPayload(
+            user: .dummy(userId: .unique),
+            lastReadAt: .unique,
+            lastReadMessageId: .unique,
+            unreadMessagesCount: 4
+        )
+        let channel: ChannelPayload = .dummy(
+            channel: .dummy(cid: cid),
+            members: [.dummy(user: read.user)],
+            channelReads: [read]
+        )
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+
+        // WHEN
+        let readId = ChannelReadDTO.createId(cid: cid, userId: read.user.id)
+        let cache = channel.getPayloadToModelIdMappings(context: database.viewContext)
+        let cachedRead = cache.model(for: readId, context: database.viewContext, type: ChannelReadDTO.self)
+
+        // THEN
+        XCTAssertEqual(cachedRead?.id, readId)
+        XCTAssertEqual(cachedRead?.user.id, read.user.id)
+    }
+
+    func test_loadOrCreate_whenLegacyReadWithoutId_backfillsIdAndReusesDTO() throws {
+        // GIVEN a read persisted before the `id` attribute existed (id is nil).
+        let cid = ChannelId.unique
+        let read = ChannelReadPayload(
+            user: .dummy(userId: .unique),
+            lastReadAt: .unique,
+            lastReadMessageId: .unique,
+            unreadMessagesCount: 6
+        )
+        let channel: ChannelPayload = .dummy(
+            channel: .dummy(cid: cid),
+            members: [.dummy(user: read.user)],
+            channelReads: [read]
+        )
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+        try database.writeSynchronously { session in
+            let context = session as! NSManagedObjectContext
+            let legacy = try XCTUnwrap(ChannelReadDTO.load(cid: cid, userId: read.user.id, context: context))
+            legacy.setValue(nil, forKey: "id")
+        }
+        XCTAssertNil(readDTO(cid: cid, userId: read.user.id)?.id)
+
+        // WHEN loading or creating the same read again.
+        try database.writeSynchronously { session in
+            let context = session as! NSManagedObjectContext
+            _ = ChannelReadDTO.loadOrCreate(cid: cid, userId: read.user.id, context: context, cache: nil)
+        }
+
+        // THEN the legacy DTO is reused (not duplicated) and its id is backfilled.
+        XCTAssertEqual(reads(cid: cid).count, 1)
+        XCTAssertEqual(readDTO(cid: cid, userId: read.user.id)?.id, ChannelReadDTO.createId(cid: cid, userId: read.user.id))
+    }
+
+    func test_saveChannel_savedTwice_doesNotDuplicateReads() throws {
+        // GIVEN
+        let cid = ChannelId.unique
+        let read = ChannelReadPayload(
+            user: .dummy(userId: .unique),
+            lastReadAt: .unique,
+            lastReadMessageId: .unique,
+            unreadMessagesCount: 2
+        )
+        let channel: ChannelPayload = .dummy(
+            channel: .dummy(cid: cid),
+            members: [.dummy(user: read.user)],
+            channelReads: [read]
+        )
+
+        // WHEN saving the same channel payload twice.
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+
+        // THEN only a single read exists for the channel.
+        XCTAssertEqual(reads(cid: cid).count, 1)
+    }
+
+    private func reads(cid: ChannelId) -> [ChannelReadDTO] {
+        let request = NSFetchRequest<ChannelReadDTO>(entityName: ChannelReadDTO.entityName)
+        request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
+        return (try? database.viewContext.fetch(request)) ?? []
+    }
+
     // MARK: - loadOrCreateChannelRead
 
     func test_loadOrCreateChannelRead_channelReadExists_returnsExpectedResult() throws {

--- a/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 @testable import StreamChat
 @testable import StreamChatTestTools
 import XCTest
@@ -227,6 +228,84 @@ final class MemberModelDTO_Tests: XCTestCase {
         
         // THEN
         XCTAssertEqual(member.name, "transformed member")
+    }
+
+    // MARK: - Composed identifier & pre-warming
+
+    func test_recursivelyGetAllIds_includesComposedMemberId() {
+        // GIVEN
+        let cid = ChannelId.unique
+        let member: MemberPayload = .dummy()
+        let channel: ChannelPayload = .dummy(channel: .dummy(cid: cid), members: [member], membership: nil)
+
+        // WHEN
+        let ids = channel.recursivelyGetAllIds()
+
+        // THEN
+        let expectedMemberId = MemberDTO.createId(userId: member.userId, channeldId: cid)
+        XCTAssertEqual(ids[MemberDTO.className]?.contains(expectedMemberId), true)
+    }
+
+    func test_saveChannel_usesPrewarmedCacheForMembers() throws {
+        // GIVEN a persisted channel with a member.
+        let cid = ChannelId.unique
+        let member: MemberPayload = .dummy()
+        let channel: ChannelPayload = .dummy(channel: .dummy(cid: cid), members: [member], membership: nil)
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+
+        // WHEN
+        let memberId = MemberDTO.createId(userId: member.userId, channeldId: cid)
+        let cache = channel.getPayloadToModelIdMappings(context: database.viewContext)
+        let cachedMember = cache.model(for: memberId, context: database.viewContext, type: MemberDTO.self)
+
+        // THEN
+        XCTAssertEqual(cachedMember?.id, memberId)
+        XCTAssertEqual(cachedMember?.user.id, member.userId)
+    }
+
+    func test_prewarmedIds_returnsMappingForExistingMembersOnly() throws {
+        // GIVEN a persisted member and a user id that has no member yet.
+        let cid = ChannelId.unique
+        let existingMember: MemberPayload = .dummy()
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: .dummy(channel: .dummy(cid: cid), members: [existingMember], membership: nil))
+        }
+
+        // WHEN
+        let mapping = MemberDTO.prewarmedIds(
+            forUserIds: [existingMember.userId, "missing-user"],
+            channelId: cid,
+            context: database.viewContext
+        )
+
+        // THEN
+        XCTAssertEqual(mapping.count, 1)
+        XCTAssertEqual(mapping.keys.first, MemberDTO.createId(userId: existingMember.userId, channeldId: cid))
+    }
+
+    func test_saveMembers_savedTwice_doesNotDuplicateMembers() throws {
+        // GIVEN
+        let cid = ChannelId.unique
+        let members: ChannelMemberListPayload = .init(members: [.dummy(), .dummy()])
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: cid, members: [], includeMembership: false))
+        }
+
+        // WHEN saving the same member list payload twice.
+        try database.writeSynchronously { session in
+            _ = session.saveMembers(payload: members, channelId: cid, query: nil)
+        }
+        try database.writeSynchronously { session in
+            _ = session.saveMembers(payload: members, channelId: cid, query: nil)
+        }
+
+        // THEN only two members exist for the channel (no duplicates created).
+        let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
+        request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
+        let savedMembers = try database.viewContext.fetch(request)
+        XCTAssertEqual(savedMembers.count, 2)
     }
 
     private func saveDummyMembers(

--- a/Tests/StreamChatTests/Utils/Codable+Extensions_Tests.swift
+++ b/Tests/StreamChatTests/Utils/Codable+Extensions_Tests.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class Codable_Extensions_Tests: XCTestCase {
+    func test_decodeRawJSON_whenDataIsNil_returnsEmptyDictionary() throws {
+        let result = try JSONDecoder.stream.decodeRawJSON(from: nil)
+        XCTAssertEqual(result, [:])
+    }
+
+    func test_decodeRawJSON_whenDataIsEmpty_returnsEmptyDictionary() throws {
+        let result = try JSONDecoder.stream.decodeRawJSON(from: Data())
+        XCTAssertEqual(result, [:])
+    }
+
+    /// This is the exact byte sequence `JSONEncoder` produces for an empty `[String: RawJSON]`, and the one
+    /// persisted for entities with no custom fields. It should take the fast path instead of a full decode.
+    func test_decodeRawJSON_whenDataIsEmptyJSONObject_returnsEmptyDictionaryWithoutDecoding() throws {
+        let data = Data("{}".utf8)
+        let result = try JSONDecoder.stream.decodeRawJSON(from: data)
+        XCTAssertEqual(result, [:])
+    }
+
+    func test_decodeRawJSON_whenDataHasFields_decodesThem() throws {
+        let data = Data(#"{"is_moderator":true,"nickname":"scrappy"}"#.utf8)
+        let result = try JSONDecoder.stream.decodeRawJSON(from: data)
+        XCTAssertEqual(result, [
+            "is_moderator": .bool(true),
+            "nickname": .string("scrappy")
+        ])
+    }
+
+    func test_decodeRawJSON_whenDataIsInvalidJSON_throws() {
+        let data = Data("not json".utf8)
+        XCTAssertThrowsError(try JSONDecoder.stream.decodeRawJSON(from: data))
+    }
+
+    /// Round-trips through the encoder actually used to persist extra data, to guard the fast path's assumption
+    /// that an empty dictionary is always encoded as the literal `{}` bytes.
+    func test_decodeRawJSON_roundTripsWithEncoderUsedForPersistedExtraData() throws {
+        let encoded = try JSONEncoder.default.encode([String: RawJSON]())
+        XCTAssertEqual(encoded, Data("{}".utf8))
+
+        let result = try JSONDecoder.stream.decodeRawJSON(from: encoded)
+        XCTAssertEqual(result, [:])
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Linear and/or Github issues related to this PR, if applicable._

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated channel and message models to improve consistency, state handling, and update workflows.
  * Streamlined how messages are created from drafts and transformed from DTOs.
* **Bug Fixes**
  * Improved livestream membership join/leave/remove handling.
  * Refined recent message selection to respect time bounds.
  * Optimized decoding for empty “custom fields” payloads.
  * Improved identifier pre-warming and caching for composed member/channel-read IDs.
* **Tests**
  * Added unit tests for background observer reuse, raw JSON fast paths, and member pre-warming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->