### PR TITLE
[IOS-1928] Bail out of oversized /sync event replay and refresh watched channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### ✅ Added
-- Add `ChatClientConfig.syncEventReplayMaximumEventCount` to configure when oversized `/sync` payloads skip event replay [#4189](https://github.com/GetStream/stream-chat-swift/pull/4189)
 - Add `SystemMessage` support to `addMembers`, `removeMembers`, and `truncateChannel` to send system messages with extra data [#4183](https://github.com/GetStream/stream-chat-swift/pull/4183)
 - Add `NSMutableAttributedString.addLinks(detectedBy:)` and `AttributedString.addLinks(detectedBy:)` for applying detected links to attributed strings while preserving existing Markdown links [#4181](https://github.com/GetStream/stream-chat-swift/pull/4181)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### ✅ Added
+- Add `ChatClientConfig.syncEventReplayMaximumEventCount` to configure when oversized `/sync` payloads skip event replay [#4189](https://github.com/GetStream/stream-chat-swift/pull/4189)
 - Add `SystemMessage` support to `addMembers`, `removeMembers`, and `truncateChannel` to send system messages with extra data [#4183](https://github.com/GetStream/stream-chat-swift/pull/4183)
 - Add `NSMutableAttributedString.addLinks(detectedBy:)` and `AttributedString.addLinks(detectedBy:)` for applying detected links to attributed strings while preserving existing Markdown links [#4181](https://github.com/GetStream/stream-chat-swift/pull/4181)
+
+### ⚡️ Performance
+- Skip oversized `/sync` event replay and refresh watched channels via `queryChannels` instead [#4189](https://github.com/GetStream/stream-chat-swift/pull/4189)
 
 ## StreamChatCommonUI
 ### ✅ Added

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -213,6 +213,7 @@ class AppConfigViewController: UITableViewController {
         case shouldShowShadowedMessages
         case isChannelAutomaticFilteringEnabled
         case isLocalUnreadCountEnabled
+        case syncEventReplayMaximumEventCount
     }
 
     enum UserConfigOption: String, CaseIterable {
@@ -394,6 +395,9 @@ class AppConfigViewController: UITableViewController {
             cell.accessoryView = makeSwitchButton(chatClientConfig.isLocalUnreadCountEnabled) { [weak self] newValue in
                 self?.chatClientConfig.isLocalUnreadCountEnabled = newValue
             }
+        case .syncEventReplayMaximumEventCount:
+            cell.detailTextLabel?.text = "\(chatClientConfig.syncEventReplayMaximumEventCount)"
+            cell.accessoryType = .disclosureIndicator
         }
     }
 
@@ -408,6 +412,8 @@ class AppConfigViewController: UITableViewController {
             showBaseURLInputAlert()
         case .reconnectionTimeout:
             pushReconnectionTimeoutSelectorVC()
+        case .syncEventReplayMaximumEventCount:
+            pushSyncEventReplayMaximumEventCountSelectorVC()
         default:
             break
         }
@@ -638,6 +644,24 @@ class AppConfigViewController: UITableViewController {
         selectorViewController.didChangeSelectedOptions = { [weak self] options in
             guard let selectedOption = options.first else { return }
             self?.chatClientConfig.reconnectionTimeout = selectedOption
+            self?.tableView.reloadData()
+        }
+
+        navigationController?.pushViewController(selectorViewController, animated: true)
+    }
+
+    private func pushSyncEventReplayMaximumEventCountSelectorVC() {
+        let selectorViewController = OptionsSelectorViewController<Int>(
+            options: [0, 1, 10, 50, 250, 500],
+            initialSelectedOptions: [chatClientConfig.syncEventReplayMaximumEventCount],
+            allowsMultipleSelection: false,
+            optionFormatter: { option in
+                "\(option)"
+            }
+        )
+        selectorViewController.didChangeSelectedOptions = { [weak self] options in
+            guard let selectedOption = options.first else { return }
+            self?.chatClientConfig.syncEventReplayMaximumEventCount = selectedOption
             self?.tableView.reloadData()
         }
 

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -213,7 +213,6 @@ class AppConfigViewController: UITableViewController {
         case shouldShowShadowedMessages
         case isChannelAutomaticFilteringEnabled
         case isLocalUnreadCountEnabled
-        case syncEventReplayMaximumEventCount
     }
 
     enum UserConfigOption: String, CaseIterable {
@@ -395,9 +394,6 @@ class AppConfigViewController: UITableViewController {
             cell.accessoryView = makeSwitchButton(chatClientConfig.isLocalUnreadCountEnabled) { [weak self] newValue in
                 self?.chatClientConfig.isLocalUnreadCountEnabled = newValue
             }
-        case .syncEventReplayMaximumEventCount:
-            cell.detailTextLabel?.text = "\(chatClientConfig.syncEventReplayMaximumEventCount)"
-            cell.accessoryType = .disclosureIndicator
         }
     }
 
@@ -412,8 +408,6 @@ class AppConfigViewController: UITableViewController {
             showBaseURLInputAlert()
         case .reconnectionTimeout:
             pushReconnectionTimeoutSelectorVC()
-        case .syncEventReplayMaximumEventCount:
-            pushSyncEventReplayMaximumEventCountSelectorVC()
         default:
             break
         }
@@ -644,24 +638,6 @@ class AppConfigViewController: UITableViewController {
         selectorViewController.didChangeSelectedOptions = { [weak self] options in
             guard let selectedOption = options.first else { return }
             self?.chatClientConfig.reconnectionTimeout = selectedOption
-            self?.tableView.reloadData()
-        }
-
-        navigationController?.pushViewController(selectorViewController, animated: true)
-    }
-
-    private func pushSyncEventReplayMaximumEventCountSelectorVC() {
-        let selectorViewController = OptionsSelectorViewController<Int>(
-            options: [0, 1, 10, 50, 250, 500],
-            initialSelectedOptions: [chatClientConfig.syncEventReplayMaximumEventCount],
-            allowsMultipleSelection: false,
-            optionFormatter: { option in
-                "\(option)"
-            }
-        )
-        selectorViewController.didChangeSelectedOptions = { [weak self] options in
-            guard let selectedOption = options.first else { return }
-            self?.chatClientConfig.syncEventReplayMaximumEventCount = selectedOption
             self?.tableView.reloadData()
         }
 

--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -160,7 +160,8 @@ extension ChatClient {
                 eventNotificationCenter: $2,
                 database: $3,
                 apiClient: $4,
-                channelListUpdater: $5
+                channelListUpdater: $5,
+                eventReplayPolicy: SyncEventReplayPolicy(maximumEventCount: $0.syncEventReplayMaximumEventCount)
             )
         }
 

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -179,6 +179,14 @@ public struct ChatClientConfig: Sendable {
     /// - SeeAlso: Query option``QueryOptions/watch`` used by ``ChannelListQuery`` and ``ChannelQuery``.
     public var isAutomaticSyncOnReconnectEnabled = true
 
+    /// The maximum number of events that may be replayed from a single `/sync` response.
+    ///
+    /// When a `/sync` payload exceeds this count (or the backend returns HTTP 400 for too many events),
+    /// the SDK skips event replay and refreshes actively watched channels via `queryChannels` instead.
+    ///
+    /// Defaults to `250`.
+    public var syncEventReplayMaximumEventCount: Int = 250
+
     /// When enabled, the per-channel unread count is tracked locally for channels where server-side
     /// read events are disabled (i.e. ``ChannelConfig/readEventsEnabled`` is `false`, typical for
     /// livestream channels).

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -184,8 +184,12 @@ public struct ChatClientConfig: Sendable {
     /// When a `/sync` payload exceeds this count (or the backend returns HTTP 400 for too many events),
     /// the SDK skips event replay and refreshes actively watched channels via `queryChannels` instead.
     ///
+    /// This property is intentionally `internal`. Customers should not tune it; the default (`250`) is
+    /// chosen to keep reconnect recovery safe and performant. Override only in SDK tests or local
+    /// debugging.
+    ///
     /// Defaults to `250`.
-    public var syncEventReplayMaximumEventCount: Int = 250
+    var syncEventReplayMaximumEventCount: Int = 250
 
     /// When enabled, the per-channel unread count is tracked locally for channels where server-side
     /// read events are disabled (i.e. ``ChannelConfig/readEventsEnabled`` is `false`, typical for

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -175,7 +175,7 @@ final class SyncEventsOperation: AsyncOperation, @unchecked Sendable {
                 return
             }
 
-            let channelIdsToSync = Array(channelIds.prefix(100))
+            let channelIdsToSync = Array(channelIds.prefix(SyncRepository.Constants.maximumChannelIdsPerRequest))
             log.info(
                 "Calling `/sync` for \(channelIdsToSync.count) channel(s) since \(context.lastSyncAt)",
                 subsystems: .offlineSupport

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -174,7 +174,8 @@ final class SyncEventsOperation: AsyncOperation, @unchecked Sendable {
             syncRepository?.syncChannelsEvents(
                 channelIds: Array(channelIds.prefix(100)),
                 lastSyncAt: context.lastSyncAt,
-                isRecovery: recovery
+                isRecovery: recovery,
+                alreadySyncedChannelIds: context.synchedChannelIds
             ) { result in
                 switch result {
                 case let .success(channelIds):

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -160,19 +160,29 @@ final class SyncGroupedChannelsOperation: AsyncOperation, @unchecked Sendable {
 final class SyncEventsOperation: AsyncOperation, @unchecked Sendable {
     init(syncRepository: SyncRepository, context: SyncContext, recovery: Bool) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak syncRepository] _, done in
+            let channelIds = Set(context.localChannelIds).subtracting(context.synchedChannelIds)
             log.info(
-                "1. Call `/sync` endpoint and get missing events for all locally existed channels",
+                "Preparing `/sync` for missing events. active=\(context.localChannelIds.count) alreadySynced=\(context.synchedChannelIds.count) remaining=\(channelIds.count)",
                 subsystems: .offlineSupport
             )
 
-            let channelIds = Set(context.localChannelIds).subtracting(context.synchedChannelIds)
             guard !channelIds.isEmpty else {
+                log.info(
+                    "Skipping `/sync` because all active channels were already refreshed by channel lists",
+                    subsystems: .offlineSupport
+                )
                 done(.continue)
                 return
             }
-            
+
+            let channelIdsToSync = Array(channelIds.prefix(100))
+            log.info(
+                "Calling `/sync` for \(channelIdsToSync.count) channel(s) since \(context.lastSyncAt)",
+                subsystems: .offlineSupport
+            )
+
             syncRepository?.syncChannelsEvents(
-                channelIds: Array(channelIds.prefix(100)),
+                channelIds: channelIdsToSync,
                 lastSyncAt: context.lastSyncAt,
                 isRecovery: recovery,
                 alreadySyncedChannelIds: context.synchedChannelIds

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -21,11 +21,21 @@ enum SyncError: Error, Sendable {
     }
 }
 
+/// Controls when `/sync` event payloads are replayed versus skipped in favor of a `queryChannels` refresh.
+struct SyncEventReplayPolicy: Sendable {
+    /// Maximum number of events that may be replayed from a single `/sync` response.
+    var maximumEventCount: Int
+
+    /// Conservative default below the backend hard cap (~2000).
+    static let `default` = SyncEventReplayPolicy(maximumEventCount: 250)
+}
+
 /// This class is in charge of the synchronization of our local storage with the remote.
 /// When executing a sync, it will remove outdated elements, and will refresh the content to always show the latest data.
 class SyncRepository: @unchecked Sendable {
     private enum Constants {
         static let maximumDaysSinceLastSync = 30
+        static let maximumChannelIdsPerRequest = 100
     }
 
     /// Maximum number of retries for each operation step.
@@ -34,6 +44,7 @@ class SyncRepository: @unchecked Sendable {
     private let database: DatabaseContainer
     private let apiClient: APIClient
     private let channelListUpdater: ChannelListUpdater
+    let eventReplayPolicy: SyncEventReplayPolicy
     let offlineRequestsRepository: OfflineRequestsRepository
     let eventNotificationCenter: EventNotificationCenter
 
@@ -58,7 +69,8 @@ class SyncRepository: @unchecked Sendable {
         eventNotificationCenter: EventNotificationCenter,
         database: DatabaseContainer,
         apiClient: APIClient,
-        channelListUpdater: ChannelListUpdater
+        channelListUpdater: ChannelListUpdater,
+        eventReplayPolicy: SyncEventReplayPolicy = .default
     ) {
         self.config = config
         self.offlineRequestsRepository = offlineRequestsRepository
@@ -66,6 +78,7 @@ class SyncRepository: @unchecked Sendable {
         self.eventNotificationCenter = eventNotificationCenter
         self.database = database
         self.apiClient = apiClient
+        self.eventReplayPolicy = eventReplayPolicy
     }
 
     deinit {
@@ -172,9 +185,10 @@ class SyncRepository: @unchecked Sendable {
     /// Background mode (other regular API requests are allowed to run at the same time)
     /// 1. Collect all the **active** channel ids (from instances of `Chat`, `ChannelList`, `ChatChannelController`, `ChatChannelListController`)
     /// 2. Refresh channel lists (channels for current pages in `ChannelList`, `ChatChannelListController`, including grouped lists)
-    /// 3. Apply updates from the /sync endpoint for channels not in active channel lists (max 2000 events is supported)
+    /// 3. Apply updates from the /sync endpoint for channels not in active channel lists
     ///      * channel controllers targeting other channels
     ///      * no channel lists active, but channel controllers are
+    ///      * oversized payloads skip event replay and refresh active watched channels via queryChannels
     /// 4. Re-watch channels what we were watching before disconnect
     private func syncLocalState(lastSyncAt: Date, completion: @escaping @Sendable () -> Void) {
         let context = SyncContext(lastSyncAt: lastSyncAt)
@@ -271,6 +285,7 @@ class SyncRepository: @unchecked Sendable {
         channelIds: [ChannelId],
         lastSyncAt: Date,
         isRecovery: Bool,
+        alreadySyncedChannelIds: Set<ChannelId> = [],
         completion: @escaping @Sendable (Result<[ChannelId], SyncError>) -> Void
     ) {
         guard lastSyncAt.numberOfDaysUntilNow < Constants.maximumDaysSinceLastSync else {
@@ -288,8 +303,44 @@ class SyncRepository: @unchecked Sendable {
             using: lastSyncAt,
             channelIds: channelIds,
             isRecoveryRequest: isRecovery,
+            alreadySyncedChannelIds: alreadySyncedChannelIds,
             completion: completion
         )
+    }
+
+    /// Refreshes actively watched channels via `queryChannels`, excluding channels already synced in the reconnect context.
+    func refreshActiveWatchedChannels(
+        excluding alreadySyncedChannelIds: Set<ChannelId>,
+        completion: @escaping @Sendable (Result<Set<ChannelId>, SyncError>) -> Void
+    ) {
+        var channelIds = Set<ChannelId>()
+        channelIds.formUnion(activeChannelControllers.allObjects.compactMap(\.cid))
+        channelIds.formUnion(activeLivestreamControllers.allObjects.compactMap(\.cid))
+        channelIds.formUnion(activeLivestreamChats.allObjects.compactMap { try? $0.cid })
+
+        let chats = activeChats.allObjects
+        let finish: @Sendable (Set<ChannelId>) -> Void = { [weak self] ids in
+            guard let self else {
+                completion(.success([]))
+                return
+            }
+            let idsToRefresh = Array(ids.subtracting(alreadySyncedChannelIds))
+            guard !idsToRefresh.isEmpty else {
+                completion(.success([]))
+                return
+            }
+            self.startWatchingChannelsInBatches(idsToRefresh, accumulated: [], completion: completion)
+        }
+
+        if chats.isEmpty {
+            finish(channelIds)
+        } else {
+            DispatchQueue.main.async {
+                var ids = channelIds
+                ids.formUnion(chats.compactMap { try? $0.cid })
+                finish(ids)
+            }
+        }
     }
 
     private func getUser(completion: @escaping @Sendable (CurrentUserDTO?) -> Void) {
@@ -304,6 +355,7 @@ class SyncRepository: @unchecked Sendable {
         using date: Date,
         channelIds: [ChannelId],
         isRecoveryRequest: Bool,
+        alreadySyncedChannelIds: Set<ChannelId>,
         completion: @escaping @Sendable (Result<[ChannelId], SyncError>) -> Void
     ) {
         log.info("Synching events for existing channels since \(date)", subsystems: .offlineSupport)
@@ -317,8 +369,23 @@ class SyncRepository: @unchecked Sendable {
         let requestCompletion: @Sendable (Result<MissingEventsPayload, Error>) -> Void = { [weak self] result in
             switch result {
             case let .success(payload):
-                log.info("Processing pending events. Count \(payload.eventPayloads.count)", subsystems: .offlineSupport)
-                self?.processMissingEventsPayload(payload) { [weak self] in
+                guard let self else { return }
+                let eventCount = payload.eventPayloads.count
+                if eventCount > self.eventReplayPolicy.maximumEventCount {
+                    log.info(
+                        "Skipping event replay; count \(eventCount) exceeds \(self.eventReplayPolicy.maximumEventCount). Refreshing watched channels instead.",
+                        subsystems: .offlineSupport
+                    )
+                    self.handleSyncEventReplayFallback(
+                        lastSyncAt: payload.eventPayloads.last?.createdAt ?? date,
+                        alreadySyncedChannelIds: alreadySyncedChannelIds,
+                        completion: completion
+                    )
+                    return
+                }
+
+                log.info("Processing pending events. Count \(eventCount)", subsystems: .offlineSupport)
+                self.processMissingEventsPayload(payload) { [weak self] in
                     self?.updateLastSyncAt(with: payload.eventPayloads.last?.createdAt ?? date, completion: { error in
                         if let error = error {
                             completion(.failure(error))
@@ -334,16 +401,12 @@ class SyncRepository: @unchecked Sendable {
                     return
                 }
                 // Backend responds with 400 if there were more than 2000 events to return
-                // Cleaning local channels data and refetching it from scratch
-                log.info("/sync returned too many events. Continuing...", subsystems: .offlineSupport)
-
-                self?.updateLastSyncAt(with: Date()) { error in
-                    if let error = error {
-                        completion(.failure(error))
-                    } else {
-                        completion(.success([]))
-                    }
-                }
+                log.info("/sync returned too many events. Refreshing watched channels instead.", subsystems: .offlineSupport)
+                self?.handleSyncEventReplayFallback(
+                    lastSyncAt: Date(),
+                    alreadySyncedChannelIds: alreadySyncedChannelIds,
+                    completion: completion
+                )
             }
         }
 
@@ -351,6 +414,50 @@ class SyncRepository: @unchecked Sendable {
             apiClient.recoveryRequest(endpoint: endpoint, completion: requestCompletion)
         } else {
             apiClient.request(endpoint: endpoint, completion: requestCompletion)
+        }
+    }
+
+    private func handleSyncEventReplayFallback(
+        lastSyncAt: Date,
+        alreadySyncedChannelIds: Set<ChannelId>,
+        completion: @escaping @Sendable (Result<[ChannelId], SyncError>) -> Void
+    ) {
+        refreshActiveWatchedChannels(excluding: alreadySyncedChannelIds) { [weak self] result in
+            switch result {
+            case let .success(refreshedIds):
+                self?.updateLastSyncAt(with: lastSyncAt) { error in
+                    if let error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(Array(refreshedIds)))
+                    }
+                }
+            case let .failure(error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func startWatchingChannelsInBatches(
+        _ channelIds: [ChannelId],
+        accumulated: Set<ChannelId>,
+        completion: @escaping @Sendable (Result<Set<ChannelId>, SyncError>) -> Void
+    ) {
+        guard !channelIds.isEmpty else {
+            completion(.success(accumulated))
+            return
+        }
+
+        let batch = Array(channelIds.prefix(Constants.maximumChannelIdsPerRequest))
+        let remaining = Array(channelIds.dropFirst(Constants.maximumChannelIdsPerRequest))
+        channelListUpdater.startWatchingChannels(withIds: batch) { [weak self] error in
+            if error != nil {
+                completion(.failure(.failedFetchingChannels))
+                return
+            }
+            var nextAccumulated = accumulated
+            nextAccumulated.formUnion(batch)
+            self?.startWatchingChannelsInBatches(remaining, accumulated: nextAccumulated, completion: completion)
         }
     }
 

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -33,7 +33,7 @@ struct SyncEventReplayPolicy: Sendable {
 /// This class is in charge of the synchronization of our local storage with the remote.
 /// When executing a sync, it will remove outdated elements, and will refresh the content to always show the latest data.
 class SyncRepository: @unchecked Sendable {
-    private enum Constants {
+    enum Constants {
         static let maximumDaysSinceLastSync = 30
         static let maximumChannelIdsPerRequest = 100
     }
@@ -321,8 +321,8 @@ class SyncRepository: @unchecked Sendable {
         channelIds.formUnion(activeChannelControllers.allObjects.compactMap(\.cid))
         channelIds.formUnion(activeLivestreamControllers.allObjects.compactMap(\.cid))
         channelIds.formUnion(activeLivestreamChats.allObjects.compactMap { try? $0.cid })
-
         let chats = activeChats.allObjects
+
         let finish: @Sendable (Set<ChannelId>) -> Void = { [weak self] ids in
             guard let self else {
                 completion(.success([]))

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -445,7 +445,11 @@ class SyncRepository: @unchecked Sendable {
                     "Fallback refreshed \(refreshedIds.count) watched channel(s). Updating lastSyncAt to \(lastSyncAt)",
                     subsystems: .offlineSupport
                 )
-                self?.updateLastSyncAt(with: lastSyncAt) { error in
+                guard let self else {
+                    completion(.failure(.couldNotUpdateUserValue(ClientError("SyncRepository deallocated"))))
+                    return
+                }
+                self.updateLastSyncAt(with: lastSyncAt) { error in
                     if let error {
                         completion(.failure(error))
                     } else {
@@ -478,7 +482,11 @@ class SyncRepository: @unchecked Sendable {
             }
             var nextAccumulated = accumulated
             nextAccumulated.formUnion(batch)
-            self?.startWatchingChannelsInBatches(remaining, accumulated: nextAccumulated, completion: completion)
+            guard let self else {
+                completion(.failure(.failedFetchingChannels))
+                return
+            }
+            self.startWatchingChannelsInBatches(remaining, accumulated: nextAccumulated, completion: completion)
         }
     }
 

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -289,6 +289,10 @@ class SyncRepository: @unchecked Sendable {
         completion: @escaping @Sendable (Result<[ChannelId], SyncError>) -> Void
     ) {
         guard lastSyncAt.numberOfDaysUntilNow < Constants.maximumDaysSinceLastSync else {
+            log.info(
+                "Skipping `/sync` because lastSyncAt (\(lastSyncAt)) is older than \(Constants.maximumDaysSinceLastSync) days",
+                subsystems: .offlineSupport
+            )
             updateLastSyncAt(with: Date()) { error in
                 if let error = error {
                     completion(.failure(error))
@@ -358,7 +362,10 @@ class SyncRepository: @unchecked Sendable {
         alreadySyncedChannelIds: Set<ChannelId>,
         completion: @escaping @Sendable (Result<[ChannelId], SyncError>) -> Void
     ) {
-        log.info("Synching events for existing channels since \(date)", subsystems: .offlineSupport)
+        log.info(
+            "Synching events for \(channelIds.count) channel(s) since \(date). replayThreshold=\(eventReplayPolicy.maximumEventCount) alreadySyncedExcluded=\(alreadySyncedChannelIds.count)",
+            subsystems: .offlineSupport
+        )
 
         guard !channelIds.isEmpty else {
             completion(.success([]))
@@ -371,9 +378,14 @@ class SyncRepository: @unchecked Sendable {
             case let .success(payload):
                 guard let self else { return }
                 let eventCount = payload.eventPayloads.count
-                if eventCount > self.eventReplayPolicy.maximumEventCount {
+                let maximumEventCount = self.eventReplayPolicy.maximumEventCount
+                log.info(
+                    "Received `/sync` payload with \(eventCount) event(s). replayThreshold=\(maximumEventCount)",
+                    subsystems: .offlineSupport
+                )
+                if eventCount > maximumEventCount {
                     log.info(
-                        "Skipping event replay; count \(eventCount) exceeds \(self.eventReplayPolicy.maximumEventCount). Refreshing watched channels instead.",
+                        "Skipping event replay; count \(eventCount) exceeds \(maximumEventCount). Refreshing watched channels instead.",
                         subsystems: .offlineSupport
                     )
                     self.handleSyncEventReplayFallback(
@@ -422,9 +434,17 @@ class SyncRepository: @unchecked Sendable {
         alreadySyncedChannelIds: Set<ChannelId>,
         completion: @escaping @Sendable (Result<[ChannelId], SyncError>) -> Void
     ) {
+        log.info(
+            "Running `/sync` fallback via queryChannels. excludingAlreadySynced=\(alreadySyncedChannelIds.count)",
+            subsystems: .offlineSupport
+        )
         refreshActiveWatchedChannels(excluding: alreadySyncedChannelIds) { [weak self] result in
             switch result {
             case let .success(refreshedIds):
+                log.info(
+                    "Fallback refreshed \(refreshedIds.count) watched channel(s). Updating lastSyncAt to \(lastSyncAt)",
+                    subsystems: .offlineSupport
+                )
                 self?.updateLastSyncAt(with: lastSyncAt) { error in
                     if let error {
                         completion(.failure(error))
@@ -433,6 +453,7 @@ class SyncRepository: @unchecked Sendable {
                     }
                 }
             case let .failure(error):
+                log.error("Fallback queryChannels failed: \(error)", subsystems: .offlineSupport)
                 completion(.failure(error))
             }
         }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/SyncRepository_Mock.swift
@@ -33,7 +33,8 @@ final class SyncRepository_Mock: SyncRepository, Spy, @unchecked Sendable {
         eventNotificationCenter: EventNotificationCenter,
         database: DatabaseContainer,
         apiClient: APIClient,
-        channelListUpdater: ChannelListUpdater
+        channelListUpdater: ChannelListUpdater,
+        eventReplayPolicy: SyncEventReplayPolicy = .default
     ) {
         super.init(
             config: config,
@@ -41,7 +42,8 @@ final class SyncRepository_Mock: SyncRepository, Spy, @unchecked Sendable {
             eventNotificationCenter: eventNotificationCenter,
             database: database,
             apiClient: apiClient,
-            channelListUpdater: channelListUpdater
+            channelListUpdater: channelListUpdater,
+            eventReplayPolicy: eventReplayPolicy
         )
     }
 
@@ -57,6 +59,7 @@ final class SyncRepository_Mock: SyncRepository, Spy, @unchecked Sendable {
         channelIds: [ChannelId],
         lastSyncAt: Date,
         isRecovery: Bool,
+        alreadySyncedChannelIds: Set<ChannelId> = [],
         completion: @escaping (Result<[ChannelId], SyncError>) -> Void
     ) {
         record()

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
@@ -53,6 +53,7 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy, @unchecked Sendable
         queryGroupedChannels_result = nil
         markAllRead_completion = nil
 
+        startWatchingChannels_callCount = 0
         startWatchingChannels_cids.removeAll()
         startWatchingChannels_completion = nil
         startWatchingChannels_completion_success = false

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -43,7 +43,7 @@ final class SyncOperations_Tests: XCTestCase {
         XCTAssertEqual(context.synchedChannelIds.count, 0)
         XCTAssertNearlySameDate(database.viewContext.currentUser?.lastSynchedEventDate?.bridgeDate, originalDate)
         XCTAssertCall(
-            "syncChannelsEvents(channelIds:lastSyncAt:isRecovery:completion:)",
+            "syncChannelsEvents(channelIds:lastSyncAt:isRecovery:alreadySyncedChannelIds:completion:)",
             on: syncRepository,
             times: 3
         )
@@ -64,7 +64,7 @@ final class SyncOperations_Tests: XCTestCase {
 
         XCTAssertEqual(context.synchedChannelIds.count, 2)
         XCTAssertCall(
-            "syncChannelsEvents(channelIds:lastSyncAt:isRecovery:completion:)",
+            "syncChannelsEvents(channelIds:lastSyncAt:isRecovery:alreadySyncedChannelIds:completion:)",
             on: syncRepository,
             times: 1
         )
@@ -85,7 +85,7 @@ final class SyncOperations_Tests: XCTestCase {
 
         XCTAssertEqual(syncRepository.syncMissingEvents_syncChannels?.count, 100)
         XCTAssertCall(
-            "syncChannelsEvents(channelIds:lastSyncAt:isRecovery:completion:)",
+            "syncChannelsEvents(channelIds:lastSyncAt:isRecovery:alreadySyncedChannelIds:completion:)",
             on: syncRepository,
             times: 1
         )

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -473,6 +473,279 @@ class SyncRepository_Tests: XCTestCase {
         XCTAssertCall("exitRecoveryMode()", on: apiClient)
     }
 
+    // MARK: - Event replay policy
+
+    func test_syncChannelsEvents_whenEventCountWithinPolicy_processesEvents() throws {
+        let eventNotificationCenter = EventNotificationCenter_Mock(database: database)
+        let policy = SyncEventReplayPolicy(maximumEventCount: 2)
+        repository = SyncRepository(
+            config: client.config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater,
+            eventReplayPolicy: policy
+        )
+
+        let cid = ChannelId.unique
+        let lastSyncDate = Date().addingTimeInterval(-3600)
+        try prepareForSyncLocalStorage(
+            createUser: true,
+            lastSynchedEventDate: lastSyncDate,
+            createChannel: true,
+            cid: cid
+        )
+
+        let eventDates = [Date.unique, Date.unique]
+        let result = waitForSyncChannelsEvents(
+            channelIds: [cid],
+            lastSyncAt: lastSyncDate,
+            requestResult: .success(messageEventPayload(cid: cid, with: eventDates))
+        )
+
+        XCTAssertEqual(try XCTUnwrap(result.get()), [cid])
+        XCTAssertEqual(eventNotificationCenter.mock_processCalledWithEvents.count, 2)
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 0)
+        XCTAssertEqual(lastSyncAtValue, eventDates.last)
+    }
+
+    func test_syncChannelsEvents_whenEventCountExceedsPolicy_skipsReplayAndRefreshesWatchedChannels() throws {
+        let eventNotificationCenter = EventNotificationCenter_Mock(database: database)
+        let policy = SyncEventReplayPolicy(maximumEventCount: 2)
+        repository = SyncRepository(
+            config: client.config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater,
+            eventReplayPolicy: policy
+        )
+
+        let cid = ChannelId.unique
+        let lastSyncDate = Date().addingTimeInterval(-3600)
+        try prepareForSyncLocalStorage(
+            createUser: true,
+            lastSynchedEventDate: lastSyncDate,
+            createChannel: true,
+            cid: cid
+        )
+
+        let channelController = ChatChannelController_Mock.mock(
+            channelQuery: .init(cid: cid),
+            channelListQuery: nil,
+            client: client
+        )
+        channelController.mockCid = cid
+        repository.startTrackingChannelController(channelController)
+        channelListUpdater.startWatchingChannels_completion_success = true
+
+        let eventDates = [Date.unique, Date.unique, Date.unique]
+        let result = waitForSyncChannelsEvents(
+            channelIds: [cid],
+            lastSyncAt: lastSyncDate,
+            requestResult: .success(messageEventPayload(cid: cid, with: eventDates))
+        )
+
+        XCTAssertEqual(Set(try XCTUnwrap(result.get())), [cid])
+        XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 1)
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_cids, [cid])
+        XCTAssertEqual(lastSyncAtValue, eventDates.last)
+    }
+
+    func test_syncChannelsEvents_whenTooManyEvents400_refreshesWatchedChannels() throws {
+        let eventNotificationCenter = EventNotificationCenter_Mock(database: database)
+        repository = SyncRepository(
+            config: client.config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater
+        )
+
+        let cid = ChannelId.unique
+        let lastSyncDate = Date().addingTimeInterval(-3600)
+        try prepareForSyncLocalStorage(
+            createUser: true,
+            lastSynchedEventDate: lastSyncDate,
+            createChannel: true,
+            cid: cid
+        )
+
+        let channelController = ChatChannelController_Mock.mock(
+            channelQuery: .init(cid: cid),
+            channelListQuery: nil,
+            client: client
+        )
+        channelController.mockCid = cid
+        repository.startTrackingChannelController(channelController)
+        channelListUpdater.startWatchingChannels_completion_success = true
+
+        let before = Date()
+        let result = waitForSyncChannelsEvents(
+            channelIds: [cid],
+            lastSyncAt: lastSyncDate,
+            requestResult: .failure(ClientError(with: APIError(code: 0, message: "too many events", statusCode: 400)))
+        )
+        let after = Date()
+
+        XCTAssertEqual(Set(try XCTUnwrap(result.get())), [cid])
+        XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 1)
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_cids, [cid])
+        let updatedLastSyncAt = try XCTUnwrap(lastSyncAtValue)
+        XCTAssertGreaterThanOrEqual(updatedLastSyncAt, before)
+        XCTAssertLessThanOrEqual(updatedLastSyncAt, after)
+    }
+
+    func test_syncChannelsEvents_whenFallback_excludesAlreadySyncedChannelIds() throws {
+        let eventNotificationCenter = EventNotificationCenter_Mock(database: database)
+        let policy = SyncEventReplayPolicy(maximumEventCount: 1)
+        repository = SyncRepository(
+            config: client.config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater,
+            eventReplayPolicy: policy
+        )
+
+        let watchedCid = ChannelId.unique
+        let alreadySyncedCid = ChannelId.unique
+        let lastSyncDate = Date().addingTimeInterval(-3600)
+        try prepareForSyncLocalStorage(
+            createUser: true,
+            lastSynchedEventDate: lastSyncDate,
+            createChannel: false
+        )
+
+        let watchedController = ChatChannelController_Mock.mock(
+            channelQuery: .init(cid: watchedCid),
+            channelListQuery: nil,
+            client: client
+        )
+        watchedController.mockCid = watchedCid
+        repository.startTrackingChannelController(watchedController)
+
+        let alreadySyncedController = ChatChannelController_Mock.mock(
+            channelQuery: .init(cid: alreadySyncedCid),
+            channelListQuery: nil,
+            client: client
+        )
+        alreadySyncedController.mockCid = alreadySyncedCid
+        repository.startTrackingChannelController(alreadySyncedController)
+        channelListUpdater.startWatchingChannels_completion_success = true
+
+        let result = waitForSyncChannelsEvents(
+            channelIds: [watchedCid, alreadySyncedCid],
+            lastSyncAt: lastSyncDate,
+            alreadySyncedChannelIds: [alreadySyncedCid],
+            requestResult: .success(messageEventPayload(cid: watchedCid, with: [Date.unique, Date.unique]))
+        )
+
+        XCTAssertEqual(Set(try XCTUnwrap(result.get())), [watchedCid])
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 1)
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_cids, [watchedCid])
+    }
+
+    func test_syncChannelsEvents_whenFallbackRefreshFails_returnsRetryableError() throws {
+        let eventNotificationCenter = EventNotificationCenter_Mock(database: database)
+        let policy = SyncEventReplayPolicy(maximumEventCount: 1)
+        repository = SyncRepository(
+            config: client.config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater,
+            eventReplayPolicy: policy
+        )
+
+        let cid = ChannelId.unique
+        let lastSyncDate = Date().addingTimeInterval(-3600)
+        try prepareForSyncLocalStorage(
+            createUser: true,
+            lastSynchedEventDate: lastSyncDate,
+            createChannel: true,
+            cid: cid
+        )
+
+        let channelController = ChatChannelController_Mock.mock(
+            channelQuery: .init(cid: cid),
+            channelListQuery: nil,
+            client: client
+        )
+        channelController.mockCid = cid
+        repository.startTrackingChannelController(channelController)
+        channelListUpdater.startWatchingChannels_completion_success = false
+
+        let expectation = expectation(description: "syncChannelsEvents")
+        var receivedResult: Result<[ChannelId], SyncError>?
+        repository.syncChannelsEvents(
+            channelIds: [cid],
+            lastSyncAt: lastSyncDate,
+            isRecovery: false
+        ) { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+
+        apiClient.waitForRequest()
+        let callback = try XCTUnwrap(apiClient.request_completion as? (Result<MissingEventsPayload, Error>) -> Void)
+        callback(.success(messageEventPayload(cid: cid, with: [Date.unique, Date.unique])))
+
+        let refreshCompletion = try XCTUnwrap(channelListUpdater.startWatchingChannels_completion)
+        refreshCompletion(ClientError("failed"))
+
+        waitForExpectations(timeout: defaultTimeout)
+
+        guard case .failure(let error) = receivedResult else {
+            return XCTFail("Expected failure")
+        }
+        XCTAssertEqual(error.shouldRetry, true)
+        XCTAssertEqual(lastSyncAtValue, lastSyncDate)
+        XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
+    }
+
+    func test_syncChannelsEvents_whenFallbackWithNoWatchedChannels_updatesLastSyncAt() throws {
+        let eventNotificationCenter = EventNotificationCenter_Mock(database: database)
+        let policy = SyncEventReplayPolicy(maximumEventCount: 1)
+        repository = SyncRepository(
+            config: client.config,
+            offlineRequestsRepository: offlineRequestsRepository,
+            eventNotificationCenter: eventNotificationCenter,
+            database: database,
+            apiClient: apiClient,
+            channelListUpdater: channelListUpdater,
+            eventReplayPolicy: policy
+        )
+
+        let cid = ChannelId.unique
+        let lastSyncDate = Date().addingTimeInterval(-3600)
+        try prepareForSyncLocalStorage(
+            createUser: true,
+            lastSynchedEventDate: lastSyncDate,
+            createChannel: true,
+            cid: cid
+        )
+
+        let eventDates = [Date.unique, Date.unique]
+        let result = waitForSyncChannelsEvents(
+            channelIds: [cid],
+            lastSyncAt: lastSyncDate,
+            requestResult: .success(messageEventPayload(cid: cid, with: eventDates))
+        )
+
+        XCTAssertEqual(try XCTUnwrap(result.get()), [])
+        XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 0)
+        XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
+        XCTAssertEqual(lastSyncAtValue, eventDates.last)
+    }
+
     // MARK: - Queue offline requests
 
     func test_queueOfflineRequest_localStorageDisabled() {
@@ -754,6 +1027,38 @@ extension SyncRepository_Tests {
 
         waitForExpectations(timeout: defaultTimeout, handler: nil)
         XCTAssertCall("exitRecoveryMode()", on: apiClient)
+    }
+
+    @discardableResult
+    func waitForSyncChannelsEvents(
+        channelIds: [ChannelId],
+        lastSyncAt: Date,
+        alreadySyncedChannelIds: Set<ChannelId> = [],
+        requestResult: Result<MissingEventsPayload, Error>
+    ) -> Result<[ChannelId], SyncError> {
+        apiClient.clear()
+
+        let expectation = expectation(description: "syncChannelsEvents")
+        var receivedResult: Result<[ChannelId], SyncError>!
+        repository.syncChannelsEvents(
+            channelIds: channelIds,
+            lastSyncAt: lastSyncAt,
+            isRecovery: false,
+            alreadySyncedChannelIds: alreadySyncedChannelIds
+        ) { result in
+            receivedResult = result
+            expectation.fulfill()
+        }
+
+        apiClient.waitForRequest()
+        guard let callback = apiClient.request_completion as? (Result<MissingEventsPayload, Error>) -> Void else {
+            XCTFail("A request for /sync should have been executed")
+            return .failure(.failedFetchingChannels)
+        }
+        callback(requestResult)
+
+        waitForExpectations(timeout: defaultTimeout)
+        return receivedResult
     }
 
     private class CancelRecoveryFlowTracker: SyncRepository, @unchecked Sendable {


### PR DESCRIPTION
### 🔗 Issue Links

- https://linear.app/stream/issue/IOS-1928/performance-bail-out-of-oversized-sync-event-replay-and-refresh
- Spec: https://app.notion.com/p/stream-wiki/Sync-events-limit-3666a5d7f9f6801f97ecc1461fc62049

### 🎯 Goal

When reconnect recovery receives a large `/sync` response, skip expensive event replay and refresh actively watched channel state via `queryChannels` instead, so oversized payloads do not stall local persistence/state updates.

### 📝 Summary

- Add injectable `SyncEventReplayPolicy` (default threshold: 250 events; wired from internal `ChatClientConfig.syncEventReplayMaximumEventCount`)
- Skip `/sync` event replay when the payload exceeds the threshold, or when `/sync` returns HTTP 400 too-many-events
- Fall back to `queryChannels` for active watched channels not already refreshed by channel lists
- Improve `.offlineSupport` logs around `/sync` skip / fallback decisions

### 🛠 Implementation

After decoding a `/sync` response, compare `eventPayloads.count` to `SyncEventReplayPolicy.maximumEventCount` before calling `eventNotificationCenter.process`.

If the payload is oversized (or `/sync` returns HTTP 400), run `refreshActiveWatchedChannels(excluding:)` which batches `ChannelListUpdater.startWatchingChannels(withIds:)` for active watched CIDs, marks successfully refreshed IDs as synced, and advances `lastSyncAt` so the same oversized payload is not retried forever.

Channel lists are intentionally not part of this fallback: reconnect already refreshes them via `RefreshChannelListOperation` / grouped sync, and those CIDs are passed as `alreadySyncedChannelIds`.

#### Fallback flow

```mermaid
flowchart TD
  A["/sync response"] --> B{Success?}
  B -->|Yes| C{"eventCount > threshold?"}
  B -->|No 400| D[Fallback path]
  C -->|No| E[Replay events as today]
  C -->|Yes| D
  D --> F["refreshActiveWatchedChannels(excluding alreadySynced)"]
  F --> G[Update lastSyncAt]
  G --> H["Return refreshed CIDs → mark synced"]
  E --> I["lastSyncAt = last event date"]
  I --> J["Return requested CIDs"]
```

### 🎨 Showcase

N/A — LLC reconnect recovery behavior.

### 🧪 Manual Testing Notes

Airplane mode / network toggles often don't produce a useful `/sync` gap in DemoApp testing. Use the avatar disconnect flow instead.

The threshold is **not** exposed in DemoApp (config is internal). To force the fallback path while testing, temporarily lower the default (e.g. `SyncEventReplayPolicy.default` / `ChatClientConfig.syncEventReplayMaximumEventCount` to `0` or `1`) and restore before merging. Also enable `.offlineSupport` info logs and ensure local storage is enabled.

1. Apply a temporary low threshold as above
2. Log in and open a channel that is **not** covered by the current channel-list refresh (otherwise reconnect refreshes it via `queryChannels` and `/sync` returns 0 events / is skipped)
3. Tap the **user avatar** → **Disconnect** (this reliably triggers reconnect recovery)
4. On another device/client, generate activity in that same channel (messages/reactions)
5. Log back in on DemoApp
6. Confirm logs show a non-empty `/sync` payload and, when over threshold, skip/fallback:
   - `Received /sync payload with N event(s)...`
   - `Skipping event replay...` / `Running /sync fallback via queryChannels...`
7. Confirm the open/watched channel UI stays up to date after login
8. Revert any temporary threshold / log changes before merge

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for replaying synchronization events, helping maintain responsive sync performance.

* **Performance**
  * Oversized sync event replays are now skipped and replaced with refreshed watched-channel data, improving reliability during high-activity periods.
  * Sync recovery now refreshes watched channels in manageable batches and provides clearer handling when recovery cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->