### PR TITLE
Fix jumping back to latest messages after a mid-page jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ⚡ Performance
 - Improve scrolling performance by caching background observer reads [#4218](https://github.com/GetStream/stream-chat-swift/pull/4218)
 ### 🐞 Fixed
-- Fix sending a message after jumping to a mid-page message not scrolling to the latest messages [#4229](https://github.com/GetStream/stream-chat-swift/pull/4229)
+- Fix the scroll-to-bottom button not disappearing after sending a message from a mid-page jump [#4229](https://github.com/GetStream/stream-chat-swift/pull/4229)
 - Fix audio attachments rendering as empty message bubbles [#4222](https://github.com/GetStream/stream-chat-swift/pull/4222)
 - Fix multiple messages staying highlighted when jumping to a message in a thread [#4216](https://github.com/GetStream/stream-chat-swift/pull/4216)
 - Fix unread banner and jump-to-unread button flickering when receiving messages in an open channel [#4214](https://github.com/GetStream/stream-chat-swift/pull/4214)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ⚡ Performance
 - Improve scrolling performance by caching background observer reads [#4218](https://github.com/GetStream/stream-chat-swift/pull/4218)
 ### 🐞 Fixed
+- Fix sending a message after jumping to a mid-page message not scrolling to the latest messages [#4229](https://github.com/GetStream/stream-chat-swift/pull/4229)
 - Fix audio attachments rendering as empty message bubbles [#4222](https://github.com/GetStream/stream-chat-swift/pull/4222)
 - Fix multiple messages staying highlighted when jumping to a message in a thread [#4216](https://github.com/GetStream/stream-chat-swift/pull/4216)
 - Fix unread banner and jump-to-unread button flickering when receiving messages in an open channel [#4214](https://github.com/GetStream/stream-chat-swift/pull/4214)

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -136,6 +136,8 @@ open class ChatChannelVC: _ViewController,
     /// The id of the first unread message
     private var firstUnreadMessageId: MessageId?
 
+    private var scrollsToBottomAfterLoadingFirstPage = false
+
     /// In case the given around message id is from a thread, we need to jump to the parent message and then the reply.
     internal var initialReplyId: MessageId?
 
@@ -414,6 +416,7 @@ open class ChatChannelVC: _ViewController,
     open func chatMessageListVCShouldLoadFirstPage(
         _ vc: ChatMessageListVC
     ) {
+        scrollsToBottomAfterLoadingFirstPage = true
         channelController.loadFirstPage()
     }
 
@@ -554,6 +557,8 @@ open class ChatChannelVC: _ViewController,
                     self.updateUnreadMessagesBannerRelatedComponents()
                 }
             }
+
+            self.scrollToBottomAfterLoadingFirstPageIfNeeded()
         }
         viewPaginationHandler.updateElementsCount(with: channelController.messages.count)
     }
@@ -606,7 +611,7 @@ open class ChatChannelVC: _ViewController,
         if let newMessagePendingEvent = event as? NewMessagePendingEvent {
             let newMessage = newMessagePendingEvent.message
             if !isFirstPageLoaded && newMessage.isSentByCurrentUser && !newMessage.isPartOfThread {
-                channelController.loadFirstPage()
+                chatMessageListVCShouldLoadFirstPage(messageListVC)
             }
         }
 
@@ -662,6 +667,13 @@ private extension ChatChannelVC {
         }
 
         return message.parentMessageId
+    }
+
+    func scrollToBottomAfterLoadingFirstPageIfNeeded() {
+        guard scrollsToBottomAfterLoadingFirstPage, isFirstPageLoaded else { return }
+        scrollsToBottomAfterLoadingFirstPage = false
+        messageListVC.scrollToBottom(animated: false)
+        messageListVC.updateScrollToBottomButtonVisibility(animated: false)
     }
 
     func makeChannelController(forParentMessageId parentMessageId: MessageId) -> ChatChannelController {

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -486,7 +486,7 @@ open class ChatThreadVC: _ViewController,
             }
         case let event as NewMessagePendingEvent:
             let newMessage = event.message
-            if !isFirstPageLoaded && newMessage.isSentByCurrentUser && newMessage.isPartOfThread {
+            if !isFirstPageLoaded && newMessage.isSentByCurrentUser && newMessage.parentMessageId == messageController.messageId {
                 chatMessageListVCShouldLoadFirstPage(messageListVC)
             }
         case let event as DraftUpdatedEvent where event.draftMessage.threadId == messageController.messageId:

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -78,6 +78,7 @@ open class ChatThreadVC: _ViewController,
     public var messageComposerBottomConstraint: NSLayoutConstraint?
 
     private var currentlyTypingUsers: Set<ChatUser> = []
+    private var scrollsToBottomAfterLoadingFirstPage = false
 
     /// A boolean value that determines whether the thread view renders the parent message at the top.
     open var shouldRenderParentMessage: Bool {
@@ -383,6 +384,7 @@ open class ChatThreadVC: _ViewController,
     }
 
     open func chatMessageListVCShouldLoadFirstPage(_ vc: ChatMessageListVC) {
+        scrollsToBottomAfterLoadingFirstPage = true
         messageController.loadFirstPage()
     }
 
@@ -485,7 +487,7 @@ open class ChatThreadVC: _ViewController,
         case let event as NewMessagePendingEvent:
             let newMessage = event.message
             if !isFirstPageLoaded && newMessage.isSentByCurrentUser && newMessage.isPartOfThread {
-                messageController.loadFirstPage()
+                chatMessageListVCShouldLoadFirstPage(messageListVC)
             }
         case let event as DraftUpdatedEvent where event.draftMessage.threadId == messageController.messageId:
             if let draft = messageController.message?.draftReply {
@@ -502,8 +504,17 @@ open class ChatThreadVC: _ViewController,
         messageListVC.setPreviousMessagesSnapshot(self.messages)
         let messages = getMessages(from: messageController)
         messageListVC.setNewMessagesSnapshot(messages)
-        messageListVC.updateMessages(with: changes)
+        messageListVC.updateMessages(with: changes) { [weak self] in
+            self?.scrollToBottomAfterLoadingFirstPageIfNeeded()
+        }
         viewPaginationHandler.updateElementsCount(with: messages.count)
+    }
+
+    private func scrollToBottomAfterLoadingFirstPageIfNeeded() {
+        guard scrollsToBottomAfterLoadingFirstPage, isFirstPageLoaded else { return }
+        scrollsToBottomAfterLoadingFirstPage = false
+        messageListVC.scrollToBottom(animated: false)
+        messageListVC.updateScrollToBottomButtonVisibility(animated: false)
     }
 
     /// Gets the replies of the thread, plus the parent message if needed.

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -208,6 +208,49 @@ extension UserRobot {
         )
         return self
     }
+
+    @discardableResult
+    func quoteMessage(
+        _ text: String,
+        quotingMessageText quotedText: String,
+        waitForAppearance: Bool = true,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        var didQuoteMessage = false
+        for _ in 0..<20 {
+            let cellCount = cells.count
+            for index in 0..<cellCount {
+                let cell = cells.element(boundBy: index)
+                guard attributes.text(in: cell).text == quotedText else { continue }
+                guard cell.isHittable else { break }
+
+                cell.waitForHitPoint().safePress(forDuration: 1)
+                contextMenu.reply.element.wait().safeTap()
+                didQuoteMessage = true
+                break
+            }
+            if didQuoteMessage {
+                break
+            }
+            scrollMessageListUp()
+        }
+
+        XCTAssertTrue(
+            didQuoteMessage,
+            "Message with text '\(quotedText)' was not found",
+            file: file,
+            line: line
+        )
+
+        sendMessage(
+            text,
+            waitForAppearance: waitForAppearance,
+            file: file,
+            line: line
+        )
+        return self
+    }
     
     @discardableResult
     func openThread(messageCellIndex: Int = 0, waitForThreadIcon: Bool = false) -> Self {

--- a/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
@@ -114,6 +114,73 @@ final class QuotedReply_Tests: StreamTestCase {
         }
     }
 
+    func test_messageListScrollsToLatest_whenUserSendsMessageAfterJumpingToQuotedMessage() throws {
+        linkToScenario(withId: 10076)
+
+        let messageCount = 60
+        let quotedText = "30"
+        let newMessage = "New message after jump"
+
+        GIVEN("user opens a channel with \(messageCount) messages") {
+            backendRobot.generateChannels(channelsCount: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        AND("user quotes a mid-page message") {
+            userRobot.quoteMessage(replyText, quotingMessageText: quotedText)
+        }
+        AND("user closes and reopens the channel") {
+            userRobot
+                .tapOnBackButton()
+                .openChannel()
+        }
+        WHEN("user taps on the quoted message") {
+            userRobot
+                .tapOnQuotedMessage(quotedText, at: 0)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(newMessage)
+        }
+        THEN("message list shows the latest message") {
+            userRobot
+                .assertMessage(newMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
+    func test_messageListScrollsToLatest_whenUserTapsScrollToBottomAfterJumpingToQuotedMessage() throws {
+        linkToScenario(withId: 10077)
+
+        let messageCount = 60
+        let quotedText = "30"
+
+        GIVEN("user opens a channel with \(messageCount) messages") {
+            backendRobot.generateChannels(channelsCount: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        AND("user quotes a mid-page message") {
+            userRobot.quoteMessage(replyText, quotingMessageText: quotedText)
+        }
+        AND("user closes and reopens the channel") {
+            userRobot
+                .tapOnBackButton()
+                .openChannel()
+        }
+        WHEN("user taps on the quoted message") {
+            userRobot
+                .tapOnQuotedMessage(quotedText, at: 0)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+        AND("user taps on the scroll to bottom button") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        THEN("message list shows the latest message") {
+            userRobot
+                .assertMessage(replyText)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
     func test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Message() {
         linkToScenario(withId: 52)
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ChatMessageController_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ChatMessageController_Mock.swift
@@ -66,6 +66,16 @@ class ChatMessageController_Mock: ChatMessageController, @unchecked Sendable {
         loadPageAroundReplyId_callCount += 1
         loadPageAroundReplyId_completion = completion
     }
+
+    var hasLoadedAllNextReplies_mock: Bool?
+    override var hasLoadedAllNextReplies: Bool {
+        hasLoadedAllNextReplies_mock ?? super.hasLoadedAllNextReplies
+    }
+
+    var loadFirstPageCallCount = 0
+    override func loadFirstPage(limit: Int? = nil, _ completion: (@MainActor (_ error: Error?) -> Void)? = nil) {
+        loadFirstPageCallCount += 1
+    }
 }
 
 extension ChatMessageController_Mock {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -746,6 +746,50 @@ import XCTest
         XCTAssertEqual(channelControllerMock.loadFirstPageCallCount, 0)
     }
 
+    func test_didReceiveNewMessagePendingEvent_whenFirstPageNotLoaded_thenScrollsToBottomAfterFirstPageLoads() {
+        channelControllerMock.hasLoadedAllNextMessages_mock = false
+        let mockedListView = makeMockMessageListView()
+        let message = ChatMessage.mock(
+            parentMessageId: nil,
+            isSentByCurrentUser: true
+        )
+
+        let pendingEvent = NewMessagePendingEvent(message: message, cid: cid)
+        vc.eventsController(vc.eventsController, didReceiveEvent: pendingEvent)
+
+        XCTAssertEqual(channelControllerMock.loadFirstPageCallCount, 1)
+        XCTAssertEqual(mockedListView.scrollToBottomCallCount, 0)
+
+        channelControllerMock.hasLoadedAllNextMessages_mock = true
+        vc.channelController(channelControllerMock, didUpdateMessages: [
+            .insert(.mock(isSentByCurrentUser: false), index: .init(item: 1, section: 0)),
+            .insert(message, index: .init(item: 0, section: 0))
+        ])
+        mockedListView.updateMessagesCompletion?()
+
+        XCTAssertEqual(mockedListView.scrollToBottomCallCount, 1)
+    }
+
+    func test_didReceiveNewMessagePendingEvent_whenFirstPageNotLoaded_whenMessagesUpdateBeforeFirstPage_thenDoesNotScrollToBottom() {
+        channelControllerMock.hasLoadedAllNextMessages_mock = false
+        let mockedListView = makeMockMessageListView()
+        let message = ChatMessage.mock(
+            parentMessageId: nil,
+            isSentByCurrentUser: true
+        )
+
+        let pendingEvent = NewMessagePendingEvent(message: message, cid: cid)
+        vc.eventsController(vc.eventsController, didReceiveEvent: pendingEvent)
+
+        vc.channelController(channelControllerMock, didUpdateMessages: [
+            .insert(.mock(isSentByCurrentUser: false), index: .init(item: 1, section: 0)),
+            .insert(message, index: .init(item: 0, section: 0))
+        ])
+        mockedListView.updateMessagesCompletion?()
+
+        XCTAssertEqual(mockedListView.scrollToBottomCallCount, 0)
+    }
+
     func test_shouldLoadFirstPage_thenLoadFirstPage() {
         vc.chatMessageListVCShouldLoadFirstPage(vc.messageListVC)
         XCTAssertEqual(channelControllerMock.loadFirstPageCallCount, 1)

--- a/Tests/StreamChatUITests/SnapshotTests/ChatThread/ChatThreadVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatThread/ChatThreadVC_Tests.swift
@@ -418,4 +418,30 @@ import XCTest
         footerView?.updateContent()
         XCTAssertEqual(footerView?.messagesCountDecorationView.textLabel.text, expected(), file: file, line: line)
     }
+
+    func test_didReceiveNewMessagePendingEvent_whenReplyBelongsToThread_thenLoadsFirstPage() {
+        messageControllerMock.hasLoadedAllNextReplies_mock = false
+        let message = ChatMessage.mock(
+            parentMessageId: messageControllerMock.messageId,
+            isSentByCurrentUser: true
+        )
+
+        let pendingEvent = NewMessagePendingEvent(message: message, cid: .unique)
+        vc.eventsController(vc.eventsController, didReceiveEvent: pendingEvent)
+
+        XCTAssertEqual(messageControllerMock.loadFirstPageCallCount, 1)
+    }
+
+    func test_didReceiveNewMessagePendingEvent_whenReplyHasDifferentParentId_thenDoesNotLoadFirstPage() {
+        messageControllerMock.hasLoadedAllNextReplies_mock = false
+        let message = ChatMessage.mock(
+            parentMessageId: .unique,
+            isSentByCurrentUser: true
+        )
+
+        let pendingEvent = NewMessagePendingEvent(message: message, cid: .unique)
+        vc.eventsController(vc.eventsController, didReceiveEvent: pendingEvent)
+
+        XCTAssertEqual(messageControllerMock.loadFirstPageCallCount, 0)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1980/swiftui-sending-message-after-jumping-to-mid-page-does-not-load-first

Related SwiftUI PR: https://github.com/GetStream/stream-chat-swiftui/pull/1584

### 🎯 Goal

After jumping to a quoted message on a mid page, sending a new message (or tapping scroll to bottom) should load the first page and land on the latest messages. UIKit already loaded the first page, but the inverted list kept its previous offset, so the scroll-to-bottom button stayed visible.

### 📝 Summary

- Scroll to the newest message as soon as the first page loads after a send from mid-history
- Use the same path for sending and for the scroll-to-bottom button
- Add E2E coverage for jumping to a quoted mid-page message, then sending or tapping scroll-to-bottom

### 🛠 Implementation

`NewMessagePendingEvent` already called `loadFirstPage()`, but `scrollToBottomIfNeeded` only scrolls on a single current-user insertion. A bulk first-page replace does not count as that, so the list stayed short of the latest message.

Sending and tapping scroll-to-bottom now go through `chatMessageListVCShouldLoadFirstPage`, which sets `scrollsToBottomAfterLoadingFirstPage`. When `didUpdateMessages` / thread `updateMessages` completes with the first page loaded, we scroll to the bottom and hide the button. The same change is applied in `ChatThreadVC`.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

1. Open a channel with enough messages to paginate
2. Quote a message on a mid page, leave the channel, reopen it, and tap the quoted message to jump there
3. Send a new message — the list should load the first page and jump to the new message
4. Repeat the jump, then tap the scroll-to-bottom button — the list should load the first page and jump to the latest messages

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - After jumping to a quoted or mid-page message, sending a new message now returns the conversation to the latest messages.
  - Loading the first page after a pending outgoing message now correctly scrolls to the bottom.
  - The scroll-to-bottom button visibility is updated consistently after returning to the latest messages.
  - Replies now load correctly only for the active conversation thread.

- **Tests**
  - Added coverage for quoted replies, pending messages, thread handling, and scroll-to-bottom behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->