### PR TITLE
Use regular symbol weight for the composer add icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `StreamImageDownloader` for downloading and caching images [#4171](https://github.com/GetStream/stream-chat-swift/pull/4171)
 
+### 🐞 Fixed
+- Fix the composer's add attachment icon being thinner than the other composer icons [#4188](https://github.com/GetStream/stream-chat-swift/pull/4188)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix `ChatMessageContentView` overwriting a Markdown link's real href when its display text itself looks like a URL, e.g. `[https://text-link.com](https://real-link.com)` [#4181](https://github.com/GetStream/stream-chat-swift/pull/4181)

--- a/Sources/StreamChatCommonUI/Appearance+Images.swift
+++ b/Sources/StreamChatCommonUI/Appearance+Images.swift
@@ -471,7 +471,7 @@ public extension Appearance {
         public var composerAdd: UIImage = loadSafely(
             systemName: "plus",
             config: UIImage.SymbolConfiguration(
-                weight: .light
+                weight: .regular
             )
         )
 


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1913](https://linear.app/stream/issue/IOS-1913/v5-ui-polish-plus-icon-in-attachments-picker-appears-thinner-than)

### 🎯 Goal

The plus icon that opens the attachment picker in the composer renders with a visibly thinner stroke than the icons next to it (mic, send), so it looks out of place next to the rest of the icon set.

### 📝 Summary

- Configure `Appearance.Images.composerAdd` with a `.regular` symbol weight instead of `.light`, so the composer plus icon matches the stroke weight of the other composer icons.

### 🛠 Implementation

`composerAdd` was the only symbol in `Appearance+Images.swift` configured with `UIImage.SymbolConfiguration(weight: .light)`. Every other composer icon added alongside it (`composerSend`, `composerMic`, `scrollDownArrow`) uses `.regular`, and the remaining non-regular weights in the file are intentional (`.medium`/`.bold`/`.heavy`/`.black` for badges and checkmarks, `.thin` for the poll vote circle). Switching the plus to `.regular` aligns it with its neighbours.

Only the stroke weight changes: both symbols already resolve at the same default symbol point size, so the icon's footprint stays the same.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| `plus` at `.light` — noticeably thinner stroke than the mic icon on the opposite side of the composer | `plus` at `.regular` — stroke matches the mic and send icons |

### 🧪 Manual Testing Notes

Run the SwiftUI SDK's demo app and compare the composer's leading plus button with the trailing mic button — the two strokes should now read as the same weight in both light and dark mode.

Note for the downstream bump: the recorded composer snapshots in `stream-chat-swiftui` (e.g. `MessageComposerView_Tests`) contain the old thinner plus and will need re-recording when the pinned revision is updated there.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the composer’s “add attachment” icon so its stroke weight is consistent with the other composer icons.
* **Documentation**
  * Updated the changelog to document the icon consistency fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->