### PR TITLE
Added channel info screens in the demo app

### DIFF
--- a/DemoApp/Info.plist
+++ b/DemoApp/Info.plist
@@ -38,6 +38,8 @@
 	<string>We need access to your location to share it in the chat.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>We need access to your microphone for taking a video.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>We need access to your photo library for sending photo attachments.</string>
 	<key>PushNotification-Configuration</key>
 	<string>APN-Configuration</string>
 	<key>UIApplicationSceneManifest</key>

--- a/DemoApp/Screens/ChannelInfo/DemoAddChannelMembersVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoAddChannelMembersVC.swift
@@ -21,7 +21,7 @@ final class DemoAddChannelMembersVC: UIViewController,
 
     private var selectedUsers: [ChatUser] = []
     private var isLoadingNextUsers = false
-    private var searchOperation: DispatchWorkItem?
+    private var hasLoadedAllUsers = false
 
     private var users: [ChatUser] {
         searchController.userArray.filter { $0.id != searchController.client.currentUserId }
@@ -113,13 +113,8 @@ final class DemoAddChannelMembersVC: UIViewController,
     // MARK: - UISearchBarDelegate
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        searchOperation?.cancel()
-
-        let operation = DispatchWorkItem { [weak self] in
-            self?.searchController.search(term: searchText.isEmpty ? nil : searchText)
-        }
-        searchOperation = operation
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300), execute: operation)
+        hasLoadedAllUsers = false
+        searchController.search(term: searchText.isEmpty ? nil : searchText)
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
@@ -156,11 +151,17 @@ final class DemoAddChannelMembersVC: UIViewController,
     // MARK: - UITableViewDelegate
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        guard indexPath.row >= users.count - 10, !isLoadingNextUsers else { return }
+        guard !hasLoadedAllUsers, !isLoadingNextUsers else { return }
+        guard indexPath.row >= users.count - 10 else { return }
 
         isLoadingNextUsers = true
-        searchController.loadNextUsers { [weak self] _ in
-            self?.isLoadingNextUsers = false
+        let loadedUserCount = searchController.userArray.count
+        searchController.loadNextUsers { [weak self] error in
+            guard let self else { return }
+            isLoadingNextUsers = false
+            // The controller has no "loaded everything" flag, so a page that brings
+            // nothing new marks the end of the list.
+            hasLoadedAllUsers = error == nil && searchController.userArray.count == loadedUserCount
         }
     }
 

--- a/DemoApp/Screens/ChannelInfo/DemoAddChannelMembersVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoAddChannelMembersVC.swift
@@ -1,0 +1,187 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatUI
+import UIKit
+
+/// The screen used to search for users and add them as members of a channel.
+final class DemoAddChannelMembersVC: UIViewController,
+    ThemeProvider,
+    ChatUserSearchControllerDelegate,
+    UISearchBarDelegate,
+    UITableViewDataSource,
+    UITableViewDelegate {
+    /// Called with the users that should be added to the channel.
+    var onConfirm: (([ChatUser]) -> Void)?
+
+    private let searchController: ChatUserSearchController
+    private let excludedUserIds: Set<UserId>
+
+    private var selectedUsers: [ChatUser] = []
+    private var isLoadingNextUsers = false
+    private var searchOperation: DispatchWorkItem?
+
+    private var users: [ChatUser] {
+        searchController.userArray.filter { $0.id != searchController.client.currentUserId }
+    }
+
+    private func isSelected(_ user: ChatUser) -> Bool {
+        selectedUsers.contains { $0.id == user.id }
+    }
+
+    private lazy var searchBar: UISearchBar = {
+        let searchBar = UISearchBar()
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        searchBar.placeholder = "Search users"
+        searchBar.delegate = self
+        searchBar.searchBarStyle = .minimal
+        return searchBar
+    }()
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .plain)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        tableView.keyboardDismissMode = .onDrag
+        tableView.register(DemoChannelInfoMemberCell.self, forCellReuseIdentifier: DemoChannelInfoMemberCell.reuseIdentifier)
+        return tableView
+    }()
+
+    private lazy var addButton = UIBarButtonItem(
+        title: "Add",
+        style: .done,
+        target: self,
+        action: #selector(addTapped)
+    )
+
+    private lazy var cancelButton = UIBarButtonItem(
+        title: "Cancel",
+        style: .plain,
+        target: self,
+        action: #selector(cancelTapped)
+    )
+
+    init(searchController: ChatUserSearchController, excludedUserIds: Set<UserId>) {
+        self.searchController = searchController
+        self.excludedUserIds = excludedUserIds
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Add Members"
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        navigationItem.leftBarButtonItem = cancelButton
+        navigationItem.rightBarButtonItem = addButton
+        addButton.isEnabled = false
+
+        view.addSubview(searchBar)
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        searchController.delegate = self
+        searchController.search(term: nil)
+    }
+
+    @objc private func addTapped() {
+        onConfirm?(selectedUsers)
+        dismiss(animated: true)
+    }
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+
+    // MARK: - UISearchBarDelegate
+
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        searchOperation?.cancel()
+
+        let operation = DispatchWorkItem { [weak self] in
+            self?.searchController.search(term: searchText.isEmpty ? nil : searchText)
+        }
+        searchOperation = operation
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300), execute: operation)
+    }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        users.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: DemoChannelInfoMemberCell.reuseIdentifier,
+            for: indexPath
+        ) as? DemoChannelInfoMemberCell ?? DemoChannelInfoMemberCell()
+
+        let user = users[indexPath.row]
+        let isAlreadyMember = excludedUserIds.contains(user.id)
+        cell.configure(with: .init(
+            chatUser: user,
+            displayName: user.name ?? user.id,
+            onlineInfoText: isAlreadyMember ? "Already a member" : DemoParticipantInfo.onlineInfo(for: user),
+            isDeactivated: false,
+            isMuted: false
+        ))
+        cell.accessoryType = isSelected(user) ? .checkmark : .none
+        cell.contentView.alpha = isAlreadyMember ? 0.5 : 1
+        cell.selectionStyle = isAlreadyMember ? .none : .default
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard indexPath.row >= users.count - 10, !isLoadingNextUsers else { return }
+
+        isLoadingNextUsers = true
+        searchController.loadNextUsers { [weak self] _ in
+            self?.isLoadingNextUsers = false
+        }
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let user = users[indexPath.row]
+        guard !excludedUserIds.contains(user.id) else { return }
+
+        if let index = selectedUsers.firstIndex(where: { $0.id == user.id }) {
+            selectedUsers.remove(at: index)
+        } else {
+            selectedUsers.append(user)
+        }
+        addButton.isEnabled = !selectedUsers.isEmpty
+        tableView.reloadRows(at: [indexPath], with: .automatic)
+    }
+
+    // MARK: - ChatUserSearchControllerDelegate
+
+    func controller(_ controller: ChatUserSearchController, didChangeUsers changes: [ListChange<ChatUser>]) {
+        tableView.reloadData()
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChannelFileAttachmentsVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelFileAttachmentsVC.swift
@@ -1,0 +1,248 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatUI
+import UIKit
+
+/// The list of the files shared in a channel, grouped by month.
+final class DemoChannelFileAttachmentsVC: UIViewController,
+    ThemeProvider,
+    ChatMessageSearchControllerDelegate,
+    UITableViewDataSource,
+    UITableViewDelegate {
+    private struct MonthlyFileAttachments {
+        let title: String
+        var attachments: [ChatMessageFileAttachment]
+    }
+
+    private let channel: ChatChannel
+    private let messageSearchController: ChatMessageSearchController
+
+    private var monthlyAttachments: [MonthlyFileAttachments] = []
+    private var isLoadingNextMessages = false
+
+    private let monthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter
+    }()
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        tableView.separatorStyle = .none
+        tableView.register(
+            DemoFileAttachmentCell.self,
+            forCellReuseIdentifier: DemoFileAttachmentCell.reuseIdentifier
+        )
+        return tableView
+    }()
+
+    private lazy var loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(
+        icon: appearance.images.folder,
+        title: "No files",
+        subtitle: "Files sent in this chat will appear here."
+    )
+
+    init(channel: ChatChannel, client: ChatClient) {
+        self.channel = channel
+        messageSearchController = client.messageSearchController()
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Files"
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+
+        emptyStateView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        view.addSubview(emptyStateView)
+        view.addSubview(loadingIndicator)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyStateView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyStateView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        messageSearchController.delegate = self
+        loadingIndicator.startAnimating()
+        emptyStateView.isHidden = true
+        messageSearchController.search(
+            query: .init(
+                channelFilter: .equal(.cid, to: channel.cid),
+                messageFilter: .withAttachments([.file])
+            )
+        ) { [weak self] _ in
+            self?.loadingIndicator.stopAnimating()
+            self?.updateContent()
+        }
+    }
+
+    private func updateContent() {
+        var result: [MonthlyFileAttachments] = []
+        for message in messageSearchController.messages {
+            let title = monthFormatter.string(from: message.createdAt)
+            for attachment in message.fileAttachments {
+                if result.last?.title == title {
+                    result[result.count - 1].attachments.append(attachment)
+                } else {
+                    result.append(.init(title: title, attachments: [attachment]))
+                }
+            }
+        }
+
+        monthlyAttachments = result
+        emptyStateView.isHidden = !monthlyAttachments.isEmpty || loadingIndicator.isAnimating
+        tableView.reloadData()
+    }
+
+    private func showPreview(for attachment: ChatMessageFileAttachment) {
+        let previewVC = components.filePreviewVC.init()
+        previewVC.content = attachment.assetURL
+        present(UINavigationController(rootViewController: previewVC), animated: true)
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        monthlyAttachments.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        monthlyAttachments[section].attachments.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        monthlyAttachments[section].title
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: DemoFileAttachmentCell.reuseIdentifier,
+            for: indexPath
+        ) as? DemoFileAttachmentCell ?? DemoFileAttachmentCell()
+        cell.configure(with: monthlyAttachments[indexPath.section].attachments[indexPath.row])
+        cell.backgroundColor = appearance.colorPalette.backgroundCoreSurfaceSubtle
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let isLastSection = indexPath.section == monthlyAttachments.count - 1
+        let isNearEnd = indexPath.row >= monthlyAttachments[indexPath.section].attachments.count - 10
+        guard isLastSection, isNearEnd, !isLoadingNextMessages else { return }
+
+        isLoadingNextMessages = true
+        messageSearchController.loadNextMessages { [weak self] _ in
+            self?.isLoadingNextMessages = false
+        }
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        showPreview(for: monthlyAttachments[indexPath.section].attachments[indexPath.row])
+    }
+
+    // MARK: - ChatMessageSearchControllerDelegate
+
+    func controller(_ controller: ChatMessageSearchController, didChangeMessages changes: [ListChange<ChatMessage>]) {
+        updateContent()
+    }
+}
+
+/// A row showing the icon, the name and the size of a file attachment.
+final class DemoFileAttachmentCell: UITableViewCell, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoFileAttachmentCell.self)
+
+    private lazy var iconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private lazy var nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.bodyBold
+        label.textColor = appearance.colorPalette.textPrimary
+        label.lineBreakMode = .byTruncatingMiddle
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var sizeLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    convenience init() {
+        self.init(style: .default, reuseIdentifier: Self.reuseIdentifier)
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with attachment: ChatMessageFileAttachment) {
+        let file = attachment.payload.file
+        iconView.image = appearance.images.fileIconPreviews[file.type.rawValue] ?? appearance.images.iconOther
+        nameLabel.text = attachment.payload.title ?? file.type.rawValue
+        sizeLabel.text = file.sizeString
+    }
+
+    private func setUpLayout() {
+        HContainer(spacing: appearance.tokens.spacingSm, alignment: .center) {
+            iconView
+                .width(appearance.tokens.iconSizeLg)
+                .height(appearance.tokens.iconSizeLg)
+            VContainer(spacing: appearance.tokens.spacingXxxs) {
+                nameLabel
+                sizeLabel
+            }
+            Spacer()
+        }.embed(
+            in: contentView,
+            insets: .init(
+                top: appearance.tokens.spacingSm,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingSm,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChannelFileAttachmentsVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelFileAttachmentsVC.swift
@@ -25,7 +25,7 @@ final class DemoChannelFileAttachmentsVC: UIViewController,
 
     private let monthFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM yyyy"
+        formatter.setLocalizedDateFormatFromTemplate("MMMMyyyy")
         return formatter
     }()
 
@@ -50,11 +50,11 @@ final class DemoChannelFileAttachmentsVC: UIViewController,
         return indicator
     }()
 
-    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(
+    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(content: .init(
         icon: appearance.images.folder,
         title: "No files",
         subtitle: "Files sent in this chat will appear here."
-    )
+    ))
 
     init(channel: ChatChannel, client: ChatClient) {
         self.channel = channel

--- a/DemoApp/Screens/ChannelInfo/DemoChannelInfoViews.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelInfoViews.swift
@@ -1,0 +1,554 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatCommonUI
+import StreamChatUI
+import UIKit
+
+/// The information about a channel member shown in the channel info screens.
+struct DemoParticipantInfo {
+    let chatUser: ChatUser
+    let displayName: String
+    let onlineInfoText: String
+    let isDeactivated: Bool
+    let isMuted: Bool
+
+    var id: UserId { chatUser.id }
+
+    var isAdminOrOwner: Bool {
+        guard let member = chatUser as? ChatChannelMember else { return false }
+        return member.memberRole == .admin || member.memberRole == .owner || member.memberRole == .moderator
+    }
+
+    static func make(
+        for user: ChatUser,
+        currentUserId: UserId?,
+        mutedUserIds: Set<UserId>
+    ) -> DemoParticipantInfo {
+        DemoParticipantInfo(
+            chatUser: user,
+            displayName: user.id == currentUserId ? L10n.you : (user.name ?? user.id),
+            onlineInfoText: onlineInfo(for: user),
+            isDeactivated: user.isDeactivated,
+            isMuted: mutedUserIds.contains(user.id)
+        )
+    }
+
+    static func onlineInfo(for user: ChatUser) -> String {
+        if user.isOnline {
+            return L10n.Message.Title.online
+        }
+        if let lastActiveAt = user.lastActiveAt, let timeAgo = DateUtils.timeAgo(relativeTo: lastActiveAt) {
+            return timeAgo
+        }
+        return L10n.Message.Title.offline
+    }
+}
+
+// MARK: - Avatar
+
+/// The channel avatar shown in the header of the channel info screen.
+///
+/// It loads the avatar in the size it is rendered, instead of the thumbnail size used in lists.
+final class DemoChannelInfoAvatarView: ChatChannelAvatarView {
+    static let size: CGFloat = 80
+
+    override func loadIntoAvatarImageView(from url: URL?, placeholder: UIImage?) {
+        components.mediaLoader.loadImage(
+            into: presenceAvatarView.avatarView.imageView,
+            from: url,
+            with: ImageLoaderOptions(
+                resize: ImageResize(CGSize(width: Self.size, height: Self.size)),
+                placeholder: placeholder
+            )
+        )
+    }
+}
+
+// MARK: - Header
+
+/// The header of the channel info screen, showing the channel avatar, its name and a subtitle.
+final class DemoChannelInfoHeaderView: UIView, ThemeProvider {
+    struct Content {
+        let channel: ChatChannel
+        let currentUserId: UserId?
+        let title: String
+        let subtitle: String
+    }
+
+    var content: Content? {
+        didSet { updateContent() }
+    }
+
+    private lazy var avatarView = DemoChannelInfoAvatarView()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.title3
+        label.textColor = appearance.colorPalette.textPrimary
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var avatarContainer: UIView = {
+        let container = UIView()
+        container.addSubview(avatarView)
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            avatarView.topAnchor.constraint(equalTo: container.topAnchor),
+            avatarView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            avatarView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            avatarView.widthAnchor.constraint(equalToConstant: DemoChannelInfoAvatarView.size),
+            avatarView.heightAnchor.constraint(equalToConstant: DemoChannelInfoAvatarView.size)
+        ])
+        return container
+    }()
+
+    init() {
+        super.init(frame: .zero)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUpLayout() {
+        VContainer(spacing: appearance.tokens.spacingXs) {
+            avatarContainer
+            titleLabel
+            subtitleLabel
+        }.embed(
+            in: self,
+            insets: .init(
+                top: appearance.tokens.spacingXl,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingXl,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+
+    private func updateContent() {
+        guard let content else { return }
+        avatarView.content = (content.channel, content.currentUserId)
+        titleLabel.text = content.title
+        subtitleLabel.text = content.subtitle
+    }
+}
+
+// MARK: - Item Cell
+
+/// A row of the channel info screen showing an icon, a title and an optional accessory.
+final class DemoChannelInfoItemCell: UITableViewCell, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoChannelInfoItemCell.self)
+
+    enum Accessory {
+        case none
+        case disclosure
+        case toggle(isOn: Bool)
+    }
+
+    var onToggle: ((Bool) -> Void)?
+
+    private lazy var iconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.body
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var disclosureView: UIImageView = {
+        let imageView = UIImageView(image: appearance.images.chevronRight.withRenderingMode(.alwaysTemplate))
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = appearance.colorPalette.textSecondary
+        return imageView
+    }()
+
+    private lazy var toggleView: UISwitch = {
+        let toggle = UISwitch()
+        toggle.addTarget(self, action: #selector(toggleValueChanged), for: .valueChanged)
+        return toggle
+    }()
+
+    convenience init() {
+        self.init(style: .default, reuseIdentifier: Self.reuseIdentifier)
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        onToggle = nil
+    }
+
+    func configure(icon: UIImage?, title: String, accessory: Accessory, isDestructive: Bool = false) {
+        let tintColor = isDestructive ? appearance.colorPalette.accentError : appearance.colorPalette.textSecondary
+        iconView.image = icon?.withRenderingMode(.alwaysTemplate)
+        iconView.tintColor = tintColor
+        titleLabel.text = title
+        titleLabel.textColor = isDestructive ? appearance.colorPalette.accentError : appearance.colorPalette.textPrimary
+
+        switch accessory {
+        case .none:
+            disclosureView.isHidden = true
+            toggleView.isHidden = true
+        case .disclosure:
+            disclosureView.isHidden = false
+            toggleView.isHidden = true
+        case let .toggle(isOn):
+            disclosureView.isHidden = true
+            toggleView.isHidden = false
+            toggleView.isOn = isOn
+        }
+
+        if case .toggle = accessory {
+            selectionStyle = .none
+        } else {
+            selectionStyle = .default
+        }
+    }
+
+    private func setUpLayout() {
+        HContainer(spacing: appearance.tokens.spacingMd, alignment: .center) {
+            iconView
+                .width(appearance.tokens.spacingLg)
+                .height(appearance.tokens.spacingLg)
+            titleLabel
+            Spacer()
+            disclosureView
+                .width(appearance.tokens.iconSizeSm)
+            toggleView
+        }.embed(
+            in: contentView,
+            insets: .init(
+                top: appearance.tokens.spacingSm,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingSm,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+
+    @objc private func toggleValueChanged() {
+        onToggle?(toggleView.isOn)
+    }
+}
+
+// MARK: - Member Cell
+
+/// A row of the members section, showing the avatar, name and online status of a member.
+final class DemoChannelInfoMemberCell: UITableViewCell, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoChannelInfoMemberCell.self)
+
+    private lazy var avatarView = components.userAvatarView.init()
+
+    private lazy var nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.bodyBold
+        label.textColor = appearance.colorPalette.textPrimary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var onlineInfoLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var mutedIconView: UIImageView = {
+        let imageView = UIImageView(image: appearance.images.muted.withRenderingMode(.alwaysTemplate))
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = appearance.colorPalette.textTertiary
+        imageView.accessibilityLabel = "Muted"
+        return imageView
+    }()
+
+    private lazy var roleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    convenience init() {
+        self.init(style: .default, reuseIdentifier: Self.reuseIdentifier)
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with participant: DemoParticipantInfo) {
+        avatarView.content = participant.chatUser
+        nameLabel.text = participant.displayName
+        onlineInfoLabel.text = participant.onlineInfoText
+        mutedIconView.isHidden = !participant.isMuted
+        roleLabel.isHidden = !participant.isAdminOrOwner
+        roleLabel.text = participant.isAdminOrOwner ? "Admin" : nil
+    }
+
+    private func setUpLayout() {
+        HContainer(spacing: appearance.tokens.spacingSm, alignment: .center) {
+            avatarView
+                .width(components.avatarThumbnailSize.width)
+                .height(components.avatarThumbnailSize.height)
+            VContainer(spacing: appearance.tokens.spacingXxxs) {
+                nameLabel
+                onlineInfoLabel
+            }
+            Spacer()
+            mutedIconView
+                .width(appearance.tokens.iconSizeSm)
+                .height(appearance.tokens.iconSizeSm)
+            roleLabel
+        }.embed(
+            in: contentView,
+            insets: .init(
+                top: appearance.tokens.spacingXs,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingXs,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+}
+
+// MARK: - Centered Button Cell
+
+/// A row rendered as a centered button, used for the "View All" action of the members section.
+final class DemoChannelInfoButtonCell: UITableViewCell, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoChannelInfoButtonCell.self)
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.bodyBold
+        label.textColor = appearance.colorPalette.buttonSecondaryText
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    convenience init() {
+        self.init(style: .default, reuseIdentifier: Self.reuseIdentifier)
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(title: String) {
+        titleLabel.text = title
+    }
+
+    private func setUpLayout() {
+        HContainer(alignment: .center) {
+            titleLabel
+        }.embed(
+            in: contentView,
+            insets: .init(
+                top: appearance.tokens.spacingSm,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingSm,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+}
+
+// MARK: - Members Section Header
+
+/// The header of the members section, showing the member count and the button to add new members.
+final class DemoChannelInfoMembersHeaderView: UITableViewHeaderFooterView, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoChannelInfoMembersHeaderView.self)
+
+    var onAddTapped: (() -> Void)?
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.headline
+        label.textColor = appearance.colorPalette.textPrimary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var addButton: UIButton = {
+        var titleAttributes = AttributeContainer()
+        titleAttributes.font = appearance.fonts.bodyBold
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.attributedTitle = AttributedString("Add", attributes: titleAttributes)
+        configuration.baseForegroundColor = appearance.colorPalette.buttonSecondaryText
+        configuration.contentInsets = .init(
+            top: 0,
+            leading: appearance.tokens.buttonPaddingXWithLabelXs,
+            bottom: 0,
+            trailing: appearance.tokens.buttonPaddingXWithLabelXs
+        )
+
+        let button = UIButton(type: .system)
+        button.configuration = configuration
+        button.layer.borderWidth = 1
+        button.layer.borderColor = appearance.colorPalette.buttonSecondaryBorder.cgColor
+        button.layer.cornerRadius = appearance.tokens.buttonVisualHeightXs / 2
+        button.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+        return button
+    }()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
+        addButton.layer.borderColor = appearance.colorPalette.buttonSecondaryBorder.cgColor
+    }
+
+    func configure(title: String, showsAddButton: Bool) {
+        titleLabel.text = title
+        addButton.isHidden = !showsAddButton
+    }
+
+    private func setUpLayout() {
+        HContainer(spacing: appearance.tokens.spacingXs, alignment: .center) {
+            titleLabel
+            Spacer()
+            addButton
+                .height(appearance.tokens.buttonVisualHeightXs)
+        }.embed(
+            in: contentView,
+            insets: .init(
+                top: appearance.tokens.spacingXs,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingXxs,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+
+    @objc private func addTapped() {
+        onAddTapped?()
+    }
+}
+
+// MARK: - Empty State
+
+/// The placeholder shown by the channel info sub-screens when they have no content.
+final class DemoChannelInfoEmptyStateView: UIView, ThemeProvider {
+    private lazy var iconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = appearance.colorPalette.textTertiary
+        return imageView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.bodyBold
+        label.textColor = appearance.colorPalette.textPrimary
+        label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    init(icon: UIImage?, title: String, subtitle: String) {
+        super.init(frame: .zero)
+
+        iconView.image = icon?.withRenderingMode(.alwaysTemplate)
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUpLayout() {
+        let iconContainer = UIView()
+        iconContainer.addSubview(iconView)
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            iconView.topAnchor.constraint(equalTo: iconContainer.topAnchor),
+            iconView.bottomAnchor.constraint(equalTo: iconContainer.bottomAnchor),
+            iconView.centerXAnchor.constraint(equalTo: iconContainer.centerXAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: appearance.tokens.iconSizeLg),
+            iconView.heightAnchor.constraint(equalToConstant: appearance.tokens.iconSizeLg)
+        ])
+
+        let container = VContainer(spacing: appearance.tokens.spacingXs) {
+            iconContainer
+            titleLabel
+            subtitleLabel
+        }
+        addSubview(container)
+        NSLayoutConstraint.activate([
+            container.centerYAnchor.constraint(equalTo: centerYAnchor),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor, constant: appearance.tokens.spacing2xl),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -appearance.tokens.spacing2xl)
+        ])
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChannelInfoViews.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelInfoViews.swift
@@ -485,8 +485,21 @@ final class DemoChannelInfoMembersHeaderView: UITableViewHeaderFooterView, Theme
 
 // MARK: - Empty State
 
-/// The placeholder shown by the channel info sub-screens when they have no content.
+/// The placeholder shown by the channel info sub-screens when they have no content,
+/// or when the content could not be loaded.
 final class DemoChannelInfoEmptyStateView: UIView, ThemeProvider {
+    struct Content {
+        let icon: UIImage?
+        let title: String
+        let subtitle: String
+        var actionTitle: String?
+        var action: (() -> Void)?
+    }
+
+    var content: Content? {
+        didSet { updateContent() }
+    }
+
     private lazy var iconView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -513,18 +526,37 @@ final class DemoChannelInfoEmptyStateView: UIView, ThemeProvider {
         return label
     }()
 
-    init(icon: UIImage?, title: String, subtitle: String) {
+    private lazy var actionButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.titleLabel?.font = appearance.fonts.bodyBold
+        button.setTitleColor(appearance.colorPalette.buttonSecondaryText, for: .normal)
+        button.addTarget(self, action: #selector(actionTapped), for: .touchUpInside)
+        return button
+    }()
+
+    init(content: Content) {
         super.init(frame: .zero)
 
-        iconView.image = icon?.withRenderingMode(.alwaysTemplate)
-        titleLabel.text = title
-        subtitleLabel.text = subtitle
         setUpLayout()
+        self.content = content
+        updateContent()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func updateContent() {
+        iconView.image = content?.icon?.withRenderingMode(.alwaysTemplate)
+        titleLabel.text = content?.title
+        subtitleLabel.text = content?.subtitle
+        actionButton.setTitle(content?.actionTitle, for: .normal)
+        actionButton.isHidden = content?.actionTitle == nil
+    }
+
+    @objc private func actionTapped() {
+        content?.action?()
     }
 
     private func setUpLayout() {
@@ -543,6 +575,7 @@ final class DemoChannelInfoEmptyStateView: UIView, ThemeProvider {
             iconContainer
             titleLabel
             subtitleLabel
+            actionButton
         }
         addSubview(container)
         NSLayoutConstraint.activate([

--- a/DemoApp/Screens/ChannelInfo/DemoChannelMediaAttachmentsVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelMediaAttachmentsVC.swift
@@ -1,0 +1,301 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatCommonUI
+import StreamChatUI
+import UIKit
+
+/// The grid of the images and videos shared in a channel.
+final class DemoChannelMediaAttachmentsVC: UIViewController,
+    ThemeProvider,
+    ChatMessageSearchControllerDelegate,
+    UICollectionViewDataSource,
+    UICollectionViewDelegateFlowLayout {
+    private struct MediaItem {
+        let message: ChatMessage
+        let attachmentId: AttachmentId
+        let previewURL: URL?
+        let videoAttachment: ChatMessageVideoAttachment?
+    }
+
+    private static let itemSpacing: CGFloat = 2
+
+    private let channel: ChatChannel
+    private let messageSearchController: ChatMessageSearchController
+
+    private var mediaItems: [MediaItem] = []
+    private var isLoadingNextMessages = false
+
+    private lazy var zoomTransitionController = ZoomTransitionController()
+
+    private lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = Self.itemSpacing
+        layout.minimumLineSpacing = Self.itemSpacing
+
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        collectionView.register(
+            DemoMediaAttachmentCell.self,
+            forCellWithReuseIdentifier: DemoMediaAttachmentCell.reuseIdentifier
+        )
+        return collectionView
+    }()
+
+    private lazy var loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(
+        icon: appearance.images.imagePlaceholder,
+        title: "No media",
+        subtitle: "Photos or videos sent in this chat will appear here."
+    )
+
+    init(channel: ChatChannel, client: ChatClient) {
+        self.channel = channel
+        messageSearchController = client.messageSearchController()
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Photos & Videos"
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+
+        emptyStateView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(collectionView)
+        view.addSubview(emptyStateView)
+        view.addSubview(loadingIndicator)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyStateView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyStateView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        messageSearchController.delegate = self
+        loadingIndicator.startAnimating()
+        emptyStateView.isHidden = true
+        messageSearchController.search(
+            query: .init(
+                channelFilter: .equal(.cid, to: channel.cid),
+                messageFilter: .withAttachments([.image, .video])
+            )
+        ) { [weak self] _ in
+            self?.loadingIndicator.stopAnimating()
+            self?.updateContent()
+        }
+    }
+
+    private func updateContent() {
+        mediaItems = messageSearchController.messages.flatMap { message -> [MediaItem] in
+            let images = message.imageAttachments.map { attachment in
+                MediaItem(
+                    message: message,
+                    attachmentId: attachment.id,
+                    previewURL: attachment.imageURL,
+                    videoAttachment: nil
+                )
+            }
+            let videos = message.videoAttachments.map { attachment in
+                MediaItem(
+                    message: message,
+                    attachmentId: attachment.id,
+                    previewURL: attachment.payload.thumbnailURL,
+                    videoAttachment: attachment
+                )
+            }
+            return images + videos
+        }
+
+        emptyStateView.isHidden = !mediaItems.isEmpty || loadingIndicator.isAnimating
+        collectionView.reloadData()
+    }
+
+    private func showGallery(for item: MediaItem, from imageView: UIImageView?) {
+        let galleryVC = components.galleryVC.init()
+        galleryVC.modalPresentationStyle = .overFullScreen
+        galleryVC.transitioningDelegate = zoomTransitionController
+        galleryVC.transitionController = zoomTransitionController
+        galleryVC.content = .init(
+            message: item.message,
+            currentPage: (item.message.videoAttachments.map(\.id) + item.message.imageAttachments.map(\.id))
+                .firstIndex(of: item.attachmentId) ?? 0
+        )
+
+        zoomTransitionController.fromImageView = imageView
+        zoomTransitionController.presentedVCImageView = { [weak galleryVC] in
+            galleryVC?.imageViewToAnimateWhenDismissing
+        }
+        zoomTransitionController.presentingImageView = { [weak imageView] in imageView }
+
+        present(galleryVC, animated: true)
+    }
+
+    // MARK: - UICollectionViewDataSource
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        mediaItems.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: DemoMediaAttachmentCell.reuseIdentifier,
+            for: indexPath
+        )
+        guard let cell = cell as? DemoMediaAttachmentCell else { return cell }
+
+        let item = mediaItems[indexPath.item]
+        if let videoAttachment = item.videoAttachment {
+            cell.configureVideo(with: videoAttachment, previewURL: item.previewURL)
+        } else {
+            cell.configureImage(with: item.previewURL)
+        }
+        return cell
+    }
+
+    // MARK: - UICollectionViewDelegateFlowLayout
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        let numberOfColumns: CGFloat = 3
+        let spacing = Self.itemSpacing * (numberOfColumns - 1)
+        let availableWidth = collectionView.bounds.width - collectionView.adjustedContentInset.left
+            - collectionView.adjustedContentInset.right
+        let itemWidth = ((availableWidth - spacing) / numberOfColumns).rounded(.down)
+        return CGSize(width: itemWidth, height: itemWidth)
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        guard indexPath.item >= mediaItems.count - 10, !isLoadingNextMessages else { return }
+
+        isLoadingNextMessages = true
+        messageSearchController.loadNextMessages { [weak self] _ in
+            self?.isLoadingNextMessages = false
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let cell = collectionView.cellForItem(at: indexPath) as? DemoMediaAttachmentCell
+        showGallery(for: mediaItems[indexPath.item], from: cell?.imageView)
+    }
+
+    // MARK: - ChatMessageSearchControllerDelegate
+
+    func controller(_ controller: ChatMessageSearchController, didChangeMessages changes: [ListChange<ChatMessage>]) {
+        updateContent()
+    }
+}
+
+/// A cell of the media grid, showing the preview of an image or a video attachment.
+final class DemoMediaAttachmentCell: UICollectionViewCell, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoMediaAttachmentCell.self)
+
+    private static let previewSize = CGSize(width: 200, height: 200)
+
+    private(set) lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = appearance.colorPalette.backgroundCoreSurfaceSubtle
+        return imageView
+    }()
+
+    private lazy var videoIconView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "play.circle.fill"))
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = .white
+        imageView.isHidden = true
+        return imageView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+        videoIconView.isHidden = true
+    }
+
+    func configureImage(with url: URL?) {
+        videoIconView.isHidden = true
+        loadPreview(from: url)
+    }
+
+    func configureVideo(with attachment: ChatMessageVideoAttachment, previewURL: URL?) {
+        videoIconView.isHidden = false
+
+        if previewURL != nil {
+            loadPreview(from: previewURL)
+            return
+        }
+
+        components.mediaLoader.loadVideoPreview(with: attachment) { [weak self] result in
+            self?.imageView.image = try? result.get().image
+        }
+    }
+
+    private func loadPreview(from url: URL?) {
+        components.mediaLoader.loadImage(
+            into: imageView,
+            from: url,
+            with: ImageLoaderOptions(resize: ImageResize(Self.previewSize))
+        )
+    }
+
+    private func setUpLayout() {
+        contentView.addSubview(imageView)
+        contentView.addSubview(videoIconView)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        videoIconView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            videoIconView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            videoIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            videoIconView.widthAnchor.constraint(equalToConstant: 28),
+            videoIconView.heightAnchor.constraint(equalToConstant: 28)
+        ])
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChannelMediaAttachmentsVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelMediaAttachmentsVC.swift
@@ -54,11 +54,11 @@ final class DemoChannelMediaAttachmentsVC: UIViewController,
         return indicator
     }()
 
-    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(
+    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(content: .init(
         icon: appearance.images.imagePlaceholder,
         title: "No media",
         subtitle: "Photos or videos sent in this chat will appear here."
-    )
+    ))
 
     init(channel: ChatChannel, client: ChatClient) {
         self.channel = channel
@@ -173,7 +173,7 @@ final class DemoChannelMediaAttachmentsVC: UIViewController,
         if let videoAttachment = item.videoAttachment {
             cell.configureVideo(with: videoAttachment, previewURL: item.previewURL)
         } else {
-            cell.configureImage(with: item.previewURL)
+            cell.configureImage(with: item.attachmentId, url: item.previewURL)
         }
         return cell
     }
@@ -240,6 +240,9 @@ final class DemoMediaAttachmentCell: UICollectionViewCell, ThemeProvider {
         return imageView
     }()
 
+    /// The attachment the cell currently shows, so that previews of already reused cells are discarded.
+    private var representedAttachmentId: AttachmentId?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUpLayout()
@@ -252,16 +255,20 @@ final class DemoMediaAttachmentCell: UICollectionViewCell, ThemeProvider {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        representedAttachmentId = nil
         imageView.image = nil
         videoIconView.isHidden = true
     }
 
-    func configureImage(with url: URL?) {
+    func configureImage(with attachmentId: AttachmentId, url: URL?) {
+        representedAttachmentId = attachmentId
         videoIconView.isHidden = true
         loadPreview(from: url)
     }
 
     func configureVideo(with attachment: ChatMessageVideoAttachment, previewURL: URL?) {
+        let attachmentId = attachment.id
+        representedAttachmentId = attachmentId
         videoIconView.isHidden = false
 
         if previewURL != nil {
@@ -270,6 +277,7 @@ final class DemoMediaAttachmentCell: UICollectionViewCell, ThemeProvider {
         }
 
         components.mediaLoader.loadVideoPreview(with: attachment) { [weak self] result in
+            guard self?.representedAttachmentId == attachmentId else { return }
             self?.imageView.image = try? result.get().image
         }
     }

--- a/DemoApp/Screens/ChannelInfo/DemoChannelMemberListVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelMemberListVC.swift
@@ -1,0 +1,128 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatUI
+import UIKit
+
+/// The full, paginated list of the members of a channel.
+final class DemoChannelMemberListVC: UIViewController,
+    ThemeProvider,
+    ChatChannelMemberListControllerDelegate,
+    CurrentChatUserControllerDelegate,
+    UITableViewDataSource,
+    UITableViewDelegate {
+    /// Called when a member is selected, so that its actions can be shown.
+    var onMemberSelected: ((DemoParticipantInfo, UIView?) -> Void)?
+
+    private let memberListController: ChatChannelMemberListController
+    private lazy var currentUserController = memberListController.client.currentUserController()
+
+    private var participants: [DemoParticipantInfo] = []
+    private var isLoadingNextMembers = false
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        tableView.separatorStyle = .none
+        tableView.register(DemoChannelInfoMemberCell.self, forCellReuseIdentifier: DemoChannelInfoMemberCell.reuseIdentifier)
+        return tableView
+    }()
+
+    init(memberListController: ChatChannelMemberListController) {
+        self.memberListController = memberListController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Members"
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        memberListController.delegate = self
+        memberListController.synchronize { [weak self] _ in
+            self?.updateContent()
+        }
+        currentUserController.delegate = self
+        currentUserController.synchronize()
+    }
+
+    private func updateContent() {
+        let currentUserId = memberListController.client.currentUserId
+        let mutedUserIds = Set((currentUserController.currentUser?.mutedUsers ?? []).map(\.id))
+        participants = memberListController.members.map { member in
+            .make(for: member, currentUserId: currentUserId, mutedUserIds: mutedUserIds)
+        }
+        tableView.reloadData()
+    }
+
+    private func loadNextMembers() {
+        guard !isLoadingNextMembers else { return }
+
+        isLoadingNextMembers = true
+        memberListController.loadNextMembers { [weak self] _ in
+            self?.isLoadingNextMembers = false
+        }
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        participants.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: DemoChannelInfoMemberCell.reuseIdentifier,
+            for: indexPath
+        ) as? DemoChannelInfoMemberCell ?? DemoChannelInfoMemberCell()
+        cell.configure(with: participants[indexPath.row])
+        cell.backgroundColor = appearance.colorPalette.backgroundCoreSurfaceSubtle
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard indexPath.row >= participants.count - 10 else { return }
+        loadNextMembers()
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        onMemberSelected?(participants[indexPath.row], tableView.cellForRow(at: indexPath))
+    }
+
+    // MARK: - Delegates
+
+    func memberListController(
+        _ controller: ChatChannelMemberListController,
+        didChangeMembers changes: [ListChange<ChatChannelMember>]
+    ) {
+        updateContent()
+    }
+
+    func currentUserController(
+        _ controller: CurrentChatUserController,
+        didChangeCurrentUser: EntityChange<CurrentChatUser>
+    ) {
+        updateContent()
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChannelMemberListVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelMemberListVC.swift
@@ -21,6 +21,7 @@ final class DemoChannelMemberListVC: UIViewController,
 
     private var participants: [DemoParticipantInfo] = []
     private var isLoadingNextMembers = false
+    private var hasLoadedAllMembers = false
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -74,11 +75,16 @@ final class DemoChannelMemberListVC: UIViewController,
     }
 
     private func loadNextMembers() {
-        guard !isLoadingNextMembers else { return }
+        guard !hasLoadedAllMembers, !isLoadingNextMembers else { return }
 
         isLoadingNextMembers = true
-        memberListController.loadNextMembers { [weak self] _ in
-            self?.isLoadingNextMembers = false
+        let loadedMemberCount = memberListController.members.count
+        memberListController.loadNextMembers { [weak self] error in
+            guard let self else { return }
+            isLoadingNextMembers = false
+            // The controller has no "loaded everything" flag, so a page that brings
+            // nothing new marks the end of the list.
+            hasLoadedAllMembers = error == nil && memberListController.members.count == loadedMemberCount
         }
     }
 

--- a/DemoApp/Screens/ChannelInfo/DemoChannelMemberListVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelMemberListVC.swift
@@ -14,7 +14,7 @@ final class DemoChannelMemberListVC: UIViewController,
     UITableViewDataSource,
     UITableViewDelegate {
     /// Called when a member is selected, so that its actions can be shown.
-    var onMemberSelected: ((DemoParticipantInfo, UIView?) -> Void)?
+    var onMemberSelected: ((DemoParticipantInfo) -> Void)?
 
     private let memberListController: ChatChannelMemberListController
     private lazy var currentUserController = memberListController.client.currentUserController()
@@ -113,7 +113,7 @@ final class DemoChannelMemberListVC: UIViewController,
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        onMemberSelected?(participants[indexPath.row], tableView.cellForRow(at: indexPath))
+        onMemberSelected?(participants[indexPath.row])
     }
 
     // MARK: - Delegates

--- a/DemoApp/Screens/ChannelInfo/DemoChannelPinnedMessagesVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelPinnedMessagesVC.swift
@@ -1,0 +1,212 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatUI
+import UIKit
+
+/// The list of the messages pinned in a channel.
+final class DemoChannelPinnedMessagesVC: UIViewController,
+    ThemeProvider,
+    UITableViewDataSource,
+    UITableViewDelegate {
+    /// Called when a pinned message is selected, so that it can be shown in the message list.
+    var onMessageSelected: ((MessageId) -> Void)?
+
+    private let channel: ChatChannel
+    private let channelController: ChatChannelController
+
+    private var pinnedMessages: [ChatMessage] = []
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        tableView.separatorStyle = .none
+        tableView.register(
+            DemoPinnedMessageCell.self,
+            forCellReuseIdentifier: DemoPinnedMessageCell.reuseIdentifier
+        )
+        return tableView
+    }()
+
+    private lazy var loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(
+        icon: appearance.images.pin,
+        title: "No pinned messages",
+        subtitle: "Long-press an important message and choose Pin to conversation."
+    )
+
+    init(channel: ChatChannel, channelController: ChatChannelController) {
+        self.channel = channel
+        self.channelController = channelController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Pinned Messages"
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+
+        emptyStateView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        view.addSubview(emptyStateView)
+        view.addSubview(loadingIndicator)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyStateView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyStateView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        pinnedMessages = channel.pinnedMessages
+        loadingIndicator.startAnimating()
+        updateContent()
+
+        channelController.loadPinnedMessages { [weak self] result in
+            guard let self else { return }
+            loadingIndicator.stopAnimating()
+            if let messages = try? result.get() {
+                pinnedMessages = messages
+            }
+            updateContent()
+        }
+    }
+
+    private func updateContent() {
+        emptyStateView.isHidden = !pinnedMessages.isEmpty || loadingIndicator.isAnimating
+        tableView.isHidden = pinnedMessages.isEmpty
+        tableView.reloadData()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        pinnedMessages.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: DemoPinnedMessageCell.reuseIdentifier,
+            for: indexPath
+        ) as? DemoPinnedMessageCell ?? DemoPinnedMessageCell()
+        cell.configure(with: pinnedMessages[indexPath.row])
+        cell.backgroundColor = appearance.colorPalette.backgroundCoreSurfaceSubtle
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        onMessageSelected?(pinnedMessages[indexPath.row].id)
+    }
+}
+
+/// A row showing the author, the content and the timestamp of a pinned message.
+final class DemoPinnedMessageCell: UITableViewCell, ThemeProvider {
+    static let reuseIdentifier = String(describing: DemoPinnedMessageCell.self)
+
+    private lazy var avatarView = components.userAvatarView.init()
+
+    private lazy var authorLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.bodyBold
+        label.textColor = appearance.colorPalette.textPrimary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var timestampLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textTertiary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var messageLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.body
+        label.textColor = appearance.colorPalette.textSecondary
+        label.numberOfLines = 2
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    convenience init() {
+        self.init(style: .default, reuseIdentifier: Self.reuseIdentifier)
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with message: ChatMessage) {
+        avatarView.content = message.author
+        authorLabel.text = message.author.name ?? message.author.id
+        timestampLabel.text = appearance.formatters.channelListMessageTimestamp.format(message.createdAt)
+        messageLabel.text = message.text.isEmpty ? message.previewText : message.text
+    }
+
+    private func setUpLayout() {
+        HContainer(spacing: appearance.tokens.spacingSm, alignment: .top) {
+            avatarView
+                .width(components.avatarThumbnailSize.width)
+                .height(components.avatarThumbnailSize.height)
+            VContainer(spacing: appearance.tokens.spacingXxxs) {
+                HContainer(spacing: appearance.tokens.spacingXs, alignment: .center) {
+                    authorLabel
+                    Spacer()
+                    timestampLabel
+                }
+                messageLabel
+            }
+        }.embed(
+            in: contentView,
+            insets: .init(
+                top: appearance.tokens.spacingSm,
+                leading: appearance.tokens.spacingMd,
+                bottom: appearance.tokens.spacingSm,
+                trailing: appearance.tokens.spacingMd
+            )
+        )
+    }
+}
+
+private extension ChatMessage {
+    /// A short description of the message when it has no text, based on its attachments.
+    var previewText: String {
+        guard let attachmentType = allAttachments.first?.type.rawValue else {
+            return ""
+        }
+        return "📎 \(attachmentType.capitalized)"
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChannelPinnedMessagesVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChannelPinnedMessagesVC.swift
@@ -18,6 +18,7 @@ final class DemoChannelPinnedMessagesVC: UIViewController,
     private let channelController: ChatChannelController
 
     private var pinnedMessages: [ChatMessage] = []
+    private var loadingFailed = false
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -40,11 +41,25 @@ final class DemoChannelPinnedMessagesVC: UIViewController,
         return indicator
     }()
 
-    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(
-        icon: appearance.images.pin,
-        title: "No pinned messages",
-        subtitle: "Long-press an important message and choose Pin to conversation."
-    )
+    private lazy var emptyStateView = DemoChannelInfoEmptyStateView(content: emptyStateContent)
+
+    private var emptyStateContent: DemoChannelInfoEmptyStateView.Content {
+        guard loadingFailed else {
+            return .init(
+                icon: appearance.images.pin,
+                title: "No pinned messages",
+                subtitle: "Long-press an important message and choose Pin to conversation."
+            )
+        }
+
+        return .init(
+            icon: appearance.images.messageListErrorIndicator,
+            title: "Something went wrong",
+            subtitle: "The pinned messages could not be loaded.",
+            actionTitle: "Try again",
+            action: { [weak self] in self?.loadPinnedMessages() }
+        )
+    }
 
     init(channel: ChatChannel, channelController: ChatChannelController) {
         self.channel = channel
@@ -81,20 +96,31 @@ final class DemoChannelPinnedMessagesVC: UIViewController,
         ])
 
         pinnedMessages = channel.pinnedMessages
+        loadPinnedMessages()
+    }
+
+    private func loadPinnedMessages() {
+        loadingFailed = false
         loadingIndicator.startAnimating()
         updateContent()
 
         channelController.loadPinnedMessages { [weak self] result in
             guard let self else { return }
             loadingIndicator.stopAnimating()
-            if let messages = try? result.get() {
+            switch result {
+            case let .success(messages):
                 pinnedMessages = messages
+            case .failure:
+                // The locally cached messages are still shown, the error state is only
+                // relevant when there is nothing to fall back to.
+                loadingFailed = pinnedMessages.isEmpty
             }
             updateContent()
         }
     }
 
     private func updateContent() {
+        emptyStateView.content = emptyStateContent
         emptyStateView.isHidden = !pinnedMessages.isEmpty || loadingIndicator.isAnimating
         tableView.isHidden = pinnedMessages.isEmpty
         tableView.reloadData()

--- a/DemoApp/Screens/ChannelInfo/DemoChatChannelInfoVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChatChannelInfoVC.swift
@@ -1,0 +1,682 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatCommonUI
+import StreamChatUI
+import UIKit
+
+/// The channel info screen, showing the channel details, its members and the available channel actions.
+///
+/// It is the UIKit counterpart of the `ChatChannelInfoView` from the SwiftUI SDK.
+final class DemoChatChannelInfoVC: UIViewController,
+    ThemeProvider,
+    ChatChannelControllerDelegate,
+    CurrentChatUserControllerDelegate,
+    UITableViewDataSource,
+    UITableViewDelegate {
+    private enum Section {
+        case options
+        case members
+        case actions
+    }
+
+    private enum Item {
+        case pinnedMessages
+        case media
+        case files
+        case member(DemoParticipantInfo)
+        case viewAllMembers
+        case mute
+        case block
+        case leave
+    }
+
+    /// The maximum amount of members shown before the "View all" button is displayed.
+    private static let maximumDisplayedMembers = 5
+
+    let channelController: ChatChannelController
+    private let currentUserController: CurrentChatUserController
+
+    private var participants: [DemoParticipantInfo] = []
+    private var sections: [(section: Section, items: [Item])] = []
+
+    private lazy var headerView = DemoChannelInfoHeaderView()
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        tableView.separatorStyle = .none
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.estimatedSectionHeaderHeight = 40
+        tableView.register(DemoChannelInfoItemCell.self, forCellReuseIdentifier: DemoChannelInfoItemCell.reuseIdentifier)
+        tableView.register(DemoChannelInfoMemberCell.self, forCellReuseIdentifier: DemoChannelInfoMemberCell.reuseIdentifier)
+        tableView.register(DemoChannelInfoButtonCell.self, forCellReuseIdentifier: DemoChannelInfoButtonCell.reuseIdentifier)
+        tableView.register(
+            DemoChannelInfoMembersHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: DemoChannelInfoMembersHeaderView.reuseIdentifier
+        )
+        return tableView
+    }()
+
+    private lazy var editButton = UIBarButtonItem(
+        title: "Edit",
+        style: .plain,
+        target: self,
+        action: #selector(editTapped)
+    )
+
+    init(cid: ChannelId, client: ChatClient) {
+        channelController = client.channelController(for: cid)
+        currentUserController = client.currentUserController()
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        tableView.tableHeaderView = headerView
+
+        channelController.delegate = self
+        channelController.synchronize()
+        currentUserController.delegate = self
+        currentUserController.synchronize()
+
+        updateContent()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        sizeTableHeaderView()
+    }
+
+    // MARK: - Content
+
+    private var client: ChatClient {
+        channelController.client
+    }
+
+    private var channel: ChatChannel? {
+        channelController.channel
+    }
+
+    private var currentUserId: UserId? {
+        client.currentUserId
+    }
+
+    private var mutedUserIds: Set<UserId> {
+        Set((currentUserController.currentUser?.mutedUsers ?? []).map(\.id))
+    }
+
+    private var blockedUserIds: Set<UserId> {
+        currentUserController.currentUser?.blockedUserIds ?? []
+    }
+
+    /// Whether the screen shows the details of the other participant of a one-on-one conversation.
+    private var showsSingleMemberDMView: Bool {
+        channel?.isDirectMessageChannel == true && participants.count <= 2
+    }
+
+    private var activeParticipants: [DemoParticipantInfo] {
+        participants.filter { !$0.isDeactivated }
+    }
+
+    private var displayedParticipants: [DemoParticipantInfo] {
+        if showsSingleMemberDMView,
+           let otherParticipant = participants.first(where: { $0.id != currentUserId }) {
+            return [otherParticipant]
+        }
+        return Array(activeParticipants.prefix(Self.maximumDisplayedMembers))
+    }
+
+    private var notDisplayedParticipantsCount: Int {
+        guard let channel else { return 0 }
+        let deactivated = participants.filter(\.isDeactivated).count
+        return channel.memberCount - displayedParticipants.count - deactivated
+    }
+
+    private var channelName: String {
+        guard let channel else { return "" }
+        if let name = channel.name, !name.isEmpty {
+            return name
+        }
+        return appearance.formatters.channelName.format(channel: channel, forCurrentUserId: currentUserId) ?? ""
+    }
+
+    private func updateContent() {
+        guard let channel else { return }
+
+        let mutedIds = mutedUserIds
+        participants = channel.lastActiveMembers.map { member in
+            .make(for: member, currentUserId: currentUserId, mutedUserIds: mutedIds)
+        }
+
+        title = showsSingleMemberDMView ? "Contact Info" : "Group Info"
+        navigationItem.rightBarButtonItem = !showsSingleMemberDMView && channel.canUpdateChannel ? editButton : nil
+
+        let onlineMembersCount = participants.filter { $0.chatUser.isOnline }.count
+        headerView.content = .init(
+            channel: channel,
+            currentUserId: currentUserId,
+            title: showsSingleMemberDMView ? (displayedParticipants.first?.displayName ?? channelName) : channelName,
+            subtitle: showsSingleMemberDMView
+                ? (displayedParticipants.first?.onlineInfoText ?? "")
+                : L10n.Message.Title.group(channel.memberCount, onlineMembersCount)
+        )
+
+        updateSections()
+        tableView.reloadData()
+        view.setNeedsLayout()
+    }
+
+    private func updateSections() {
+        var sections: [(section: Section, items: [Item])] = []
+
+        sections.append((.options, [.pinnedMessages, .media, .files]))
+
+        if !showsSingleMemberDMView {
+            var memberItems = displayedParticipants.map { Item.member($0) }
+            if notDisplayedParticipantsCount > 0 {
+                memberItems.append(.viewAllMembers)
+            }
+            sections.append((.members, memberItems))
+        }
+
+        var actionItems: [Item] = []
+        if channel?.canMuteChannel == true {
+            actionItems.append(.mute)
+        }
+        if showsSingleMemberDMView {
+            actionItems.append(.block)
+        }
+        if canLeaveConversation {
+            actionItems.append(.leave)
+        }
+        if !actionItems.isEmpty {
+            sections.append((.actions, actionItems))
+        }
+
+        self.sections = sections
+    }
+
+    private func sizeTableHeaderView() {
+        guard let headerView = tableView.tableHeaderView else { return }
+
+        let height = headerView.systemLayoutSizeFitting(
+            CGSize(width: tableView.bounds.width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+
+        guard headerView.frame.height != height else { return }
+        headerView.frame.size.height = height
+        tableView.tableHeaderView = headerView
+    }
+
+    // MARK: - Actions
+
+    private var canLeaveConversation: Bool {
+        guard let channel else { return false }
+        return showsSingleMemberDMView ? channel.canDeleteChannel : channel.canLeaveChannel
+    }
+
+    private var leaveConversationTitle: String {
+        showsSingleMemberDMView ? "Delete conversation" : "Leave group"
+    }
+
+    private var isDMUserBlocked: Bool {
+        guard let otherUserId = displayedParticipants.first?.id else { return false }
+        return blockedUserIds.contains(otherUserId)
+    }
+
+    private var blockUserTitle: String {
+        isDMUserBlocked ? "Unblock User" : "Block User"
+    }
+
+    private func setChannelMuted(_ isMuted: Bool) {
+        let completion: @MainActor (Error?) -> Void = { [weak self] error in
+            guard let self else { return }
+            if error != nil {
+                presentErrorAlert()
+            }
+            updateContent()
+        }
+
+        if isMuted {
+            channelController.muteChannel(completion: completion)
+        } else {
+            channelController.unmuteChannel(completion: completion)
+        }
+    }
+
+    private func blockUserTapped() {
+        guard let otherUserId = displayedParticipants.first?.id else { return }
+
+        let title = blockUserTitle
+        let message = isDMUserBlocked
+            ? "Are you sure you want to unblock this user?"
+            : "Are you sure you want to block this user?"
+        presentAlert(title: title, message: message, actions: [
+            .init(title: title, style: .destructive, handler: { [weak self] _ in
+                guard let self else { return }
+                let userController = client.userController(userId: otherUserId)
+                let completion: @MainActor (Error?) -> Void = { [weak self] error in
+                    if error != nil {
+                        self?.presentErrorAlert()
+                    }
+                }
+                if isDMUserBlocked {
+                    userController.unblock(completion: completion)
+                } else {
+                    userController.block(completion: completion)
+                }
+            })
+        ])
+    }
+
+    private func leaveConversationTapped() {
+        let title = leaveConversationTitle
+        let message = showsSingleMemberDMView
+            ? "Are you sure you want to delete this conversation?"
+            : "Are you sure you want to leave this group?"
+        presentAlert(title: title, message: message, actions: [
+            .init(title: title, style: .destructive, handler: { [weak self] _ in
+                self?.leaveConversation()
+            })
+        ])
+    }
+
+    private func leaveConversation() {
+        let completion: @MainActor (Error?) -> Void = { [weak self] error in
+            guard let self else { return }
+            if error != nil {
+                presentErrorAlert()
+            } else {
+                dismissChannel()
+            }
+        }
+
+        if showsSingleMemberDMView {
+            channelController.deleteChannel(completion: completion)
+        } else if let currentUserId {
+            channelController.removeMembers(userIds: [currentUserId], completion: completion)
+        }
+    }
+
+    /// Pops back to the channel list, because the channel is not available anymore.
+    private func dismissChannel() {
+        guard let navigationController else {
+            dismiss(animated: true)
+            return
+        }
+
+        if let channelListVC = navigationController.viewControllers.first(where: { $0 is ChatChannelListVC }) {
+            navigationController.popToViewController(channelListVC, animated: true)
+        } else {
+            navigationController.popToRootViewController(animated: true)
+        }
+    }
+
+    private func presentErrorAlert() {
+        presentAlert(title: "Something went wrong.")
+    }
+
+    @objc private func editTapped() {
+        guard let channel else { return }
+
+        let editVC = DemoEditChannelInfoVC(channelController: channelController, channel: channel)
+        present(UINavigationController(rootViewController: editVC), animated: true)
+    }
+
+    private func addMembersTapped() {
+        let addMembersVC = DemoAddChannelMembersVC(
+            searchController: client.userSearchController(),
+            excludedUserIds: Set(participants.map(\.id))
+        )
+        addMembersVC.onConfirm = { [weak self] users in
+            guard let self, !users.isEmpty else { return }
+            channelController.addMembers(userIds: Set(users.map(\.id))) { [weak self] error in
+                if error != nil {
+                    self?.presentErrorAlert()
+                }
+            }
+        }
+        present(UINavigationController(rootViewController: addMembersVC), animated: true)
+    }
+
+    // MARK: - Navigation
+
+    private func showPinnedMessages() {
+        guard let channel else { return }
+
+        let pinnedMessagesVC = DemoChannelPinnedMessagesVC(
+            channel: channel,
+            channelController: client.channelController(for: channel.cid)
+        )
+        pinnedMessagesVC.onMessageSelected = { [weak self] messageId in
+            self?.jumpToMessage(messageId)
+        }
+        navigationController?.pushViewController(pinnedMessagesVC, animated: true)
+    }
+
+    private func showMediaAttachments() {
+        guard let channel else { return }
+
+        let mediaVC = DemoChannelMediaAttachmentsVC(channel: channel, client: client)
+        navigationController?.pushViewController(mediaVC, animated: true)
+    }
+
+    private func showFileAttachments() {
+        guard let channel else { return }
+
+        let filesVC = DemoChannelFileAttachmentsVC(channel: channel, client: client)
+        navigationController?.pushViewController(filesVC, animated: true)
+    }
+
+    private func showAllMembers() {
+        guard let channel else { return }
+
+        let memberListVC = DemoChannelMemberListVC(
+            memberListController: client.memberListController(query: .init(cid: channel.cid))
+        )
+        memberListVC.onMemberSelected = { [weak self, weak memberListVC] participant, sourceView in
+            guard let self, let memberListVC else { return }
+            presentActions(for: participant, in: memberListVC, sourceView: sourceView)
+        }
+        navigationController?.pushViewController(memberListVC, animated: true)
+    }
+
+    /// Goes back to the message list of the channel and scrolls to the given message.
+    private func jumpToMessage(_ messageId: MessageId) {
+        guard let navigationController,
+              let channelVC = navigationController.viewControllers.last(where: { $0 is ChatChannelVC }) as? ChatChannelVC
+        else { return }
+
+        navigationController.popToViewController(channelVC, animated: true)
+        channelVC.jumpToMessage(id: messageId)
+    }
+
+    private func presentActions(
+        for participant: DemoParticipantInfo,
+        in viewController: UIViewController,
+        sourceView: UIView?
+    ) {
+        let actions = participantActions(for: participant)
+        guard !actions.isEmpty else { return }
+
+        viewController.presentAlert(
+            title: participant.displayName,
+            actions: actions,
+            preferredStyle: .actionSheet,
+            sourceView: sourceView ?? viewController.view
+        )
+    }
+
+    private func participantActions(for participant: DemoParticipantInfo) -> [UIAlertAction] {
+        guard let channel else { return [] }
+
+        if participant.id == currentUserId {
+            guard !showsSingleMemberDMView, canLeaveConversation else { return [] }
+            return [
+                .init(title: "Leave group", style: .destructive, handler: { [weak self] _ in
+                    self?.leaveConversationTapped()
+                })
+            ]
+        }
+
+        var actions: [UIAlertAction] = []
+
+        actions.append(.init(title: "Send direct message", style: .default, handler: { [weak self] _ in
+            self?.showDirectMessageChannel(with: participant)
+        }))
+
+        if channel.config.mutesEnabled {
+            let isMuted = mutedUserIds.contains(participant.id)
+            actions.append(.init(title: isMuted ? "Unmute user" : "Mute user", style: .default, handler: { [weak self] _ in
+                guard let self else { return }
+                let userController = client.userController(userId: participant.id)
+                let completion: @MainActor (Error?) -> Void = { [weak self] error in
+                    if error != nil {
+                        self?.presentErrorAlert()
+                    }
+                }
+                if isMuted {
+                    userController.unmute(completion: completion)
+                } else {
+                    userController.mute(completion: completion)
+                }
+            }))
+        }
+
+        let isBlocked = blockedUserIds.contains(participant.id)
+        actions.append(.init(title: isBlocked ? "Unblock user" : "Block user", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            let userController = client.userController(userId: participant.id)
+            let completion: @MainActor (Error?) -> Void = { [weak self] error in
+                if error != nil {
+                    self?.presentErrorAlert()
+                }
+            }
+            if isBlocked {
+                userController.unblock(completion: completion)
+            } else {
+                userController.block(completion: completion)
+            }
+        }))
+
+        if channel.canUpdateChannelMembers {
+            actions.append(.init(title: "Remove user", style: .destructive, handler: { [weak self] _ in
+                self?.removeUserTapped(participant)
+            }))
+        }
+
+        return actions
+    }
+
+    private func removeUserTapped(_ participant: DemoParticipantInfo) {
+        guard let channel else { return }
+
+        presentAlert(
+            title: "Remove User",
+            message: "Are you sure you want to remove \(participant.displayName) from \(channel.name ?? channel.cid.id)?",
+            actions: [
+                .init(title: "Remove User", style: .destructive, handler: { [weak self] _ in
+                    self?.channelController.removeMembers(userIds: [participant.id]) { [weak self] error in
+                        if error != nil {
+                            self?.presentErrorAlert()
+                        }
+                    }
+                })
+            ]
+        )
+    }
+
+    private func showDirectMessageChannel(with participant: DemoParticipantInfo) {
+        guard let currentUserId, let channel else { return }
+
+        let directMessageController = try? client.channelController(
+            createDirectMessageChannelWith: [currentUserId, participant.id],
+            team: channel.team,
+            extraData: [:]
+        )
+        guard let directMessageController else { return }
+
+        let channelVC = components.channelVC.init()
+        channelVC.channelController = directMessageController
+        navigationController?.pushViewController(channelVC, animated: true)
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        sections[section].items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = makeCell(for: sections[indexPath.section].items[indexPath.row], at: indexPath)
+        cell.backgroundColor = appearance.colorPalette.backgroundCoreSurfaceSubtle
+        return cell
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func makeCell(for item: Item, at indexPath: IndexPath) -> UITableViewCell {
+        switch item {
+        case .pinnedMessages:
+            let cell = dequeueItemCell(at: indexPath)
+            cell.configure(icon: appearance.images.pin, title: "Pinned Messages", accessory: .disclosure)
+            return cell
+
+        case .media:
+            let cell = dequeueItemCell(at: indexPath)
+            cell.configure(icon: appearance.images.imagePlaceholder, title: "Photos & Videos", accessory: .disclosure)
+            return cell
+
+        case .files:
+            let cell = dequeueItemCell(at: indexPath)
+            cell.configure(icon: appearance.images.folder, title: "Files", accessory: .disclosure)
+            return cell
+
+        case let .member(participant):
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: DemoChannelInfoMemberCell.reuseIdentifier,
+                for: indexPath
+            ) as? DemoChannelInfoMemberCell ?? DemoChannelInfoMemberCell()
+            cell.configure(with: participant)
+            return cell
+
+        case .viewAllMembers:
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: DemoChannelInfoButtonCell.reuseIdentifier,
+                for: indexPath
+            ) as? DemoChannelInfoButtonCell ?? DemoChannelInfoButtonCell()
+            cell.configure(title: "View all")
+            return cell
+
+        case .mute:
+            let cell = dequeueItemCell(at: indexPath)
+            let isGroup = (channel?.memberCount ?? 0) > 2
+            cell.configure(
+                icon: appearance.images.muted,
+                title: isGroup ? "Mute Group" : "Mute User",
+                accessory: .toggle(isOn: channel?.isMuted == true)
+            )
+            cell.onToggle = { [weak self] isOn in
+                self?.setChannelMuted(isOn)
+            }
+            return cell
+
+        case .block:
+            let cell = dequeueItemCell(at: indexPath)
+            cell.configure(
+                icon: appearance.images.messageActionBlockUser,
+                title: blockUserTitle,
+                accessory: .none
+            )
+            return cell
+
+        case .leave:
+            let cell = dequeueItemCell(at: indexPath)
+            cell.configure(
+                icon: showsSingleMemberDMView
+                    ? appearance.images.trash
+                    : UIImage(systemName: "rectangle.portrait.and.arrow.right") ?? appearance.images.trash,
+                title: leaveConversationTitle,
+                accessory: .none,
+                isDestructive: true
+            )
+            return cell
+        }
+    }
+
+    private func dequeueItemCell(at indexPath: IndexPath) -> DemoChannelInfoItemCell {
+        tableView.dequeueReusableCell(
+            withIdentifier: DemoChannelInfoItemCell.reuseIdentifier,
+            for: indexPath
+        ) as? DemoChannelInfoItemCell ?? DemoChannelInfoItemCell()
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard sections[section].section == .members, let channel else { return nil }
+
+        let headerView = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: DemoChannelInfoMembersHeaderView.reuseIdentifier
+        ) as? DemoChannelInfoMembersHeaderView
+        headerView?.configure(
+            title: channel.memberCount == 1 ? "1 Member" : "\(channel.memberCount) Members",
+            showsAddButton: !channel.isDirectMessageChannel && channel.canUpdateChannelMembers
+        )
+        headerView?.onAddTapped = { [weak self] in
+            self?.addMembersTapped()
+        }
+        return headerView
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        sections[section].section == .members ? UITableView.automaticDimension : appearance.tokens.spacingSm
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch sections[indexPath.section].items[indexPath.row] {
+        case .pinnedMessages:
+            showPinnedMessages()
+        case .media:
+            showMediaAttachments()
+        case .files:
+            showFileAttachments()
+        case let .member(participant):
+            presentActions(for: participant, in: self, sourceView: tableView.cellForRow(at: indexPath))
+        case .viewAllMembers:
+            showAllMembers()
+        case .block:
+            blockUserTapped()
+        case .leave:
+            leaveConversationTapped()
+        case .mute:
+            break
+        }
+    }
+
+    // MARK: - Delegates
+
+    func channelController(
+        _ channelController: ChatChannelController,
+        didUpdateChannel channel: EntityChange<ChatChannel>
+    ) {
+        updateContent()
+    }
+
+    func currentUserController(
+        _ controller: CurrentChatUserController,
+        didChangeCurrentUser: EntityChange<CurrentChatUser>
+    ) {
+        updateContent()
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoChatChannelInfoVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoChatChannelInfoVC.swift
@@ -399,9 +399,9 @@ final class DemoChatChannelInfoVC: UIViewController,
         let memberListVC = DemoChannelMemberListVC(
             memberListController: client.memberListController(query: .init(cid: channel.cid))
         )
-        memberListVC.onMemberSelected = { [weak self, weak memberListVC] participant, sourceView in
+        memberListVC.onMemberSelected = { [weak self, weak memberListVC] participant in
             guard let self, let memberListVC else { return }
-            presentActions(for: participant, in: memberListVC, sourceView: sourceView)
+            presentParticipantInfo(for: participant, from: memberListVC)
         }
         navigationController?.pushViewController(memberListVC, animated: true)
     }
@@ -416,99 +416,108 @@ final class DemoChatChannelInfoVC: UIViewController,
         channelVC.jumpToMessage(id: messageId)
     }
 
-    private func presentActions(
+    private func presentParticipantInfo(
         for participant: DemoParticipantInfo,
-        in viewController: UIViewController,
-        sourceView: UIView?
+        from viewController: UIViewController
     ) {
         let actions = participantActions(for: participant)
         guard !actions.isEmpty else { return }
 
-        viewController.presentAlert(
-            title: participant.displayName,
-            actions: actions,
-            preferredStyle: .actionSheet,
-            sourceView: sourceView ?? viewController.view
-        )
+        let participantInfoVC = DemoParticipantInfoVC(participant: participant, actions: actions)
+        viewController.present(participantInfoVC, animated: true)
     }
 
-    private func participantActions(for participant: DemoParticipantInfo) -> [UIAlertAction] {
+    private func participantActions(for participant: DemoParticipantInfo) -> [DemoParticipantAction] {
         guard let channel else { return [] }
 
         if participant.id == currentUserId {
             guard !showsSingleMemberDMView, canLeaveConversation else { return [] }
             return [
-                .init(title: "Leave group", style: .destructive, handler: { [weak self] _ in
-                    self?.leaveConversationTapped()
-                })
+                .init(
+                    title: "Leave group",
+                    iconName: "rectangle.portrait.and.arrow.right",
+                    isDestructive: true,
+                    confirmation: .init(
+                        title: "Leave group",
+                        message: "Are you sure you want to leave this group?",
+                        buttonTitle: "Leave"
+                    ),
+                    action: { [weak self] in self?.leaveConversation() }
+                )
             ]
         }
 
-        var actions: [UIAlertAction] = []
+        var actions: [DemoParticipantAction] = []
 
-        actions.append(.init(title: "Send direct message", style: .default, handler: { [weak self] _ in
-            self?.showDirectMessageChannel(with: participant)
-        }))
+        actions.append(.init(
+            title: "Send Direct Message",
+            iconName: "message",
+            action: { [weak self] in self?.showDirectMessageChannel(with: participant) }
+        ))
 
         if channel.config.mutesEnabled {
             let isMuted = mutedUserIds.contains(participant.id)
-            actions.append(.init(title: isMuted ? "Unmute user" : "Mute user", style: .default, handler: { [weak self] _ in
-                guard let self else { return }
-                let userController = client.userController(userId: participant.id)
-                let completion: @MainActor (Error?) -> Void = { [weak self] error in
-                    if error != nil {
-                        self?.presentErrorAlert()
+            actions.append(.init(
+                title: isMuted ? "Unmute \(participant.displayName)" : "Mute \(participant.displayName)",
+                iconName: isMuted ? "speaker.wave.1" : "speaker.slash",
+                action: { [weak self] in
+                    guard let self else { return }
+                    let userController = client.userController(userId: participant.id)
+                    if isMuted {
+                        userController.unmute(completion: handleUserActionResult)
+                    } else {
+                        userController.mute(completion: handleUserActionResult)
                     }
                 }
-                if isMuted {
-                    userController.unmute(completion: completion)
-                } else {
-                    userController.mute(completion: completion)
-                }
-            }))
+            ))
         }
 
         let isBlocked = blockedUserIds.contains(participant.id)
-        actions.append(.init(title: isBlocked ? "Unblock user" : "Block user", style: .default, handler: { [weak self] _ in
-            guard let self else { return }
-            let userController = client.userController(userId: participant.id)
-            let completion: @MainActor (Error?) -> Void = { [weak self] error in
-                if error != nil {
-                    self?.presentErrorAlert()
+        actions.append(.init(
+            title: isBlocked ? "Unblock User" : "Block User",
+            iconName: "nosign",
+            confirmation: isBlocked ? nil : .init(
+                title: "Block User",
+                message: "Are you sure you want to block this user?",
+                buttonTitle: "Block User"
+            ),
+            action: { [weak self] in
+                guard let self else { return }
+                let userController = client.userController(userId: participant.id)
+                if isBlocked {
+                    userController.unblock(completion: handleUserActionResult)
+                } else {
+                    userController.block(completion: handleUserActionResult)
                 }
             }
-            if isBlocked {
-                userController.unblock(completion: completion)
-            } else {
-                userController.block(completion: completion)
-            }
-        }))
+        ))
 
         if channel.canUpdateChannelMembers {
-            actions.append(.init(title: "Remove user", style: .destructive, handler: { [weak self] _ in
-                self?.removeUserTapped(participant)
-            }))
+            actions.append(.init(
+                title: "Remove User",
+                iconName: "person.badge.minus",
+                isDestructive: true,
+                confirmation: .init(
+                    title: "Remove User",
+                    message: "Are you sure you want to remove \(participant.displayName) "
+                        + "from \(channel.name ?? channel.cid.id)?",
+                    buttonTitle: "Remove User"
+                ),
+                action: { [weak self] in
+                    self?.channelController.removeMembers(
+                        userIds: [participant.id],
+                        completion: self?.handleUserActionResult
+                    )
+                }
+            ))
         }
 
         return actions
     }
 
-    private func removeUserTapped(_ participant: DemoParticipantInfo) {
-        guard let channel else { return }
-
-        presentAlert(
-            title: "Remove User",
-            message: "Are you sure you want to remove \(participant.displayName) from \(channel.name ?? channel.cid.id)?",
-            actions: [
-                .init(title: "Remove User", style: .destructive, handler: { [weak self] _ in
-                    self?.channelController.removeMembers(userIds: [participant.id]) { [weak self] error in
-                        if error != nil {
-                            self?.presentErrorAlert()
-                        }
-                    }
-                })
-            ]
-        )
+    private func handleUserActionResult(_ error: Error?) {
+        guard error != nil else { return }
+        presentErrorAlert()
     }
 
     private func showDirectMessageChannel(with participant: DemoParticipantInfo) {
@@ -652,7 +661,7 @@ final class DemoChatChannelInfoVC: UIViewController,
         case .files:
             showFileAttachments()
         case let .member(participant):
-            presentActions(for: participant, in: self, sourceView: tableView.cellForRow(at: indexPath))
+            presentParticipantInfo(for: participant, from: self)
         case .viewAllMembers:
             showAllMembers()
         case .block:

--- a/DemoApp/Screens/ChannelInfo/DemoEditChannelInfoVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoEditChannelInfoVC.swift
@@ -145,10 +145,17 @@ final class DemoEditChannelInfoVC: UIViewController,
         saveButton.isEnabled = !name.isEmpty && (name != channel.name || pickedImage != nil)
     }
 
-    private func setLoading(_ isLoading: Bool) {
-        isLoading ? loadingIndicator.startAnimating() : loadingIndicator.stopAnimating()
-        saveButton.isEnabled = !isLoading
-        avatarView.alpha = isLoading ? 0.5 : 1
+    private func setSaving(_ isSaving: Bool) {
+        isSaving ? loadingIndicator.startAnimating() : loadingIndicator.stopAnimating()
+        avatarView.alpha = isSaving ? 0.5 : 1
+        nameTextField.isEnabled = !isSaving
+        uploadButton.isEnabled = !isSaving
+        cancelButton.isEnabled = !isSaving
+        if isSaving {
+            saveButton.isEnabled = false
+        } else {
+            updateSaveButton()
+        }
     }
 
     @objc private func nameChanged() {
@@ -188,24 +195,35 @@ final class DemoEditChannelInfoVC: UIViewController,
 
     @objc private func saveTapped() {
         let name = nameTextField.text ?? ""
+        setSaving(true)
 
-        guard let pickedImage, let localURL = try? saveToTemporaryURL(pickedImage) else {
-            updateChannel(name: name, imageURL: channel.imageURL)
+        guard let pickedImage else {
+            updateChannel(name: name, imageURL: channel.imageURL, uploadedImageURL: nil)
             return
         }
 
-        setLoading(true)
+        let localURL: URL
+        do {
+            localURL = try saveToTemporaryURL(pickedImage)
+        } catch {
+            saveFailed()
+            return
+        }
+
         channelController.client.uploadAttachment(localUrl: localURL, progress: nil) { [weak self] result in
-            let uploadedURL = try? result.get().fileURL
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                setLoading(false)
-                updateChannel(name: name, imageURL: uploadedURL ?? channel.imageURL)
+                guard let uploadedURL = try? result.get().fileURL else {
+                    saveFailed()
+                    return
+                }
+                updateChannel(name: name, imageURL: uploadedURL, uploadedImageURL: uploadedURL)
             }
         }
     }
 
-    private func updateChannel(name: String, imageURL: URL?) {
+    /// Updates the channel, deleting the freshly uploaded image again when the update itself fails.
+    private func updateChannel(name: String, imageURL: URL?, uploadedImageURL: URL?) {
         channelController.updateChannel(
             name: name,
             imageURL: imageURL,
@@ -213,12 +231,20 @@ final class DemoEditChannelInfoVC: UIViewController,
             extraData: channel.extraData
         ) { [weak self] error in
             guard let self else { return }
-            if error != nil {
-                presentAlert(title: "Something went wrong.")
-            } else {
-                dismiss(animated: true)
+            guard error == nil else {
+                if let uploadedImageURL {
+                    channelController.client.deleteAttachment(remoteUrl: uploadedImageURL) { _ in }
+                }
+                saveFailed()
+                return
             }
+            dismiss(animated: true)
         }
+    }
+
+    private func saveFailed() {
+        setSaving(false)
+        presentAlert(title: "Something went wrong.")
     }
 
     private func saveToTemporaryURL(_ image: UIImage) throws -> URL {

--- a/DemoApp/Screens/ChannelInfo/DemoEditChannelInfoVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoEditChannelInfoVC.swift
@@ -1,0 +1,259 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatUI
+import UIKit
+
+/// The screen used to change the name and the picture of a group channel.
+final class DemoEditChannelInfoVC: UIViewController,
+    ThemeProvider,
+    UITextFieldDelegate,
+    UIImagePickerControllerDelegate,
+    UINavigationControllerDelegate {
+    private let channelController: ChatChannelController
+    private let channel: ChatChannel
+
+    private var pickedImage: UIImage?
+
+    private lazy var avatarView = DemoChannelInfoAvatarView()
+
+    private lazy var uploadButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "Upload"
+        configuration.baseForegroundColor = appearance.colorPalette.buttonSecondaryText
+
+        let button = UIButton(type: .system)
+        button.configuration = configuration
+        button.addTarget(self, action: #selector(uploadTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var nameTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Group name"
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var nameTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "Add a group name"
+        textField.font = appearance.fonts.body
+        textField.textColor = appearance.colorPalette.textPrimary
+        textField.borderStyle = .roundedRect
+        textField.clearButtonMode = .whileEditing
+        textField.delegate = self
+        textField.addTarget(self, action: #selector(nameChanged), for: .editingChanged)
+        return textField
+    }()
+
+    private lazy var loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private lazy var saveButton = UIBarButtonItem(
+        title: "Save",
+        style: .done,
+        target: self,
+        action: #selector(saveTapped)
+    )
+
+    private lazy var cancelButton = UIBarButtonItem(
+        title: "Cancel",
+        style: .plain,
+        target: self,
+        action: #selector(cancelTapped)
+    )
+
+    init(channelController: ChatChannelController, channel: ChatChannel) {
+        self.channelController = channelController
+        self.channel = channel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = "Edit Group"
+        view.backgroundColor = appearance.colorPalette.backgroundCoreApp
+        navigationItem.leftBarButtonItem = cancelButton
+        navigationItem.rightBarButtonItem = saveButton
+
+        setUpLayout()
+
+        avatarView.content = (channel, channelController.client.currentUserId)
+        nameTextField.text = channel.name
+        updateSaveButton()
+    }
+
+    private func setUpLayout() {
+        let avatarContainer = UIView()
+        avatarContainer.addSubview(avatarView)
+        avatarContainer.addSubview(loadingIndicator)
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            avatarView.topAnchor.constraint(equalTo: avatarContainer.topAnchor),
+            avatarView.bottomAnchor.constraint(equalTo: avatarContainer.bottomAnchor),
+            avatarView.centerXAnchor.constraint(equalTo: avatarContainer.centerXAnchor),
+            avatarView.widthAnchor.constraint(equalToConstant: DemoChannelInfoAvatarView.size),
+            avatarView.heightAnchor.constraint(equalToConstant: DemoChannelInfoAvatarView.size),
+            loadingIndicator.centerXAnchor.constraint(equalTo: avatarView.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor)
+        ])
+
+        let container = VContainer(spacing: appearance.tokens.spacingMd) {
+            avatarContainer
+            uploadButton
+            VContainer(spacing: appearance.tokens.spacingXxs) {
+                nameTitleLabel
+                nameTextField
+            }
+            Spacer()
+        }
+        view.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: appearance.tokens.spacingXl
+            ),
+            container.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: appearance.tokens.spacingMd
+            ),
+            container.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -appearance.tokens.spacingMd
+            ),
+            container.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+
+    private func updateSaveButton() {
+        let name = nameTextField.text ?? ""
+        saveButton.isEnabled = !name.isEmpty && (name != channel.name || pickedImage != nil)
+    }
+
+    private func setLoading(_ isLoading: Bool) {
+        isLoading ? loadingIndicator.startAnimating() : loadingIndicator.stopAnimating()
+        saveButton.isEnabled = !isLoading
+        avatarView.alpha = isLoading ? 0.5 : 1
+    }
+
+    @objc private func nameChanged() {
+        updateSaveButton()
+    }
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+
+    @objc private func uploadTapped() {
+        var actions: [UIAlertAction] = [
+            .init(title: "Choose Image", style: .default, handler: { [weak self] _ in
+                self?.presentImagePicker(sourceType: .photoLibrary)
+            })
+        ]
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            actions.append(.init(title: "Take Photo", style: .default, handler: { [weak self] _ in
+                self?.presentImagePicker(sourceType: .camera)
+            }))
+        }
+
+        presentAlert(
+            title: "Edit Group Picture",
+            actions: actions,
+            preferredStyle: .actionSheet,
+            sourceView: uploadButton
+        )
+    }
+
+    private func presentImagePicker(sourceType: UIImagePickerController.SourceType) {
+        let picker = UIImagePickerController()
+        picker.sourceType = sourceType
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    @objc private func saveTapped() {
+        let name = nameTextField.text ?? ""
+
+        guard let pickedImage, let localURL = try? saveToTemporaryURL(pickedImage) else {
+            updateChannel(name: name, imageURL: channel.imageURL)
+            return
+        }
+
+        setLoading(true)
+        channelController.client.uploadAttachment(localUrl: localURL, progress: nil) { [weak self] result in
+            let uploadedURL = try? result.get().fileURL
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                setLoading(false)
+                updateChannel(name: name, imageURL: uploadedURL ?? channel.imageURL)
+            }
+        }
+    }
+
+    private func updateChannel(name: String, imageURL: URL?) {
+        channelController.updateChannel(
+            name: name,
+            imageURL: imageURL,
+            team: channel.team,
+            extraData: channel.extraData
+        ) { [weak self] error in
+            guard let self else { return }
+            if error != nil {
+                presentAlert(title: "Something went wrong.")
+            } else {
+                dismiss(animated: true)
+            }
+        }
+    }
+
+    private func saveToTemporaryURL(_ image: UIImage) throws -> URL {
+        guard let data = image.jpegData(compressionQuality: 0.8) else {
+            throw ClientError.Unexpected("Failed to encode the picked image.")
+        }
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jpg")
+        try data.write(to: url)
+        return url
+    }
+
+    // MARK: - UITextFieldDelegate
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+
+    // MARK: - UIImagePickerControllerDelegate
+
+    func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+    ) {
+        picker.dismiss(animated: true)
+
+        guard let image = info[.originalImage] as? UIImage else { return }
+        pickedImage = image
+        avatarView.presenceAvatarView.avatarView.imageView.image = image
+        updateSaveButton()
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+    }
+}

--- a/DemoApp/Screens/ChannelInfo/DemoParticipantInfoVC.swift
+++ b/DemoApp/Screens/ChannelInfo/DemoParticipantInfoVC.swift
@@ -1,0 +1,247 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatUI
+import UIKit
+
+/// An action that can be performed on a channel member from the channel info screen.
+struct DemoParticipantAction {
+    struct Confirmation {
+        let title: String
+        let message: String
+        let buttonTitle: String
+    }
+
+    let title: String
+    /// The name of the SF Symbol shown next to the title.
+    let iconName: String
+    var isDestructive: Bool = false
+    var confirmation: Confirmation?
+    let action: () -> Void
+}
+
+/// The bottom sheet showing a channel member and the actions available for it.
+///
+/// It is the UIKit counterpart of the `ParticipantInfoView` from the SwiftUI SDK.
+final class DemoParticipantInfoVC: UIViewController, ThemeProvider {
+    /// The height the sheet uses until its content has been laid out.
+    private static let estimatedContentHeight: CGFloat = 280
+    private static let avatarSize: CGFloat = 48
+
+    private let participant: DemoParticipantInfo
+    private let actions: [DemoParticipantAction]
+
+    private var contentHeight = DemoParticipantInfoVC.estimatedContentHeight
+
+    private lazy var avatarView = components.userAvatarView.init()
+
+    private lazy var nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.title3
+        label.textColor = appearance.colorPalette.textPrimary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var mutedIconView: UIImageView = {
+        let imageView = UIImageView(image: appearance.images.muted.withRenderingMode(.alwaysTemplate))
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = appearance.colorPalette.textTertiary
+        imageView.accessibilityLabel = "Muted"
+        return imageView
+    }()
+
+    private lazy var onlineInfoLabel: UILabel = {
+        let label = UILabel()
+        label.font = appearance.fonts.footnote
+        label.textColor = appearance.colorPalette.textSecondary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var contentContainer: UIStackView = {
+        let container = VContainer(spacing: 0)
+        container.addArrangedSubview(headerView)
+        actions.forEach { action in
+            container.addArrangedSubview(
+                DemoParticipantActionRow(action: action) { [weak self] action in
+                    self?.perform(action)
+                }
+            )
+        }
+        return container
+    }()
+
+    private lazy var headerView: UIView = {
+        HContainer(spacing: appearance.tokens.spacingMd, alignment: .center) {
+            avatarView
+                .width(Self.avatarSize)
+                .height(Self.avatarSize)
+            VContainer(spacing: appearance.tokens.spacingXxxs) {
+                HContainer(spacing: appearance.tokens.spacingXs, alignment: .center) {
+                    nameLabel
+                    mutedIconView
+                        .width(appearance.tokens.iconSizeSm)
+                        .height(appearance.tokens.iconSizeSm)
+                    Spacer()
+                }
+                onlineInfoLabel
+            }
+            Spacer()
+        }.padding(appearance.tokens.spacingMd)
+    }()
+
+    init(participant: DemoParticipantInfo, actions: [DemoParticipantAction]) {
+        self.participant = participant
+        self.actions = actions
+        super.init(nibName: nil, bundle: nil)
+
+        modalPresentationStyle = .pageSheet
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = appearance.colorPalette.backgroundCoreSurfaceCard
+        view.addSubview(contentContainer)
+        NSLayoutConstraint.activate([
+            contentContainer.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        avatarView.content = participant.chatUser
+        nameLabel.text = participant.displayName
+        onlineInfoLabel.text = participant.onlineInfoText
+        mutedIconView.isHidden = !participant.isMuted
+
+        setUpSheet()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let fittingHeight = contentContainer.systemLayoutSizeFitting(
+            CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height + view.safeAreaInsets.top + view.safeAreaInsets.bottom
+
+        guard abs(fittingHeight - contentHeight) > 1 else { return }
+        contentHeight = fittingHeight
+
+        if #available(iOS 16.0, *) {
+            sheetPresentationController?.invalidateDetents()
+        }
+    }
+
+    private func setUpSheet() {
+        guard let sheet = sheetPresentationController else { return }
+
+        sheet.prefersGrabberVisible = true
+        sheet.preferredCornerRadius = appearance.tokens.radius2xl
+        if #available(iOS 16.0, *) {
+            sheet.detents = [
+                .custom(identifier: .init("participantInfo")) { [weak self] context in
+                    min(self?.contentHeight ?? Self.estimatedContentHeight, context.maximumDetentValue)
+                },
+                .medium()
+            ]
+        } else {
+            sheet.detents = [.medium()]
+        }
+    }
+
+    // MARK: - Actions
+
+    private func perform(_ action: DemoParticipantAction) {
+        guard let confirmation = action.confirmation else {
+            dismiss(animated: true) { action.action() }
+            return
+        }
+
+        presentAlert(
+            title: confirmation.title,
+            message: confirmation.message,
+            actions: [
+                .init(title: confirmation.buttonTitle, style: .destructive, handler: { [weak self] _ in
+                    self?.dismiss(animated: true) { action.action() }
+                })
+            ]
+        )
+    }
+}
+
+/// A single action row of the participant info sheet.
+private final class DemoParticipantActionRow: UIControl, ThemeProvider {
+    private let action: DemoParticipantAction
+    private let onTap: (DemoParticipantAction) -> Void
+
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted ? appearance.colorPalette.backgroundCoreSurfaceSubtle : .clear
+        }
+    }
+
+    private lazy var iconView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: action.iconName))
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = action.isDestructive
+            ? appearance.colorPalette.accentError
+            : appearance.colorPalette.textSecondary
+        return imageView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = action.title
+        label.font = appearance.fonts.body
+        label.textColor = action.isDestructive
+            ? appearance.colorPalette.accentError
+            : appearance.colorPalette.textPrimary
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    init(action: DemoParticipantAction, onTap: @escaping (DemoParticipantAction) -> Void) {
+        self.action = action
+        self.onTap = onTap
+        super.init(frame: .zero)
+
+        accessibilityLabel = action.title
+        accessibilityTraits = .button
+        addTarget(self, action: #selector(tapped), for: .touchUpInside)
+        setUpLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUpLayout() {
+        HContainer(spacing: appearance.tokens.spacingMd, alignment: .center) {
+            iconView
+                .width(appearance.tokens.spacingLg)
+                .height(appearance.tokens.spacingLg)
+            titleLabel
+            Spacer()
+        }
+        .padding(appearance.tokens.spacingMd)
+        .embed(in: self)
+        // The stack must not swallow the touches the row itself handles.
+        subviews.forEach { $0.isUserInteractionEnabled = false }
+    }
+
+    @objc private func tapped() {
+        onTap(action)
+    }
+}

--- a/DemoApp/StreamChat/Components/DemoChatChannelVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelVC.swift
@@ -48,6 +48,21 @@ final class DemoChatChannelVC: ChatChannelVC, UIGestureRecognizerDelegate {
         )
         navigationItem.leftBarButtonItems = [customBackButton]
         navigationController?.interactivePopGestureRecognizer?.delegate = self
+
+        channelAvatarView.isUserInteractionEnabled = true
+        channelAvatarView.isAccessibilityElement = true
+        channelAvatarView.accessibilityTraits = .button
+        channelAvatarView.accessibilityLabel = "Channel info"
+        channelAvatarView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(channelAvatarTapped))
+        )
+    }
+
+    @objc private func channelAvatarTapped() {
+        guard let cid = channelController.cid else { return }
+
+        let channelInfoVC = DemoChatChannelInfoVC(cid: cid, client: channelController.client)
+        show(channelInfoVC, sender: self)
     }
 
     @objc private func debugTap() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1984/demoapp-add-chat-info-screens-on-uikit.

### 🎯 Goal

Add the chat info screens in the demo app. 

### 📝 Summary

We don't need to add it in the SDK, but it's good for the demo app if it shows this functionality - it's anyway fast to build with AI.

### 🛠 Implementation

Used SwiftUI's implementation as a reference.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a channel information screen with channel details, member management, mute, block, leave, edit, and delete actions.
  * Added searchable member selection and paginated member lists.
  * Added member detail views with participant status and contextual actions.
  * Added pinned messages, media attachments, file attachments, previews, and grouped file browsing.
  * Added channel editing for names and images.
  * Made the channel avatar open channel information when tapped.
  * Added loading, empty, error, retry, and pagination states.
  * Added photo library permission messaging for photo attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->