### PR TITLE
[CI] Add verbose input to smoke and cron checks

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: true
         default: main
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +25,7 @@ concurrency:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   contents: read
@@ -64,7 +70,7 @@ jobs:
     - name: Launch Allure TestOps
       run: bundle exec fastlane allure_launch cron:true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" mock_server_branch:${{ inputs.mock_server_branch }}
+      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" mock_server_branch:${{ inputs.mock_server_branch }} ${{ env.VERBOSE }}
       timeout-minutes: 120
     - name: Allure TestOps Upload
       if: success() || failure()
@@ -123,7 +129,7 @@ jobs:
         version: ${{ matrix.ios }}
         device: ${{ matrix.device }}
     - name: Run LLC Tests (Debug)
-      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true
+      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true ${{ env.VERBOSE }}
       timeout-minutes: 100
     - name: Parse xcresult
       if: failure()
@@ -174,7 +180,7 @@ jobs:
         version: ${{ matrix.ios }}
         device: ${{ matrix.device }}
     - name: Run Common UI Tests (Debug)
-      run: bundle exec fastlane test_common_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true
+      run: bundle exec fastlane test_common_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true ${{ env.VERBOSE }}
       timeout-minutes: 100
     - name: Parse xcresult
       if: failure()
@@ -206,12 +212,12 @@ jobs:
     - name: List Xcode versions
       run: mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
     - name: Build LLC
-      run: bundle exec fastlane test device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
     - name: Build UI
-      run: bundle exec fastlane test_ui device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test_ui device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
     - name: Build Common UI
-      run: bundle exec fastlane test_common_ui device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test_common_ui device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
 
   automated-code-review:

--- a/.github/workflows/sdk-performance-metrics.yml
+++ b/.github/workflows/sdk-performance-metrics.yml
@@ -15,9 +15,16 @@ on:
       - '**/*.png'
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   actions: write
@@ -55,7 +62,7 @@ jobs:
           INSTALL_GCLOUD: true
 
       - name: Run XCMetrics
-        run: bundle exec fastlane xcmetrics
+        run: bundle exec fastlane xcmetrics ${{ env.VERBOSE }}
         timeout-minutes: 120
         env:
           GITHUB_PR_NUM: ${{ github.event.pull_request.number }}

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -8,6 +8,12 @@ on:
       - '**/*.png'
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
   push:
     branches:
@@ -15,6 +21,7 @@ on:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   actions: write
@@ -51,5 +58,5 @@ jobs:
           APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
 
       - name: Run Detailed SDK Size Metrics
-        run: bundle exec fastlane size_analyze
+        run: bundle exec fastlane size_analyze ${{ env.VERBOSE }}
         timeout-minutes: 30

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -14,6 +14,11 @@ on:
         type: boolean
         required: false
         default: false
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +29,7 @@ env:
   IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.2)"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   contents: read
@@ -48,7 +54,7 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build
-      run: bundle exec fastlane build_test_app_and_frameworks
+      run: bundle exec fastlane build_test_app_and_frameworks ${{ env.VERBOSE }}
       timeout-minutes: 60
     - uses: actions/upload-artifact@v4
       if: success()
@@ -91,13 +97,13 @@ jobs:
     - name: List Xcode versions
       run: mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
     - name: Build LLC
-      run: bundle exec fastlane test device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
     - name: Build UI
-      run: bundle exec fastlane test_ui device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test_ui device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
     - name: Build Common UI
-      run: bundle exec fastlane test_common_ui device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test_common_ui device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
 
   test-llc-debug:
@@ -114,7 +120,7 @@ jobs:
         INSTALL_YEETD: true
         INSTALL_SONAR: true
     - name: Run LLC Tests (Debug)
-      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
       timeout-minutes: 60
     - name: Run Sonar analysis
       run: bundle exec fastlane sonar_upload
@@ -160,7 +166,7 @@ jobs:
         INSTALL_YEETD: true
         SKIP_SWIFT_BOOTSTRAP: true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" skip_build:true record:"${{ github.event.inputs.record_snapshots }}"
+      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" skip_build:true record:"${{ github.event.inputs.record_snapshots }}" ${{ env.VERBOSE }}
       timeout-minutes: 120
       env:
         GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }} # to open a PR
@@ -195,7 +201,7 @@ jobs:
         INSTALL_YEETD: true
         SKIP_SWIFT_BOOTSTRAP: true
     - name: Run Common UI Tests (Debug)
-      run: bundle exec fastlane test_common_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" skip_build:true
+      run: bundle exec fastlane test_common_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" skip_build:true ${{ env.VERBOSE }}
       timeout-minutes: 60
     - name: Parse xcresult
       if: failure()
@@ -257,7 +263,7 @@ jobs:
         INSTALL_YEETD: true
         SKIP_SWIFT_BOOTSTRAP: true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" batch:'${{ matrix.batch }}' test_without_building:true
+      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" batch:'${{ matrix.batch }}' test_without_building:true ${{ env.VERBOSE }}
       timeout-minutes: 100
       env:
         MATRIX_SIZE: ${{ strategy.job-total }}
@@ -303,19 +309,19 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build Demo App
-      run: bundle exec fastlane build_demo
+      run: bundle exec fastlane build_demo ${{ env.VERBOSE }}
       timeout-minutes: 10
     - name: Build iMessageClone App
-      run: bundle exec fastlane build_imessage_clone
+      run: bundle exec fastlane build_imessage_clone ${{ env.VERBOSE }}
       timeout-minutes: 10
     - name: Build SlackClone App
-      run: bundle exec fastlane build_slack_clone
+      run: bundle exec fastlane build_slack_clone ${{ env.VERBOSE }}
       timeout-minutes: 10
     - name: Build MessengerClone App
-      run: bundle exec fastlane build_messenger_clone
+      run: bundle exec fastlane build_messenger_clone ${{ env.VERBOSE }}
       timeout-minutes: 10
     - name: Build YouTubeClone App
-      run: bundle exec fastlane build_youtube_clone
+      run: bundle exec fastlane build_youtube_clone ${{ env.VERBOSE }}
       timeout-minutes: 10
 
   test-integration:
@@ -334,5 +340,5 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Test SPM Integration
-      run: bundle exec fastlane spm_integration
+      run: bundle exec fastlane spm_integration ${{ env.VERBOSE }}
       timeout-minutes: 25

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,7 @@ swift_environment_path = File.absolute_path('../Sources/StreamChat/Generated/Sys
 is_localhost = !is_ci
 mock_server_driver_port = 4566
 @force_check = false
+xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
 
 before_all do |lane|
   if is_ci
@@ -185,7 +186,8 @@ lane :test do |options|
     devices: options[:device],
     number_of_retries: 5,
     build_for_testing: options[:build_for_testing],
-    skip_build: options[:skip_build]
+    skip_build: options[:skip_build],
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   next if options[:build_for_testing]
@@ -200,7 +202,8 @@ lane :test do |options|
     cloned_source_packages_path: source_packages_path,
     devices: options[:device],
     skip_build: true,
-    number_of_retries: options[:cron] ? 3 : 2
+    number_of_retries: options[:cron] ? 3 : 2,
+    xcodebuild_formatter: xcodebuild_formatter
   }
 
   scan(scan_options)
@@ -246,7 +249,8 @@ lane :build_test_app_and_frameworks do
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
     clean: is_localhost,
-    build_for_testing: true
+    build_for_testing: true,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -267,7 +271,8 @@ lane :xcmetrics do |options|
     clean: is_localhost,
     sdk: 'iphoneos',
     skip_detect_devices: true,
-    build_for_testing: true
+    build_for_testing: true,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   firebase_error = ''
@@ -426,7 +431,8 @@ lane :test_e2e do |options|
     test_without_building: options[:test_without_building],
     devices: options[:device],
     prelaunch_simulator: is_ci,
-    number_of_retries: 3
+    number_of_retries: 3,
+    xcodebuild_formatter: xcodebuild_formatter
   }
 
   begin
@@ -455,7 +461,8 @@ lane :test_e2e_mock do |options|
     test_without_building: options[:test_without_building],
     devices: options[:device],
     prelaunch_simulator: is_ci,
-    number_of_retries: 3
+    number_of_retries: 3,
+    xcodebuild_formatter: xcodebuild_formatter
   }
 
   if ENV['MATRIX_SIZE'] && options[:batch]
@@ -521,7 +528,8 @@ lane :test_ui do |options|
     skip_build: options[:skip_build],
     result_bundle: true,
     devices: options[:device],
-    fail_build: !record_mode
+    fail_build: !record_mode,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   if record_mode && is_ci
@@ -560,7 +568,8 @@ lane :test_common_ui do |options|
     skip_build: options[:skip_build],
     result_bundle: true,
     devices: options[:device],
-    number_of_retries: options[:cron] ? 3 : 2
+    number_of_retries: options[:cron] ? 3 : 2,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -638,7 +647,8 @@ private_lane :build_example_app do |options|
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
     build_for_testing: true,
-    devices: options[:device]
+    devices: options[:device],
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -654,7 +664,8 @@ lane :spm_integration do
     clean: is_localhost,
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
-    destination: 'generic/platform=iOS Simulator'
+    destination: 'generic/platform=iOS Simulator',
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -850,7 +861,8 @@ lane :size_analyze do
     skip_package_pkg: true,
     skip_codesigning: true,
     derived_data_path: derived_data_path,
-    cloned_source_packages_path: source_packages_path
+    cloned_source_packages_path: source_packages_path,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   show_detailed_sdk_size(sdk_names: sdk_names, threshold: 42)


### PR DESCRIPTION
### 🎯 Goal

When a CI test job fails for a non-obvious reason, get the unfiltered `xcodebuild` output without having to edit the workflow, push, and wait.

### 🛠 Implementation

- New `workflow_dispatch` input `verbose` (boolean, **default `false`**) on `smoke-checks.yml` and `cron-checks.yml`.
- One workflow-level env instead of repeating the expression per step:
  ```yaml
  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
  ```
  appended as `${{ env.VERBOSE }}` to the test steps only (build-only steps are left alone).
- `Fastfile` bridges the flag into `scan`, so `--verbose` also stops the output being formatted:
  ```ruby
  xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
  ```
  passed to the `scan` calls of the test lanes. No lane option needed — fastlane sets `Globals.verbose` from `ARGV` before the `Fastfile` is loaded.

On `pull_request` / `schedule` runs the input is absent, the expression yields `''`, and both the commands and the `scan` config are identical to today (`nil` keeps fastlane's default formatter).

### 🧐 Why `xcodebuild_formatter: ''` and not `output_style: 'raw'`

Both drop the formatter, but who writes `test_output/report.junit` depends on the *resolved* formatter: xcpretty's pipe when it resolves to `xcpretty`, otherwise trainer parsing the xcresult. `output_style: 'raw'` removes the pipe while leaving the resolved formatter at `xcpretty`, so no junit is written and the `retreive_failed_tests` retry path dies with "There is no junit report to parse", masking the real failure. `xcodebuild_formatter: ''` moves junit generation to trainer, so retries keep working. This matters because the default is dynamic — `xcbeautify` if installed, else `xcpretty`.

### 🧪 Verification

- Probed the repo's own fastlane (2.228.0) with a real `Scan.config`: unset → resolved `"xcpretty"`, pipe `| tee <log> | xcpretty --report junit …`; `''` → resolved `""`, pipe `| tee <log>` only, junit via trainer.
- `bundle exec fastlane rubocop` clean; workflows parse as YAML.
- No new secret exposure: no secret is passed as a CLI arg or into xcodebuild by these lanes, `--verbose` does not dump `ENV`, fastlane masks `sensitive:` config items, and raw xcodebuild output echoes build settings rather than the runner environment.

Same change is being applied across the iOS SDK repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an optional verbose mode for automated E2E, UI, common UI, LLC, build, and compatibility test runs.
  * Test workflows now provide more detailed diagnostic output when verbose mode is enabled.
  * Verbose settings can be enabled when manually starting supported test workflows.
* **Chores**
  * Improved test-runner integration so verbose logging produces clearer, unformatted output for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->