### PR TITLE
[CI] Lint Package.swift before release and verify it after release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Integration Test
         run: | # reports to @support on failure
-          version=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
-          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-chat-swift --field version="$version"
+          test -n "$RELEASE_VERSION"
+          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-chat-swift --field version="$RELEASE_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,6 +30,13 @@ jobs:
           APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
         run: bundle exec fastlane publish_release --verbose
 
+      - name: Integration Test
+        run: | # reports to @support on failure
+          version=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
+          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-chat-swift --field version="$version"
+        env:
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+
   merge-main-to-develop:
     name: Merge main to develop
     runs-on: macos-15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       fastlane
       pry
     fastlane-plugin-sonarcloud_metric_kit (0.2.1)
-    fastlane-plugin-stream_actions (0.4.7)
+    fastlane-plugin-stream_actions (0.4.8)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -385,7 +385,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-lizard
   fastlane-plugin-sonarcloud_metric_kit
-  fastlane-plugin-stream_actions (= 0.4.7)
+  fastlane-plugin-stream_actions (= 0.4.8)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   faye-websocket

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,7 @@ lane :release do |options|
     Dir.chdir('fastlane') { update_img_shields_sdk_sizes }
   end
 
+  lint_swift_package
   check_unsafe_flags
 
   release_ios_sdk(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,6 +82,7 @@ lane :publish_release do |options|
   release_version = get_sdk_version_from_environment
   UI.user_error!("Release #{release_version} has already been published.") if git_tag_exists(tag: release_version, remote: true)
   UI.user_error!('Release version cannot be empty') if release_version.to_s.empty?
+  File.write(ENV['GITHUB_ENV'], "RELEASE_VERSION=#{release_version}\n", mode: 'a') if ENV['GITHUB_ENV']
   ensure_git_branch(branch: 'main')
 
   publish_ios_sdk(

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,5 +4,5 @@
 
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-sonarcloud_metric_kit'
-gem 'fastlane-plugin-stream_actions', '0.4.7'
+gem 'fastlane-plugin-stream_actions', '0.4.8'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Resolves: https://linear.app/stream/issue/IOS-1934
Resolves: https://linear.app/stream/issue/IOS-1741

### 🎯 Goal

Verify package health at both ends of a release: block bad `Package.swift` pins **before** publishing, and integration-test the actually released versions **after** publishing (until now the post-release pipeline run tested develop tips).

### 🛠 Implementation

- Bump `fastlane-plugin-stream_actions` to 0.4.8, which brings the new `lint_swift_package` action and a default changelog entry when a release section is empty (IOS-1741).
- The `release` lane now runs `lint_swift_package` — it fails on branch/revision pins, version ranges, local-path deps, non-https urls, and duplicates in `Package.swift`; only `from:`/`exact:` pins pass.
- `release-publish.yml` passes `sdk` + the just-published version (from `gh release view`) to [apple-internal-testing-pipeline](https://github.com/GetStream/apple-internal-testing-pipeline), which pins this SDK to that exact version and all other Stream SDKs to their latest released versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality Improvements**
  * Releases now run Swift package linting before publishing.
  * Published releases automatically trigger integration testing for the released SDK version.
  * Release validation and authentication have been improved for more reliable publishing.

* **Chores**
  * Updated release automation tooling.
  * Improved version handling throughout the publishing workflow.
  * Updated the release actions plugin to its latest supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->