### PR TITLE
Add colors for chat thread connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+## StreamChatCommonUI
+### ✅ Added
+- Add `chatThreadConnectorIncoming` and `chatThreadConnectorOutgoing` colors for customizing the thread connector [#4195](https://github.com/GetStream/stream-chat-swift/pull/4195)
+
 # [5.8.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.8.0)
 _August 03, 2026_
 

--- a/Sources/StreamChatCommonUI/Appearance+ColorPalette.swift
+++ b/Sources/StreamChatCommonUI/Appearance+ColorPalette.swift
@@ -270,6 +270,10 @@ public extension Appearance {
         public lazy var chatPollProgressTrackIncoming: UIColor = controlProgressBarTrack
         /// Poll progress bar track color in outgoing messages.
         public lazy var chatPollProgressTrackOutgoing: UIColor = brand200
+        /// Color for the chat thread connector for incoming messages.
+        public lazy var chatThreadConnectorIncoming: UIColor = borderCoreDefault
+        /// Color for the chat thread connector for outgoing messages.
+        public lazy var chatThreadConnectorOutgoing: UIColor = brand150
 
         // MARK: - Control
 

--- a/Sources/StreamChatCommonUI/Appearance+ColorPalette.swift
+++ b/Sources/StreamChatCommonUI/Appearance+ColorPalette.swift
@@ -270,9 +270,9 @@ public extension Appearance {
         public lazy var chatPollProgressTrackIncoming: UIColor = controlProgressBarTrack
         /// Poll progress bar track color in outgoing messages.
         public lazy var chatPollProgressTrackOutgoing: UIColor = brand200
-        /// Color for the chat thread connector for incoming messages.
+        /// Color for the chat thread connector for incoming messages. Used in the SwiftUI SDK only.
         public lazy var chatThreadConnectorIncoming: UIColor = borderCoreDefault
-        /// Color for the chat thread connector for outgoing messages.
+        /// Color for the chat thread connector for outgoing messages. Used in the SwiftUI SDK only.
         public lazy var chatThreadConnectorOutgoing: UIColor = brand150
 
         // MARK: - Control


### PR DESCRIPTION
### 🔗 Issue Links

Needed for https://linear.app/stream/issue/IOS-1919/v5-ui-polish-thread-indicator-uses-wrong-text-and-connector-tokens.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable color options for incoming and outgoing chat thread connectors.
  * Incoming connectors use the default border color, while outgoing connectors use the brand color by default.
  * Available for SwiftUI SDK styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->