### PR TITLE
[v4] Add configurable attachment downloads directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### ✅ Added
+- Add `ChatClientConfig.localAttachmentDownloadsFolderURL` to configure where attachment downloads are stored
+
 ### 🔄 Changed
 
 # [4.101.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.101.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### ✅ Added
-- Add `ChatClientConfig.localAttachmentDownloadsFolderURL` to configure where attachment downloads are stored
+- Add `ChatClientConfig.localAttachmentDownloadsFolderURL` to configure where attachment downloads are stored [#4180](https://github.com/GetStream/stream-chat-swift/pull/4180)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `ChatClientConfig.localAttachmentDownloadsFolderURL` to configure where attachment downloads are stored [#4180](https://github.com/GetStream/stream-chat-swift/pull/4180)
 
-### 🔄 Changed
 
 # [4.101.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.101.2)
 _July 03, 2026_

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -34,6 +34,22 @@ public struct ChatClientConfig {
         Self.initLocalStorageFolderURL(groupIdentifier: nil)
     }()
 
+    /// The base folder `ChatClient` uses to store attachments downloaded to local storage.
+    ///
+    /// Downloaded attachments are stored inside a `StreamAttachmentDownloads` subfolder created within this location.
+    /// By default this points to the user's `Documents` directory, which is user-visible when the app enables file
+    /// sharing (`UIFileSharingEnabled` / `LSSupportsOpeningDocumentsInPlace`) and is included in device backups.
+    ///
+    /// Set this to a non-user-visible location such as `Library/Application Support` or `Library/Caches` to keep
+    /// downloaded attachments out of the Files app and, optionally, out of backups. When `nil`, the SDK falls back
+    /// to the default `Documents` directory.
+    ///
+    /// - Important: Relative download paths are resolved against this URL on each launch, so changing it between
+    /// launches means previously downloaded files stored under the old location won't be found.
+    public var localAttachmentDownloadsFolderURL: URL? = {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+    }()
+
     static func initLocalStorageFolderURL(groupIdentifier: String?) -> URL? {
         #if os(macOS)
         let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -219,7 +219,10 @@ private extension AttachmentDTO {
         guard let localDownloadState else { return nil }
         let localFileURL: URL? = {
             guard let localRelativePath, !localRelativePath.isEmpty else { return nil }
-            return URL.streamAttachmentLocalStorageURL(forRelativePath: localRelativePath)
+            return URL.streamAttachmentLocalStorageURL(
+                forRelativePath: localRelativePath,
+                baseURL: managedObjectContext?.chatClientConfig?.localAttachmentDownloadsFolderURL
+            )
         }()
         let file: AttachmentFile? = {
             // Most attachments contain the attachment file information

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -329,9 +329,12 @@ class DatabaseContainer: NSPersistentContainer, @unchecked Sendable {
                     }
                 }
                 
-                if FileManager.default.fileExists(atPath: URL.streamAttachmentDownloadsDirectory.path) {
+                let downloadsDirectory = URL.streamAttachmentDownloadsDirectory(
+                    baseURL: self?.chatClientConfig.localAttachmentDownloadsFolderURL
+                )
+                if FileManager.default.fileExists(atPath: downloadsDirectory.path) {
                     do {
-                        try FileManager.default.removeItem(at: .streamAttachmentDownloadsDirectory)
+                        try FileManager.default.removeItem(at: downloadsDirectory)
                     } catch {
                         log.debug("Failed to remove local downloads", subsystems: .database)
                     }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
@@ -218,13 +218,22 @@ extension AttachmentFile {
 
 extension URL {
     /// The directory URL for attachment downloads.
-    static var streamAttachmentDownloadsDirectory: URL {
-        (FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory)
-            .appendingPathComponent("StreamAttachmentDownloads", isDirectory: true)
+    ///
+    /// - Parameter baseURL: The base folder the downloads directory is created within. When `nil`, the user's
+    ///   `Documents` directory is used.
+    static func streamAttachmentDownloadsDirectory(baseURL: URL? = nil) -> URL {
+        let base = baseURL
+            ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("StreamAttachmentDownloads", isDirectory: true)
     }
-    
-    static func streamAttachmentLocalStorageURL(forRelativePath path: String) -> URL {
-        URL(fileURLWithPath: path, isDirectory: false, relativeTo: .streamAttachmentDownloadsDirectory).standardizedFileURL
+
+    static func streamAttachmentLocalStorageURL(forRelativePath path: String, baseURL: URL? = nil) -> URL {
+        URL(
+            fileURLWithPath: path,
+            isDirectory: false,
+            relativeTo: streamAttachmentDownloadsDirectory(baseURL: baseURL)
+        ).standardizedFileURL
     }
 }
 

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -161,13 +161,17 @@ class CurrentUserUpdater: Worker {
     }
     
     func deleteAllLocalAttachmentDownloads(completion: @escaping (Error?) -> Void) {
+        let downloadsBaseURL = database.chatClientConfig.localAttachmentDownloadsFolderURL
         database.write({ session in
             // Try to delete all the local files even when one of them happens to fail.
             var latestError: Error?
             let attachments = session.allLocallyDownloadedAttachments()
             for attachment in attachments {
                 if let localRelativePath = attachment.localRelativePath {
-                    let localURL = URL.streamAttachmentLocalStorageURL(forRelativePath: localRelativePath)
+                    let localURL = URL.streamAttachmentLocalStorageURL(
+                        forRelativePath: localRelativePath,
+                        baseURL: downloadsBaseURL
+                    )
                     if FileManager.default.fileExists(atPath: localURL.path) {
                         do {
                             try FileManager.default.removeItem(at: localURL)

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -774,7 +774,10 @@ class MessageUpdater: Worker {
         completion: @escaping (Result<ChatMessageAttachment<Payload>, Error>) -> Void
     ) where Payload: DownloadableAttachmentPayload {
         let attachmentId = attachment.id
-        let localURL = URL.streamAttachmentLocalStorageURL(forRelativePath: attachment.relativeStoragePath)
+        let localURL = URL.streamAttachmentLocalStorageURL(
+            forRelativePath: attachment.relativeStoragePath,
+            baseURL: database.chatClientConfig.localAttachmentDownloadsFolderURL
+        )
         apiClient.downloadFile(
             from: attachment.remoteURL,
             to: localURL,

--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -125,7 +125,7 @@ final class DatabaseContainer_Tests: XCTestCase {
         }
         
         // Assert that local downloads were removed
-        XCTAssertEqual(false, FileManager.default.fileExists(atPath: URL.streamAttachmentDownloadsDirectory.path))
+        XCTAssertEqual(false, FileManager.default.fileExists(atPath: URL.streamAttachmentDownloadsDirectory().path))
     }
     
     func test_removingAllData_whileAnotherWrite() throws {

--- a/Tests/StreamChatTests/Models/Attachments/ChatMessageAttachment_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/ChatMessageAttachment_Tests.swift
@@ -126,4 +126,33 @@ final class ChatMessageAttachment_Tests: XCTestCase {
         )
         XCTAssertEqual(typeErasedAttachment.attachment(payloadType: Joke.self), jokeAttachment)
     }
+
+    func test_streamAttachmentDownloadsDirectory_usesCustomBaseURL() {
+        let baseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let downloadsDirectory = URL.streamAttachmentDownloadsDirectory(baseURL: baseURL)
+        let localFileURL = URL.streamAttachmentLocalStorageURL(
+            forRelativePath: "message-id-0/File.txt",
+            baseURL: baseURL
+        )
+
+        XCTAssertEqual(
+            downloadsDirectory,
+            baseURL.appendingPathComponent("StreamAttachmentDownloads", isDirectory: true)
+        )
+        XCTAssertEqual(
+            localFileURL.path,
+            downloadsDirectory.appendingPathComponent("message-id-0/File.txt").path
+        )
+    }
+
+    func test_streamAttachmentDownloadsDirectory_defaultsToDocuments() {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        let downloadsDirectory = URL.streamAttachmentDownloadsDirectory()
+
+        XCTAssertEqual(
+            downloadsDirectory,
+            documents?.appendingPathComponent("StreamAttachmentDownloads", isDirectory: true)
+        )
+    }
 }

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -696,11 +696,11 @@ final class CurrentUserUpdater_Tests: XCTestCase {
     
     func test_deleteAllLocalAttachmentDownloads_success() throws {
         let storedFileCount: () -> Int = {
-            let paths = try? FileManager.default.subpathsOfDirectory(atPath: URL.streamAttachmentDownloadsDirectory.path)
+            let paths = try? FileManager.default.subpathsOfDirectory(atPath: URL.streamAttachmentDownloadsDirectory().path)
             return paths?.count ?? 0
         }
-        if FileManager.default.fileExists(atPath: URL.streamAttachmentDownloadsDirectory.path) {
-            try FileManager.default.removeItem(at: .streamAttachmentDownloadsDirectory)
+        if FileManager.default.fileExists(atPath: URL.streamAttachmentDownloadsDirectory().path) {
+            try FileManager.default.removeItem(at: URL.streamAttachmentDownloadsDirectory())
         }
         
         let attachmentIds = try (0..<5).map { _ in try setUpDownloadedAttachment(with: .mockFile) }
@@ -869,7 +869,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
     
     private func setUpDownloadedAttachment(with payload: AnyAttachmentPayload, messageId: MessageId = .unique, cid: ChannelId = .unique) throws -> AttachmentId {
         let attachmentId: AttachmentId = .init(cid: cid, messageId: messageId, index: 0)
-        try FileManager.default.createDirectory(at: .streamAttachmentDownloadsDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: URL.streamAttachmentDownloadsDirectory(), withIntermediateDirectories: true)
         try database.createChannel(cid: cid, withMessages: false)
         try database.createMessage(id: messageId, cid: cid)
         try database.writeSynchronously { session in


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1889](https://linear.app/stream/issue/IOS-1889/allow-configuring-attachment-downloads-directory-avoid-documents)

Cherry-pick of [#4174](https://github.com/GetStream/stream-chat-swift/pull/4174) to v4.

### 🎯 Goal

Backport configurable attachment download storage to v4 so customers with file sharing enabled can keep downloaded attachments outside `Documents/` (avoiding Files app visibility and unwanted iCloud backups).

### 📝 Summary

- Add `ChatClientConfig.localAttachmentDownloadsFolderURL` (defaults to Documents)
- Resolve download / delete / `removeAllData` paths against the configured base directory
- Add unit coverage for custom vs default directory resolution

### 🛠 Implementation

Cherry-picked from develop PR #4174 with conflict resolution for v4 API differences (kept non-`@Sendable` completion signatures; did not bring the develop-only custom download `URLRequest` API).

### 🧪 Manual Testing Notes

1. Set `config.localAttachmentDownloadsFolderURL` to Application Support or Caches
2. Download an attachment
3. Confirm the file is stored under `{configuredBase}/StreamAttachmentDownloads/...` and not under Documents

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo