### PR TITLE
Add code documentation guidelines for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,13 @@ The project uses Swift 6.0 strict concurrency. When adding new code:
 
 ### Development guidelines
 
+Code documentation
+
+- Write doc comments (`///`) only for `public` declarations — types, methods, and properties that are part of the SDK's public API.
+- Do not add doc comments to `internal`, `private`, or test code.
+- Keep doc comments concise: a one-line summary; add parameter/return docs only when they are not obvious from the signature.
+- Do not add inline comments narrating what the code or a change does; comment only non-obvious constraints or reasoning.
+
 Accessibility & UI quality
 
 - Ensure UIKit components have accessibility labels, traits, and dynamic type support.


### PR DESCRIPTION
### 🔗 Issue Links

None.

### 🎯 Goal

Prevent AI coding agents from generating verbose doc comments by documenting that only public API gets doc comments.

### 📝 Summary

- Added a "Code documentation" policy to `AGENTS.md`: doc comments (`///`) only for public declarations, kept concise, and no comments narrating changes.

### 🛠 Implementation

Documentation-only change to the agent guidance file; no source code affected.

### 🎨 Showcase

Not applicable — documentation-only change.

### 🧪 Manual Testing Notes

Not applicable — documentation-only change.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for code documentation in development standards.
  * Clarified when to use `///` doc comments for public APIs.
  * Recommended keeping documentation brief and avoiding inline comments for obvious behavior, while still capturing non-obvious constraints or reasoning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->