### PR TITLE
Exclude hard-deleted messages from the channel list preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `CurrentChatUserController.unmuteUsers(_:completion:)` and `ConnectedUser.unmuteUsers(_:)` for unmuting multiple users at once
 - Add `CurrentChatUser.totalUnreadCountByTeam` for accessing the unread message count per team
 ### 🐞 Fixed
+- Fix the channel list showing "Message deleted" after hard deleting the last message [#4230](https://github.com/GetStream/stream-chat-swift/pull/4230)
 - Fix a rare crash caused by the main thread being blocked in `BackgroundDatabaseObserver.rawItems.getter` [#4218](https://github.com/GetStream/stream-chat-swift/pull/4218)
 - Fix unread count not clearing immediately when marking a channel as read [#4214](https://github.com/GetStream/stream-chat-swift/pull/4214)
 - Fix mention suggestions not showing members in channels with 100+ members in the `MentionSuggestionsProvider` [#4213](https://github.com/GetStream/stream-chat-swift/pull/4213)

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -578,7 +578,11 @@ extension ChatChannel {
             extraData = [:]
         }
         
-        let allSortedMessageDTOs = dto.messages.sorted(by: { $0.createdAt.bridgeDate > $1.createdAt.bridgeDate })
+        // Hard-deleted messages stay in the DB (deleting them crashes; see CIS-1963)
+        // but must not appear in latestMessages or lastMessageFromCurrentUser.
+        let allSortedMessageDTOs = dto.messages
+            .filter { !$0.isHardDeleted }
+            .sorted(by: { $0.createdAt.bridgeDate > $1.createdAt.bridgeDate })
         let channelMessageDTOs = allSortedMessageDTOs
             .filter { $0.parentMessageId == nil || $0.showReplyInChannel }
         let reads: [ChatChannelRead] = try dto.reads.map { try $0.asModel() }

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -52,6 +52,66 @@ final class ChannelDTO_Tests: XCTestCase {
         XCTAssertEqual(channel.latestMessages.first?.id, newerMessage.id)
     }
 
+    func test_saveChannel_latestMessagesExcludesHardDeletedMessages() throws {
+        // GIVEN
+        let previousMessage: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: .unique,
+            createdAt: Date(timeIntervalSince1970: 1000)
+        )
+        let hardDeletedMessage: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: .unique,
+            createdAt: Date(timeIntervalSince1970: 2000),
+            deletedAt: Date(timeIntervalSince1970: 2500)
+        )
+
+        let channelPayload: ChannelPayload = .dummy(
+            channel: .dummy(),
+            messages: [previousMessage, hardDeletedMessage]
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channelPayload)
+            session.message(id: hardDeletedMessage.id)?.isHardDeleted = true
+        }
+
+        // THEN
+        let channel = try XCTUnwrap(
+            database.viewContext.channel(cid: channelPayload.channel.cid)?.asModel()
+        )
+        XCTAssertEqual(channel.latestMessages.map(\.id), [previousMessage.id])
+    }
+
+    func test_saveChannel_latestMessagesEmpty_whenOnlyMessageIsHardDeleted() throws {
+        // GIVEN
+        let hardDeletedMessage: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: .unique,
+            createdAt: Date(timeIntervalSince1970: 2000),
+            deletedAt: Date(timeIntervalSince1970: 2500)
+        )
+
+        let channelPayload: ChannelPayload = .dummy(
+            channel: .dummy(),
+            messages: [hardDeletedMessage]
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channelPayload)
+            session.message(id: hardDeletedMessage.id)?.isHardDeleted = true
+        }
+
+        // THEN
+        let channel = try XCTUnwrap(
+            database.viewContext.channel(cid: channelPayload.channel.cid)?.asModel()
+        )
+        XCTAssertTrue(channel.latestMessages.isEmpty)
+    }
+
     func test_saveChannel_latestMessagesFirstIncludesDeletedMessages() throws {
         // GIVEN
         let regularMessage: MessagePayload = .dummy(
@@ -897,6 +957,36 @@ final class ChannelDTO_Tests: XCTestCase {
         }
 
         XCTAssertEqual(lastMessageFromCurrentUser.text, message2.text)
+    }
+
+    func test_lastMessageFromCurrentUser_whenLastMessageIsHardDeleted() throws {
+        let user: UserPayload = dummyCurrentUser
+        let channelId: ChannelId = .unique
+        let previousMessage: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: user.id,
+            createdAt: Date(timeIntervalSince1970: 1000)
+        )
+        let hardDeletedMessage: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: user.id,
+            createdAt: Date(timeIntervalSince1970: 2000),
+            deletedAt: Date(timeIntervalSince1970: 2500)
+        )
+
+        let channelPayload = dummyPayload(with: channelId, messages: [previousMessage, hardDeletedMessage])
+
+        try database.createCurrentUser(id: user.id)
+
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channelPayload)
+            session.message(id: hardDeletedMessage.id)?.isHardDeleted = true
+        }
+
+        let channel = try XCTUnwrap(database.viewContext.channel(cid: channelId)?.asModel())
+        XCTAssertEqual(channel.lastMessageFromCurrentUser?.id, previousMessage.id)
     }
 
     func test_lastMessageFromCurrentUser_whenLastMessageIsThreadReply() throws {

--- a/Tests/StreamChatTests/Database/DatabaseSession_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseSession_Tests.swift
@@ -796,6 +796,55 @@ final class DatabaseSession_Tests: XCTestCase {
         XCTAssertNil(channelDTO.messageCount)
     }
 
+    func test_saveEvent_whenMessageHardDeletedEvent_latestMessagesExcludesHardDeletedMessage() throws {
+        // GIVEN
+        let previousMessage: MessagePayload = .dummy(
+            messageId: .unique,
+            authorUserId: .unique,
+            createdAt: Date(timeIntervalSince1970: 1000)
+        )
+        let message: MessagePayload = .dummy(
+            messageId: .unique,
+            authorUserId: .unique,
+            createdAt: Date(timeIntervalSince1970: 2000)
+        )
+
+        let channel: ChannelPayload = .dummy(
+            messages: [previousMessage, message]
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channel)
+        }
+
+        // WHEN
+        let hardDeletedMessage: MessagePayload = .dummy(
+            messageId: message.id,
+            authorUserId: message.user.id,
+            createdAt: message.createdAt,
+            deletedAt: Date(timeIntervalSince1970: 3000)
+        )
+
+        let messageDeletedEvent = EventPayload(
+            eventType: .messageDeleted,
+            cid: channel.channel.cid,
+            channel: channel.channel,
+            message: hardDeletedMessage,
+            hardDelete: true
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveEvent(payload: messageDeletedEvent)
+        }
+
+        // THEN
+        let channelModel = try XCTUnwrap(
+            database.viewContext.channel(cid: channel.channel.cid)?.asModel()
+        )
+        XCTAssertEqual(channelModel.latestMessages.map(\.id), [previousMessage.id])
+        XCTAssertTrue(database.viewContext.message(id: message.id)?.isHardDeleted == true)
+    }
+
     func test_saveEvent_whenMessageDeletedEvent_latestMessagesFirstStillReturnsDeletedMessage() throws {
         // GIVEN
         let message: MessagePayload = .dummy(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1734](https://linear.app/stream/issue/IOS-1734/message-delete-preview-appears-after-hard-deleting-the-last-message)

### 🎯 Goal

After hard deleting the last message in a channel, the channel list still showed the "Message deleted" preview. Soft delete should keep that placeholder; hard delete should not.

### 📝 Summary

- Exclude hard-deleted messages when building `ChatChannel.latestMessages` and `lastMessageFromCurrentUser`
- Soft-deleted messages still appear in `latestMessages`, so the preview can show "Message deleted"
- Cover hard-delete WS events and the last-message-only case with unit tests

### 🛠 Implementation

Hard-deleted messages stay in Core Data because deleting the row crashes (CIS-1963). The message list already hides them with `isHardDeleted == NO`. `latestMessages` was built from the channel's `messages` relationship without that filter, so UIKit and SwiftUI both treated the hard-deleted message as the channel preview.

The channel model now drops `isHardDeleted` messages before computing latest messages. After a hard delete of the last message, the preview falls back to the previous message, or the empty-channel placeholder if none remain.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| Channel list shows "Message deleted" after hard deleting the last message | Channel list shows the previous message, or empty if it was the only one |

### 🧪 Manual Testing Notes

1. Open a channel whose latest message is visible in the channel list preview.
2. Hard delete that last message.
3. Go back to the channel list: the preview should not show "Message deleted".
4. Repeat with a channel that has an older message: the preview should show that older message.
5. Soft delete the last message: the preview should still show "Message deleted".

This applies to both UIKit and SwiftUI, since both read `channel.latestMessages`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel lists so they update correctly after the last message in a channel is permanently deleted.
  * Prevented permanently deleted messages from appearing as the latest message or as the current user’s last message.
  * Fixed the scroll-to-bottom button so it disappears after sending a message from a mid-page position.

* **Tests**
  * Added coverage for channel updates and latest-message behavior after permanent deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->