### PR TITLE
Fix TestFlight deploy failing on changelog emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _August 03, 2026_
 - Add `SystemMessage` support to `addMembers`, `removeMembers`, and `truncateChannel` to send system messages with extra data [#4183](https://github.com/GetStream/stream-chat-swift/pull/4183)
 - Add `NSMutableAttributedString.addLinks(detectedBy:)` and `AttributedString.addLinks(detectedBy:)` for applying detected links to attributed strings while preserving existing Markdown links [#4181](https://github.com/GetStream/stream-chat-swift/pull/4181)
 
-### ⚡️ Performance
+### ⚡ Performance
 - Skip oversized `/sync` event replay and refresh watched channels via `queryChannels` instead [#4189](https://github.com/GetStream/stream-chat-swift/pull/4189)
 
 ### 🐞 Fixed
@@ -70,7 +70,7 @@ _July 03, 2026_
 - Add support for searching roles [#4139](https://github.com/GetStream/stream-chat-swift/pull/4139)
 - Add highlighting for `@here`, `@channel`, role and group mentions in messages [#4140](https://github.com/GetStream/stream-chat-swift/pull/4140)
 - Add customizable mention suggestion providers [#4141](https://github.com/GetStream/stream-chat-swift/pull/4141)
-### ⚡️ Performance
+### ⚡ Performance
 - Improve channel list performance with optimizations in model conversions [#4165](https://github.com/GetStream/stream-chat-swift/pull/4165)
 - Reduce SDK size by 1 MB (including StreamChatCommonUI) [#4165](https://github.com/GetStream/stream-chat-swift/pull/4165)
 ### 🔄 Changed
@@ -391,7 +391,7 @@ _November 18, 2025_
 ## StreamChat
 ### ✅ Added
 - Add `ChatClientConfig.isAutomaticSyncOnReconnectEnabled` for toggling automatic syncing [#3879](https://github.com/GetStream/stream-chat-swift/pull/3879)
-### ⚡️ Performance
+### ⚡ Performance
 - Reduce SDK size by converting Events from structs to classes [#3878](https://github.com/GetStream/stream-chat-swift/pull/3878)
 ### 🔄 Changed
 - Change Events from structs to classes [#3878](https://github.com/GetStream/stream-chat-swift/pull/3878)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       fastlane
       pry
     fastlane-plugin-sonarcloud_metric_kit (0.2.1)
-    fastlane-plugin-stream_actions (0.4.0)
+    fastlane-plugin-stream_actions (0.4.7)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -385,7 +385,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-lizard
   fastlane-plugin-sonarcloud_metric_kit
-  fastlane-plugin-stream_actions (= 0.4.0)
+  fastlane-plugin-stream_actions (= 0.4.7)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   faye-websocket

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,5 +4,5 @@
 
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-sonarcloud_metric_kit'
-gem 'fastlane-plugin-stream_actions', '0.4.0'
+gem 'fastlane-plugin-stream_actions', '0.4.7'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Resolve: https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Every `Test Flight Deploy DemoApp` run for 5.8.0 failed ([example](https://github.com/GetStream/stream-chat-swift/actions/runs/30803435098/job/91653176330)) with:

```
Could not set changelog: An attribute value has invalid text. - Text for whatsNew contains invalid characters:'[️]'. - whatsNew
```

The `### ⚡️ Performance` changelog heading is two codepoints (`U+26A1` + `U+FE0F`). Pilot strips emoji from the changelog before upload, but leaves the invisible variation selector behind, and App Store Connect rejects it. The binary itself uploads and processes fine — the lane dies at the What's New step, skipping external distribution.

### 🛠 Implementation

- `CHANGELOG.md`: use bare `⚡` (no variation selector) in the Performance headings, like the older sections that deployed fine. The remaining `U+FE0F` occurrences in the file are all in historical v4 sections that `read_changelog` never extracts.
- Bump `fastlane-plugin-stream_actions` to [0.4.7](https://github.com/GetStream/fastlane-plugin-stream_actions), which now strips `U+FE0E`/`U+FE0F`/`U+200D` from the changelog before handing it to pilot — so no future changelog emoji can kill a deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Fastlane stream actions plugin to version 0.4.7.

* **Documentation**
  * Refined performance section icons in the changelog for consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
