### PR TITLE
OpenAPI: Migrate delete channel endpoint to v2

### DIFF
--- a/Scripts/openapi_generate.sh
+++ b/Scripts/openapi_generate.sh
@@ -18,6 +18,7 @@ allowed_endpoints=(
     createPoll
     createPollOption
     createUserGroup
+    deleteChannel
     deleteChannelFile
     deleteChannelImage
     deleteDevice
@@ -73,6 +74,7 @@ allowed_models=(
   CreatePollOptionRequest
   CreatePollRequest
   CreateUserGroupRequest
+  DeleteChannelResponse
   DeliveredMessagePayload
   DeviceResponse
   Field
@@ -468,6 +470,7 @@ remove_property UserPayload blockedUserIds
 remove_property SharedLocation channel
 remove_property SharedLocation message
 remove_property SharedLocationsResponse duration
+remove_property DeleteChannelResponse duration
 remove_property MutedChannelPayloadResponse channelMutes
 remove_property MutedChannelPayloadResponse duration
 remove_property MutedChannelPayloadResponse ownUser
@@ -574,7 +577,6 @@ inject_v1_endpoint_paths() {
     case groupedChannels
     case createChannel(String)
     case updateChannel(String)
-    case deleteChannel(String)
     case channelUpdate(String)
     case showChannel(String, Bool)
     case truncateChannel(String)
@@ -635,7 +637,6 @@ EOF
         case .groupedChannels: return "channels/grouped"
         case let .createChannel(queryString): return "channels/\(queryString)/query"
         case let .updateChannel(queryString): return "channels/\(queryString)/query"
-        case let .deleteChannel(payloadPath): return "channels/\(payloadPath)"
         case let .channelUpdate(payloadPath): return "channels/\(payloadPath)"
         case let .showChannel(channelId, show): return "channels/\(channelId)/\(show ? "show" : "hide")"
         case let .truncateChannel(channelId): return "channels/\(channelId)/truncate"

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -82,16 +82,6 @@ extension Endpoint {
         )
     }
     
-    static func deleteChannel(cid: ChannelId) -> Endpoint<EmptyResponse> {
-        .init(
-            path: .deleteChannel(cid.apiPath),
-            method: .delete,
-            queryItems: nil,
-            requiresConnectionId: false,
-            body: nil
-        )
-    }
-
     static func truncateChannel(
         cid: ChannelId,
         skipPush: Bool,

--- a/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
@@ -21,7 +21,6 @@ enum EndpointPath: Codable {
     case groupedChannels
     case createChannel(String)
     case updateChannel(String)
-    case deleteChannel(String)
     case channelUpdate(String)
     case showChannel(
         String,
@@ -75,6 +74,10 @@ enum EndpointPath: Codable {
     case createPoll
     case createPollOption(pollId: String)
     case createUserGroup
+    case deleteChannel(
+        type: String,
+        id: String
+    )
     case deleteChannelFile(
         type: String,
         id: String
@@ -157,7 +160,6 @@ enum EndpointPath: Codable {
         case .groupedChannels: return "channels/grouped"
         case let .createChannel(queryString): return "channels/\(queryString)/query"
         case let .updateChannel(queryString): return "channels/\(queryString)/query"
-        case let .deleteChannel(payloadPath): return "channels/\(payloadPath)"
         case let .channelUpdate(payloadPath): return "channels/\(payloadPath)"
         case let .showChannel(
             channelId,
@@ -215,6 +217,11 @@ enum EndpointPath: Codable {
             return "/api/v2/polls/\(APIHelper.escapedPathItem(pollId))/options"
         case .createUserGroup:
             return "/api/v2/usergroups"
+        case let .deleteChannel(
+            type: type,
+            id: id
+        ):
+            return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))"
         case let .deleteChannelFile(
             type: type,
             id: id
@@ -522,6 +529,26 @@ extension Endpoint {
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
             body: createUserGroupRequest
+        )
+    }
+
+    static func deleteChannel(
+        type: String,
+        id: String,
+        hardDelete: Bool?,
+        requiresConnectionId: Bool = false
+    ) -> Endpoint<DeleteChannelResponse> {
+        return .init(
+            path: .deleteChannel(
+                type: type,
+                id: id
+            ),
+            method: .delete,
+            queryItems: APIHelper.mapValuesToQueryDictionary([
+                "hard_delete": hardDelete
+            ]),
+            requiresConnectionId: requiresConnectionId,
+            body: nil
         )
     }
 

--- a/Sources/StreamChat/Generated/OpenAPI/models/DeleteChannelResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/DeleteChannelResponse.swift
@@ -1,0 +1,17 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+final class DeleteChannelResponse: Sendable, Codable, JSONEncodable {
+    let channel: ChannelDetailPayload?
+
+    init(channel: ChannelDetailPayload? = nil) {
+        self.channel = channel
+    }
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case channel
+    }
+}

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -272,12 +272,14 @@ class ChannelUpdater: Worker, @unchecked Sendable {
     ///   - cid: The channel identifier.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func deleteChannel(cid: ChannelId, completion: (@Sendable (Error?) -> Void)? = nil) {
-        apiClient.request(endpoint: .deleteChannel(cid: cid)) { [weak self] result in
+        apiClient.request(
+            endpoint: .deleteChannel(type: cid.type.rawValue, id: cid.id, hardDelete: nil)
+        ) { [weak self] result in
             switch result {
-            case .success:
-                self?.database.write {
-                    if let channel = $0.channel(cid: cid) {
-                        channel.truncatedAt = channel.lastMessageAt ?? channel.createdAt
+            case let .success(payload):
+                self?.database.write { session in
+                    if let channelPayload = payload.channel {
+                        try session.saveChannel(payload: channelPayload, query: nil, cache: nil)
                     }
                 } completion: { error in
                     completion?(error)

--- a/TestTools/StreamChatTestTools/Extensions/EndpoinPath+Equatable.swift
+++ b/TestTools/StreamChatTestTools/Extensions/EndpoinPath+Equatable.swift
@@ -21,7 +21,7 @@ extension EndpointPath: @retroactive Equatable {
         case (.channels, .channels): return true
         case let (.createChannel(string1), .createChannel(string2)): return string1 == string2
         case let (.updateChannel(string1), .updateChannel(string2)): return string1 == string2
-        case let (.deleteChannel(string1), .deleteChannel(string2)): return string1 == string2
+        case let (.deleteChannel(type1, id1), .deleteChannel(type2, id2)): return type1 == type2 && id1 == id2
         case let (.channelUpdate(string1), .channelUpdate(string2)): return string1 == string2
         case let (.showChannel(string1, bool1), .showChannel(string2, bool2)): return string1 == string2 && bool1 == bool2
         case let (.truncateChannel(string1), .truncateChannel(string2)): return string1 == string2

--- a/TestTools/StreamChatTestTools/TestData/DummyData/DeleteChannelResponse+Dummy.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/DeleteChannelResponse+Dummy.swift
@@ -1,0 +1,16 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+extension DeleteChannelResponse {
+    static func dummy(
+        channel: ChannelDetailPayload? = .dummy()
+    ) -> DeleteChannelResponse {
+        DeleteChannelResponse(
+            channel: channel
+        )
+    }
+}

--- a/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -165,25 +165,6 @@ final class ChannelEndpoints_Tests: XCTestCase {
         XCTAssertEqual(expectedEndpoint.method, endpoint.method)
     }
 
-    func test_deleteChannel_buildsCorrectly() {
-        let cid = ChannelId.unique
-
-        let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: .deleteChannel(cid.apiPath),
-            method: .delete,
-            queryItems: nil,
-            requiresConnectionId: false,
-            body: nil
-        )
-
-        // Build endpoint
-        let endpoint: Endpoint<EmptyResponse> = .deleteChannel(cid: cid)
-
-        // Assert endpoint is built correctly
-        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
-        XCTAssertEqual("channels/\(cid.type.rawValue)/\(cid.id)", endpoint.path.value)
-    }
-
     func test_truncateChannel_buildsCorrectly() {
         let cid = ChannelId.unique
         let skipPush = false

--- a/Tests/StreamChatTests/APIClient/Endpoints/EndpointPath_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/EndpointPath_Tests.swift
@@ -39,7 +39,7 @@ final class EndpointPathTests: XCTestCase {
     }
 
     func test_deleteChannel_shouldNOTBeQueuedOffline() {
-        XCTAssertFalse(EndpointPath.deleteChannel("").shouldBeQueuedOffline)
+        XCTAssertFalse(EndpointPath.deleteChannel(type: "", id: "").shouldBeQueuedOffline)
     }
 
     func test_banMember_shouldNOTBeQueuedOffline() {
@@ -223,7 +223,7 @@ final class EndpointPathTests: XCTestCase {
         assertResultEncodingAndDecoding(.channels)
         assertResultEncodingAndDecoding(.createChannel("channel_idc"))
         assertResultEncodingAndDecoding(.updateChannel("channel_idu"))
-        assertResultEncodingAndDecoding(.deleteChannel("channel_idd"))
+        assertResultEncodingAndDecoding(.deleteChannel(type: "messaging", id: "channel_idd"))
         assertResultEncodingAndDecoding(.channelUpdate("channel_idq"))
         assertResultEncodingAndDecoding(.showChannel("channel_id", false))
         assertResultEncodingAndDecoding(.truncateChannel("channel_idq"))

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -1225,7 +1225,11 @@ final class ChannelUpdater_Tests: XCTestCase {
         channelUpdater.deleteChannel(cid: channelID)
 
         // Assert correct endpoint is called
-        let referenceEndpoint: Endpoint<EmptyResponse> = .deleteChannel(cid: channelID)
+        let referenceEndpoint: Endpoint<DeleteChannelResponse> = .deleteChannel(
+            type: channelID.type.rawValue,
+            id: channelID.id,
+            hardDelete: nil
+        )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
 
@@ -1241,7 +1245,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         XCTAssertFalse(completionCalled)
 
         // Simulate API response with success
-        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+        apiClient.test_simulateResponse(Result<DeleteChannelResponse, Error>.success(.dummy()))
 
         // Assert completion is called
         AssertAsync.willBeTrue(completionCalled)
@@ -1254,7 +1258,7 @@ final class ChannelUpdater_Tests: XCTestCase {
 
         // Simulate API response with failure
         let error = TestError()
-        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+        apiClient.test_simulateResponse(Result<DeleteChannelResponse, Error>.failure(error))
 
         // Assert the completion is called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1843](https://linear.app/stream/issue/IOS-1843)

> [!IMPORTANT]
> Based on the `open-api-mute-channel` branch which brings in channel data

### 🎯 Goal

Migrate delete channel endpoint to v2 and save returned channel data to update `truncatedAt` (soft delete)

### 📝 Summary

* Use v2 endpoint and response payload
* Update `truncateAt` with response payload

### 🛠 Implementation

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

1. Create a channel
2. Delete the channel, result: channel disappears from the channel list

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel deletion handling by processing the server’s returned channel data.
  * Removed legacy channel-deletion routing.
  * Removed the obsolete deletion duration field from API responses.

* **Tests**
  * Updated channel deletion coverage for the revised response format and endpoint parameters.
  * Updated offline queue and serialization checks for channel deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->