### PR TITLE
fix: Reset Markdown styling when message content changes

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -624,24 +624,22 @@ open class ChatMessageContentView: _View, ThemeProvider, UITextViewDelegate {
         }
 
         // Set the text content
-        if textView?.text != text {
-            let attributes: [NSAttributedString.Key: Any] = [
-                .foregroundColor: messageTextColor,
-                .font: messageTextFont
-            ]
-            if isMarkdownEnabled {
-                textView?.attributedText = markdownFormatter.format(text, attributes: attributes)
-            } else {
-                let attributedText = NSAttributedString(string: text, attributes: attributes)
-                textView?.attributedText = attributedText
-            }
-    
-            // Link Detection (Must be after Markdown)
-            if let attributedText = textView?.attributedText {
-                let mutableAttributedText = NSMutableAttributedString(attributedString: attributedText)
-                mutableAttributedText.addLinks(detectedBy: linkDetector)
-                textView?.attributedText = mutableAttributedText
-            }
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: messageTextColor,
+            .font: messageTextFont
+        ]
+        if isMarkdownEnabled {
+            textView?.attributedText = markdownFormatter.format(text, attributes: attributes)
+        } else {
+            let attributedText = NSAttributedString(string: text, attributes: attributes)
+            textView?.attributedText = attributedText
+        }
+
+        // Link Detection (Must be after Markdown)
+        if let attributedText = textView?.attributedText {
+            let mutableAttributedText = NSMutableAttributedString(attributedString: attributedText)
+            mutableAttributedText.addLinks(detectedBy: linkDetector)
+            textView?.attributedText = mutableAttributedText
         }
 
         // Mentions

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -237,7 +237,62 @@ import XCTest
 
         AssertSnapshot(view, variants: .onlyUserInterfaceStyles)
     }
-    
+
+    func test_updateContent_whenMarkdownAndPlainTextHaveSameRenderedString_resetsFont() throws {
+        let view = contentView(message: .mock(text: "**test**"))
+        let hostView = UIView()
+        hostView.addSubview(view)
+
+        let markdownText = try XCTUnwrap(view.textView?.attributedText)
+        let markdownFont = try XCTUnwrap(markdownText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        XCTAssertTrue(markdownFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+
+        view.content = .mock(text: "test")
+
+        let plainText = try XCTUnwrap(view.textView?.attributedText)
+        let plainFont = try XCTUnwrap(plainText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        XCTAssertEqual(plainText.string, "test")
+        XCTAssertEqual(plainFont, view.messageTextFont)
+        XCTAssertFalse(plainFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+        withExtendedLifetime(hostView) {}
+    }
+
+    func test_updateContent_whenMarkdownIsDisabled_resetsPreviouslyBoldFont() throws {
+        let appearance = Appearance.default
+        let view = contentView(message: .mock(text: "**test**"), appearance: appearance)
+        let hostView = UIView()
+        hostView.addSubview(view)
+
+        let markdownText = try XCTUnwrap(view.textView?.attributedText)
+        let markdownFont = try XCTUnwrap(markdownText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        XCTAssertTrue(markdownFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+
+        appearance.formatters.isMarkdownEnabled = false
+        view.content = .mock(text: "test")
+
+        let plainText = try XCTUnwrap(view.textView?.attributedText)
+        let plainFont = try XCTUnwrap(plainText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        XCTAssertEqual(plainText.string, "test")
+        XCTAssertEqual(plainFont, view.messageTextFont)
+        XCTAssertFalse(plainFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+        withExtendedLifetime(hostView) {}
+    }
+
+    func test_updateContent_whenRebuildingMarkdownText_appliesMarkdownAndLinkDetection() throws {
+        let view = contentView(message: .mock(text: "Initial text"))
+        let hostView = UIView()
+        hostView.addSubview(view)
+
+        view.content = .mock(text: "**test** https://getstream.io")
+
+        let attributedText = try XCTUnwrap(view.textView?.attributedText)
+        let boldFont = try XCTUnwrap(attributedText.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        let linkRange = (attributedText.string as NSString).range(of: "https://getstream.io")
+        XCTAssertTrue(boldFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+        XCTAssertEqual(attributedText.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL, URL(string: "https://getstream.io"))
+        withExtendedLifetime(hostView) {}
+    }
+
     func test_appearance_whenMessageWithMarkdownOrderedListFromTheCurrentUserIsSent() {
         let channelWithReadsEnabled: ChatChannel = .mock(
             cid: .unique,


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Linear and/or Github issues related to this PR, if applicable._

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

Update `ChatMessageContentView.updateContent()` so every relevant content refresh rebuilds the message's attributed text from the current raw or translated text and current appearance attributes, instead of using the rendered string as a change detector. Preserve the existing Markdown-enabled/disabled branches and run link detection after formatting exactly as today. This favors correct reuse, translation, font, and color state over the invalid rendered-text shortcut without adding a test-only seam or changing the public formatter API.

When a `ChatMessageContentView` renders a Markdown-bold message and is then updated with equivalent plain text, the plain message can retain the prior bold styling. The rendering guard compares `textView.text`, which contains Markdown's rendered characters, with the next raw message text, so `**test**` and `test` can appear equal after the first render. That equality skips rebuilding `attributedText`, leaving attributes from the previous message on a reused content view. The issue is confined to StreamChatUI's message-content update path rather than Markdown parsing itself.

Fixes #3677

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
  Not run: no test command resolved in this workspace, so nothing was executed to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message formatting updates so changes between Markdown and plain text correctly refresh displayed styling.
  * Ensured links continue to be detected when message content is rebuilt.
* **Tests**
  * Added coverage for Markdown-to-plain-text updates, disabling Markdown formatting, and link detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->