### PR TITLE
Fix double slash handling in some of the endpoint paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ⚡️ Performance
 - Skip oversized `/sync` event replay and refresh watched channels via `queryChannels` instead [#4189](https://github.com/GetStream/stream-chat-swift/pull/4189)
 
+### 🐞 Fixed
+- Fix double slash handling in some of the endpoint paths [#4191](https://github.com/GetStream/stream-chat-swift/pull/4191) 
+
 ## StreamChatCommonUI
 ### ✅ Added
 - Add `StreamImageDownloader` for downloading and caching images [#4171](https://github.com/GetStream/stream-chat-swift/pull/4171)

--- a/Scripts/openapi_generate.sh
+++ b/Scripts/openapi_generate.sh
@@ -461,6 +461,7 @@ inject_v1_endpoint_paths() {
   trap 'rm -f "$cases_file" "$values_file"' RETURN
 
   cat > "$cases_file" <<'EOF'
+    case custom(String)
     case connect
     case sync
     case users
@@ -529,6 +530,7 @@ inject_v1_endpoint_paths() {
 EOF
 
   cat > "$values_file" <<'EOF'
+        case let .custom(path): return path
         case .connect: return "connect"
         case .sync: return "sync"
         case .users: return "users"

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
@@ -24,6 +24,7 @@ extension EndpointPath {
              .channels,
              .channelUpdate,
              .connect,
+             .custom,
              .createCall,
              .createChannel,
              .createDevice,

--- a/Sources/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder.swift
@@ -222,8 +222,10 @@ class DefaultRequestEncoder: RequestEncoder, @unchecked Sendable {
         guard var url = urlComponents.url else {
             throw ClientError.InvalidURL("URL can't be created using components: \(urlComponents)")
         }
+        
+        let endpointPath = String(endpoint.path.value.drop(while: { $0 == "/" }))
+        url = url.appendingPathComponent(endpointPath)
 
-        url = url.appendingPathComponent(endpoint.path.value)
         return url
     }
 

--- a/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 enum EndpointPath: Codable {
+    case custom(String)
     case connect
     case sync
     case users
@@ -139,6 +140,7 @@ enum EndpointPath: Codable {
 
     var value: String {
         switch self {
+        case let .custom(path): return path
         case .connect: return "connect"
         case .sync: return "sync"
         case .users: return "users"

--- a/Sources/StreamChat/Generated/OpenAPI/models/PushPreferenceInput.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PushPreferenceInput.swift
@@ -24,7 +24,7 @@ final class PushPreferenceInput: Sendable, Codable, JSONEncodable {
             }
         }
     }
-
+    
     /// Set the push preferences for a specific channel. If empty it sets the default for the user
     let channelCid: String?
     /// Set the level of chat push notifications for the user. Note: "mentions" is deprecated in favor of "direct_mentions". One of: all, mentions, direct_mentions, all_mentions, none, default

--- a/Sources/StreamChat/Query/ChannelQuery.swift
+++ b/Sources/StreamChat/Query/ChannelQuery.swift
@@ -29,7 +29,7 @@ public struct ChannelQuery: Encodable, Sendable {
     /// Top-level keys of the message author's channel-member `custom` to project onto `message.member`.
     ///
     /// When `nil` or empty, the option is omitted and the response is unchanged.
-    public var memberCustomInclude: [String]? = nil
+    public var memberCustomInclude: [String]?
     /// ChannelCreatePayload that is needed only when creating channel
     let channelPayload: ChannelEditDetailPayload?
     /// A pagination for members for the channel to be retrieved.

--- a/Tests/StreamChatTests/APIClient/Endpoints/EndpointPath_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/EndpointPath_Tests.swift
@@ -196,6 +196,7 @@ final class EndpointPathTests: XCTestCase {
     // MARK: - Codable
 
     func test_isProperlyEncodedAndDecoded() throws {
+        assertResultEncodingAndDecoding(.custom("/custom-path"))
         assertResultEncodingAndDecoding(.connect)
         assertResultEncodingAndDecoding(.sync)
         assertResultEncodingAndDecoding(.users)

--- a/Tests/StreamChatTests/APIClient/RequestEncoder_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/RequestEncoder_Tests.swift
@@ -337,6 +337,36 @@ final class RequestEncoder_Tests: XCTestCase {
         XCTAssertEqual(urlComponenets.queryItems?["stringValue"], testStringValue)
     }
 
+    func test_encodingRequestURL_normalizesBaseURLAndEndpointPathSlashes() throws {
+        let testCases = [
+            (baseURL: "https://example.com", endpointPath: "path", expectedURL: "https://example.com/path"),
+            (baseURL: "https://example.com/", endpointPath: "path", expectedURL: "https://example.com/path"),
+            (baseURL: "https://example.com", endpointPath: "/path", expectedURL: "https://example.com/path"),
+            (baseURL: "https://example.com/", endpointPath: "/path", expectedURL: "https://example.com/path"),
+            (baseURL: "https://example.com/", endpointPath: "//path", expectedURL: "https://example.com/path")
+        ]
+
+        for testCase in testCases {
+            let encoder = DefaultRequestEncoder(
+                baseURL: try XCTUnwrap(URL(string: testCase.baseURL)),
+                apiKey: apiKey
+            )
+            let endpoint = Endpoint<Data>(
+                path: .custom(testCase.endpointPath),
+                method: .get,
+                requiresConnectionId: false,
+                requiresToken: false
+            )
+
+            let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                "\(testCase.expectedURL)?api_key=\(apiKey.apiKeyString)"
+            )
+        }
+    }
+
     func test_encodingRequestBody_POST() throws {
         // Prepare a POST endpoint with JSON body
         let endpoint = Endpoint<Data>(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1936](https://linear.app/stream/issue/IOS-1936)

### 🎯 Goal

Some endpoint paths start with `/` and creates 

### 📝 Summary

* Handle double slash handling on iOS 18 and lower (newer OS versions handle it automatically)

### 🛠 Implementation

Trim leading slashes from API paths

### 🎨 Showcase

### 🧪 Manual Testing Notes

Run demo app with iOS 18 simulator, observe that API calls succeed.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request URL construction to prevent duplicate slashes between the base URL and endpoint paths.
  * Added support for custom endpoint paths.
  * Prevented custom endpoints from being queued for offline processing.
* **Tests**
  * Added coverage for custom endpoint encoding and URL normalization across varied slash formats.
* **Documentation**
  * Updated the changelog with the endpoint path correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->