### PR TITLE
Fix flaky date assertions in SyncRepository_Tests

### DIFF
--- a/TestTools/StreamChatTestTools/Assertions/AssertDate.swift
+++ b/TestTools/StreamChatTestTools/Assertions/AssertDate.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 public func XCTAssertNearlySameDate(_ lhs: Date, _ rhs: Date, file: StaticString = #filePath, line: UInt = #line) {
-    XCTAssertTrue(lhs.isNearlySameDate(as: rhs))
+    XCTAssertTrue(lhs.isNearlySameDate(as: rhs), "\(lhs) is not nearly the same date as \(rhs)", file: file, line: line)
 }
 
 public func XCTAssertNearlySameDate(_ lhs: Date?, _ rhs: Date?, file: StaticString = #filePath, line: UInt = #line) {

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -182,7 +182,7 @@ class SyncRepository_Tests: XCTestCase {
         waitForSyncLocalStateRun(requestResult: .success(messageEventPayload(cid: cid, with: [eventDate])))
 
         // Should use first event's created at date
-        XCTAssertEqual(lastSyncAtValue, eventDate)
+        XCTAssertNearlySameDate(lastSyncAtValue, eventDate)
         // Write: API Response, lastSyncAt
         XCTAssertEqual(database.writeSessionCounter, 2)
         XCTAssertEqual(repository.activeChannelControllers.count, 1)
@@ -213,7 +213,7 @@ class SyncRepository_Tests: XCTestCase {
         waitForSyncLocalStateRun(requestResult: .success(messageEventPayload(cid: cid, with: [eventDate])))
 
         // Should use first event's created at date
-        XCTAssertEqual(lastSyncAtValue, eventDate)
+        XCTAssertNearlySameDate(lastSyncAtValue, eventDate)
         // Write: API Response, lastSyncAt
         XCTAssertEqual(database.writeSessionCounter, 2)
         XCTAssertEqual(repository.activeChannelControllers.count, 0)
@@ -507,7 +507,7 @@ class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(result.get()), [cid])
         XCTAssertEqual(eventNotificationCenter.mock_processCalledWithEvents.count, 2)
         XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 0)
-        XCTAssertEqual(lastSyncAtValue, eventDates.last)
+        XCTAssertNearlySameDate(lastSyncAtValue, eventDates.last)
     }
 
     func test_syncChannelsEvents_whenEventCountExceedsPolicy_skipsReplayAndRefreshesWatchedChannels() throws {
@@ -552,7 +552,7 @@ class SyncRepository_Tests: XCTestCase {
         XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
         XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 1)
         XCTAssertEqual(channelListUpdater.startWatchingChannels_cids, [cid])
-        XCTAssertEqual(lastSyncAtValue, eventDates.last)
+        XCTAssertNearlySameDate(lastSyncAtValue, eventDates.last)
     }
 
     func test_syncChannelsEvents_whenTooManyEvents400_refreshesWatchedChannels() throws {
@@ -707,7 +707,7 @@ class SyncRepository_Tests: XCTestCase {
             return XCTFail("Expected failure")
         }
         XCTAssertEqual(error.shouldRetry, true)
-        XCTAssertEqual(lastSyncAtValue, lastSyncDate)
+        XCTAssertNearlySameDate(lastSyncAtValue, lastSyncDate)
         XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
     }
 
@@ -743,7 +743,7 @@ class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(result.get()), [])
         XCTAssertEqual(channelListUpdater.startWatchingChannels_callCount, 0)
         XCTAssertTrue(eventNotificationCenter.mock_processCalledWithEvents.isEmpty)
-        XCTAssertEqual(lastSyncAtValue, eventDates.last)
+        XCTAssertNearlySameDate(lastSyncAtValue, eventDates.last)
     }
 
     // MARK: - Queue offline requests


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1946](https://linear.app/stream/issue/IOS-1946/fix-flaky-date-assertions-in-syncrepository-tests)

### 🎯 Goal

Stop `SyncRepository_Tests` from failing intermittently on date comparisons.

### 📝 Summary

- Use `XCTAssertNearlySameDate` for the six exact `lastSyncAt` date comparisons in `SyncRepository_Tests`
- Forward `file`/`line` from `XCTAssertNearlySameDate` so failures point at the call site

### 🛠 Implementation

`lastSyncAtValue` reads `currentUser.lastSynchedEventDate` back out of Core Data, so the value has round-tripped through `DBDate`/`bridgeDate` and lost sub-microsecond precision. Comparing it to the in-memory seed with `XCTAssertEqual` therefore only passes when the seed's fractional part happens to survive the round trip:

```
test_syncChannelsEvents_whenFallbackRefreshFails_returnsRetryableError
Found difference for timeIntervalSinceReferenceDate:
  Received: 807620408.004376
  Expected: 807620408.0043759
```

Because the seeds are live or random timestamps (`Date.unique`, `Date().addingTimeInterval(-3600)`), the outcome varies run to run. Two assertions in this same file already used `XCTAssertNearlySameDate` (±0.01s tolerance), so this applies the same helper to the remaining six rather than introducing a new pattern.

`XCTAssertNearlySameDate` accepted `file`/`line` but never passed them to `XCTAssertTrue`, so a failure was reported inside `AssertDate.swift` instead of the failing test. Now that eight assertions in this file depend on the helper, it also forwards them and includes both dates in the message.

### 🧪 Manual Testing Notes

Test-only change. `SyncRepository_Tests` ran 15 consecutive times with 0 failures (35 tests per run).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date assertion failures by showing the correct failure message and source location.
  * Updated synchronization timestamp tests to allow for negligible timing differences, reducing false test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->