### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -12,6 +12,10 @@ env:
   IOS_SIMULATOR_DEVICE: "iPhone 16 Pro (18.5)"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test-backend-integration:
     name: Test Backend Integration

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -21,6 +21,10 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test-e2e-debug:
     name: Test E2E UI (Debug)

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -22,7 +22,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
-  actions: write
   contents: read
 
 jobs:

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -3,6 +3,10 @@ name: Record Snapshots
 on:
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   record:
     name: Record

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   merge-release-to-main:

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   merge-release-to-main:
     name: Merge release to main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,6 +3,9 @@ name: "Publish new release"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Publish new release

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -8,6 +8,10 @@ on:
         type: string
         required: true
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   test-release:
     name: Start new release

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -9,8 +9,8 @@ on:
         required: true
 
 permissions:
-  actions: write
   contents: write
+  pull-requests: write
 
 jobs:
   test-release:

--- a/.github/workflows/sdk-performance-metrics.yml
+++ b/.github/workflows/sdk-performance-metrics.yml
@@ -19,6 +19,11 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   performance:
     name: Metrics

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -16,6 +16,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   sdk_size:
     name: Metrics

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -17,6 +17,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
 

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -26,9 +26,8 @@ env:
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   guard:

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -28,7 +28,7 @@ env:
 permissions:
   actions: write
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   guard:

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -25,6 +25,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
 jobs:
   guard:
     name: Guard

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,6 +12,9 @@ concurrency:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: macos-15

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,6 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -24,7 +24,7 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   deploy:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -22,6 +22,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   deploy:
     runs-on: macos-15

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -10,6 +10,9 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+
 jobs:
   copyright:
     name: Copyright

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -11,7 +11,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   copyright:

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -12,6 +12,7 @@ env:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   copyright:


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **28** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [x] CI green
- [x] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation workflows to declare explicit GitHub Actions permission scopes.
  * Applied least-privilege access across workflows (typically `contents: read` and `pull-requests`/`actions` read or write only where necessary).
  * No changes to workflow triggers, jobs, or execution logic—only token permission scopes were tightened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->