### PR TITLE
OpenAPI: Remove server-side only userid arguments from endpoints

### DIFF
--- a/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
@@ -603,15 +603,12 @@ extension Endpoint {
 
     static func deletePoll(
         pollId: String,
-        userId: String?,
         requiresConnectionId: Bool = false
     ) -> Endpoint<EmptyResponse> {
         return .init(
             path: .deletePoll(pollId: pollId),
             method: .delete,
-            queryItems: APIHelper.mapValuesToQueryDictionary([
-                "user_id": userId
-            ]),
+            queryItems: nil,
             requiresConnectionId: requiresConnectionId,
             body: nil
         )
@@ -621,7 +618,6 @@ extension Endpoint {
         messageId: String,
         pollId: String,
         voteId: String,
-        userId: String?,
         requiresConnectionId: Bool = false
     ) -> Endpoint<PollVotePayloadResponse> {
         return .init(
@@ -631,9 +627,7 @@ extension Endpoint {
                 voteId: voteId
             ),
             method: .delete,
-            queryItems: APIHelper.mapValuesToQueryDictionary([
-                "user_id": userId
-            ]),
+            queryItems: nil,
             requiresConnectionId: requiresConnectionId,
             body: nil
         )
@@ -767,16 +761,13 @@ extension Endpoint {
 
     static func queryPollVotes(
         pollId: String,
-        userId: String?,
         queryPollVotesRequest: QueryPollVotesRequestBody,
         requiresConnectionId: Bool = false
     ) -> Endpoint<PollVoteListResponse> {
         return .init(
             path: .queryPollVotes(pollId: pollId),
             method: .post,
-            queryItems: APIHelper.mapValuesToQueryDictionary([
-                "user_id": userId
-            ]),
+            queryItems: nil,
             requiresConnectionId: requiresConnectionId,
             body: queryPollVotesRequest
         )

--- a/Sources/StreamChat/Generated/OpenAPI/models/ChannelMemberResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/ChannelMemberResponse.swift
@@ -8,6 +8,8 @@ final class ChannelMemberResponse: Sendable, Codable, JSONEncodable {
     let archivedAt: Date?
     /// Expiration date of the ban
     let banExpires: Date?
+    /// Whether the member's ban also applies to channels the channel's creator will create in the future (an active future channel ban by the creator targets this member)
+    let banFromFutureChannels: Bool?
     /// Whether member is banned this channel or not
     let banned: Bool
     /// Role of the member in the channel
@@ -17,6 +19,8 @@ final class ChannelMemberResponse: Sendable, Codable, JSONEncodable {
     let custom: [String: RawJSON]
     let deletedAt: Date?
     let deletedMessages: [String]?
+    /// Expiration date of the future channel ban; absent when the future channel ban is permanent
+    let futureChannelBanExpires: Date?
     /// Date when invite was accepted
     let inviteAcceptedAt: Date?
     /// Date when invite was rejected
@@ -40,12 +44,14 @@ final class ChannelMemberResponse: Sendable, Codable, JSONEncodable {
     init(
         archivedAt: Date? = nil,
         banExpires: Date? = nil,
+        banFromFutureChannels: Bool? = nil,
         banned: Bool,
         channelRole: String,
         createdAt: Date,
         custom: [String: RawJSON],
         deletedAt: Date? = nil,
         deletedMessages: [String]? = nil,
+        futureChannelBanExpires: Date? = nil,
         inviteAcceptedAt: Date? = nil,
         inviteRejectedAt: Date? = nil,
         invited: Bool? = nil,
@@ -61,12 +67,14 @@ final class ChannelMemberResponse: Sendable, Codable, JSONEncodable {
     ) {
         self.archivedAt = archivedAt
         self.banExpires = banExpires
+        self.banFromFutureChannels = banFromFutureChannels
         self.banned = banned
         self.channelRole = channelRole
         self.createdAt = createdAt
         self.custom = custom
         self.deletedAt = deletedAt
         self.deletedMessages = deletedMessages
+        self.futureChannelBanExpires = futureChannelBanExpires
         self.inviteAcceptedAt = inviteAcceptedAt
         self.inviteRejectedAt = inviteRejectedAt
         self.invited = invited
@@ -84,12 +92,14 @@ final class ChannelMemberResponse: Sendable, Codable, JSONEncodable {
     enum CodingKeys: String, CodingKey, CaseIterable {
         case archivedAt = "archived_at"
         case banExpires = "ban_expires"
+        case banFromFutureChannels = "ban_from_future_channels"
         case banned
         case channelRole = "channel_role"
         case createdAt = "created_at"
         case custom
         case deletedAt = "deleted_at"
         case deletedMessages = "deleted_messages"
+        case futureChannelBanExpires = "future_channel_ban_expires"
         case inviteAcceptedAt = "invite_accepted_at"
         case inviteRejectedAt = "invite_rejected_at"
         case invited

--- a/Sources/StreamChat/Repositories/PollsRepository.swift
+++ b/Sources/StreamChat/Repositories/PollsRepository.swift
@@ -160,8 +160,7 @@ class PollsRepository: @unchecked Sendable {
                     endpoint: .deletePollVote(
                         messageId: messageId,
                         pollId: pollId,
-                        voteId: voteId,
-                        userId: nil
+                        voteId: voteId
                     )
                 ) { [weak self] in
                     if $0.error != nil, $0.error?.isBackendNotFound404StatusCode == false, exists {
@@ -205,7 +204,7 @@ class PollsRepository: @unchecked Sendable {
         completion: (@Sendable (Error?) -> Void)? = nil
     ) {
         apiClient.request(
-            endpoint: .deletePoll(pollId: pollId, userId: nil)
+            endpoint: .deletePoll(pollId: pollId)
         ) { [weak self] in
             if $0.error == nil {
                 self?.database.write { session in
@@ -240,7 +239,7 @@ class PollsRepository: @unchecked Sendable {
         completion: (@Sendable (Result<VotePaginationResponse, Error>) -> Void)? = nil
     ) {
         apiClient.request(
-            endpoint: .queryPollVotes(pollId: query.pollId, userId: nil, queryPollVotesRequest: query.toRequest())
+            endpoint: .queryPollVotes(pollId: query.pollId, queryPollVotesRequest: query.toRequest())
         ) { [weak self] (result: Result<PollVoteListResponse, Error>) in
             switch result {
             case let .success(payload):
@@ -278,7 +277,7 @@ class PollsRepository: @unchecked Sendable {
             sort: sort.isEmpty ? nil : sort
         )
         apiClient.request(
-            endpoint: .queryPollVotes(pollId: pollId, userId: nil, queryPollVotesRequest: request),
+            endpoint: .queryPollVotes(pollId: pollId, queryPollVotesRequest: request),
             completion: { [weak self] result in
                 guard let self else { return }
                 switch result {

--- a/Tests/StreamChatTests/APIClient/Endpoints/PollsEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/PollsEndpoints_Tests.swift
@@ -42,7 +42,7 @@ final class PollsEndpoints_Tests: XCTestCase {
     }
     
     func test_deletePoll() {
-        let endpoint = Endpoint<EmptyResponse>.deletePoll(pollId: "test", userId: nil)
+        let endpoint = Endpoint<EmptyResponse>.deletePoll(pollId: "test")
         
         XCTAssertEqual(endpoint.method, .delete)
         XCTAssertEqual(endpoint.path.value, "/api/v2/polls/test")
@@ -95,7 +95,6 @@ final class PollsEndpoints_Tests: XCTestCase {
         let request = QueryPollVotesRequestBody(limit: 30, prev: "10")
         let endpoint = Endpoint<PollVoteListResponse>.queryPollVotes(
             pollId: "test",
-            userId: nil,
             queryPollVotesRequest: request
         )
         
@@ -137,8 +136,7 @@ final class PollsEndpoints_Tests: XCTestCase {
         let endpoint = Endpoint<PollVotePayloadResponse>.deletePollVote(
             messageId: "message_id",
             pollId: "test",
-            voteId: "vote",
-            userId: nil
+            voteId: "vote"
         )
 
         XCTAssertEqual(endpoint.method, .delete)

--- a/Tests/StreamChatTests/Repositories/PollsRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/PollsRepository_Tests.swift
@@ -378,8 +378,7 @@ final class PollsRepository_Tests: XCTestCase {
         let referenceEndpoint: Endpoint<PollVotePayloadResponse> = .deletePollVote(
             messageId: messageId,
             pollId: pollId,
-            voteId: voteId,
-            userId: nil
+            voteId: voteId
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
         XCTAssertEqual(payload.optionId, pollOptionId)
@@ -421,8 +420,7 @@ final class PollsRepository_Tests: XCTestCase {
         let referenceEndpoint: Endpoint<PollVotePayloadResponse> = .deletePollVote(
             messageId: messageId,
             pollId: pollId,
-            voteId: voteId,
-            userId: nil
+            voteId: voteId
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
@@ -447,7 +445,6 @@ final class PollsRepository_Tests: XCTestCase {
         wait(for: [completionCalled], timeout: defaultTimeout)
         let referenceEndpoint: Endpoint<PollVoteListResponse> = .queryPollVotes(
             pollId: pollId,
-            userId: nil,
             queryPollVotesRequest: query.toRequest()
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
@@ -471,7 +468,6 @@ final class PollsRepository_Tests: XCTestCase {
         wait(for: [completionCalled], timeout: defaultTimeout)
         let referenceEndpoint: Endpoint<PollVoteListResponse> = .queryPollVotes(
             pollId: pollId,
-            userId: nil,
             queryPollVotesRequest: query.toRequest()
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
@@ -499,7 +495,7 @@ final class PollsRepository_Tests: XCTestCase {
         
         wait(for: [completionCalled], timeout: defaultTimeout)
         let referenceEndpoint: Endpoint<PollVoteListResponse> = .queryPollVotes(
-            pollId: pollId, userId: nil, queryPollVotesRequest: .init()
+            pollId: pollId, queryPollVotesRequest: .init()
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
         XCTAssertEqual(response.votes.count, 1)
@@ -526,7 +522,7 @@ final class PollsRepository_Tests: XCTestCase {
         
         wait(for: [completionCalled], timeout: defaultTimeout)
         let referenceEndpoint: Endpoint<PollVoteListResponse> = .queryPollVotes(
-            pollId: pollId, userId: nil, queryPollVotesRequest: .init()
+            pollId: pollId, queryPollVotesRequest: .init()
         )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
@@ -548,7 +544,7 @@ final class PollsRepository_Tests: XCTestCase {
         apiClient.test_simulateResponse(.success(emptyResponse))
         
         wait(for: [completionCalled], timeout: defaultTimeout)
-        let referenceEndpoint: Endpoint<EmptyResponse> = .deletePoll(pollId: pollId, userId: nil)
+        let referenceEndpoint: Endpoint<EmptyResponse> = .deletePoll(pollId: pollId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
     
@@ -567,7 +563,7 @@ final class PollsRepository_Tests: XCTestCase {
         apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
         
         wait(for: [completionCalled], timeout: defaultTimeout)
-        let referenceEndpoint: Endpoint<EmptyResponse> = .deletePoll(pollId: pollId, userId: nil)
+        let referenceEndpoint: Endpoint<EmptyResponse> = .deletePoll(pollId: pollId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1840](https://linear.app/stream/issue/IOS-1840)
Related: [CHA-4525](https://linear.app/stream/issue/CHA-4525)

### 🎯 Goal

OpenAPI generator was updated to skip userId (server-side only) in client side spec

### 📝 Summary

### 🛠 Implementation

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll deletion and vote management requests for more reliable API behavior.
  * Updated poll vote querying and removal flows to use the correct request parameters.

* **Tests**
  * Updated endpoint and repository coverage to validate poll operations under the revised request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->