### PR TITLE
Bump fastlane-plugin-stream_actions to 0.4.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       fastlane
       pry
     fastlane-plugin-sonarcloud_metric_kit (0.2.1)
-    fastlane-plugin-stream_actions (0.4.8)
+    fastlane-plugin-stream_actions (0.4.9)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -385,7 +385,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-lizard
   fastlane-plugin-sonarcloud_metric_kit
-  fastlane-plugin-stream_actions (= 0.4.8)
+  fastlane-plugin-stream_actions (= 0.4.9)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   faye-websocket

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,5 +4,5 @@
 
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-sonarcloud_metric_kit'
-gem 'fastlane-plugin-stream_actions', '0.4.8'
+gem 'fastlane-plugin-stream_actions', '0.4.9'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Fixes https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Fix TestFlight deploys failing at the changelog step when it contains text-presentation symbols like `⚠` (App Store Connect rejects them in `whatsNew`, and pilot's emoji stripper misses them).

### 📝 Summary

- Bump `fastlane-plugin-stream_actions` to 0.4.9, which strips all pictographs and their invisible companions from the TestFlight changelog before upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Fastlane stream actions plugin to version 0.4.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->