### PR TITLE
Reformat OpenAPI generated code

### DIFF
--- a/Scripts/openapi_generate.sh
+++ b/Scripts/openapi_generate.sh
@@ -424,24 +424,6 @@ rename_generated_type MarkDeliveredResponse EmptyResponse
 rename_generated_type Response EmptyResponse
 rename_generated_type ShowChannelResponse EmptyResponse
 
-# Remove a generated property (declaration, doc comment, init param, assignment,
-#     CodingKeys case). Runs before publicize, so there are no access modifiers to
-#     handle. Assumes the single-line init the generator emits (step 7 re-wraps).
-remove_property() {
-  local file="$OUTPUT_DIR_CHAT/models/$1.swift"
-  awk -v p="$2" '
-    function flush() { for (i = 1; i <= n; i++) print b[i]; n = 0 }
-    { s = $0; sub(/^[[:space:]]+/, "", s) }
-    s ~ /^(\/\/\/|@available)/         { b[++n] = $0; next }
-    s ~ "^let " p ": "                 { n = 0; next }
-    s ~ "^self\\." p " = " p "$"       { next }
-    s ~ "^case " p "( =|$)"            { next }
-    s ~ /^init\(/ { sub("\\(" p ": [^,)]*, ", "("); sub(", " p ": [^,)]*", ""); sub("\\(" p ": [^,)]*\\)", "()") }
-    { flush(); print }
-  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-}
-remove_property FileUploadResponse duration
-
 retype_property PushPreference chatLevel String PushPreferenceLevel
 rename_property PushPreference chatLevel level
 restore_nonoptional_property PushPreference level PushPreferenceLevel .all
@@ -488,6 +470,7 @@ remove_property() {
   perl -0777 -pi -e 's/ &&(\n\s*\})/$1/g' "$file"
 }
 remove_property CurrentUserUnreads duration
+remove_property FileUploadResponse duration
 remove_property MessageReactionsPayload duration
 remove_property PushPreferenceInput callLevel
 remove_property PushPreferenceInput chatPreferences
@@ -753,14 +736,7 @@ PY
 }
 inject_v1_endpoint_paths
 
-# 7. Force generated OpenAPI function declarations to wrap one parameter per line.
-swiftformat "$OUTPUT_DIR_CHAT" \
-  --rules wrapArguments \
-  --wrapparameters before-first \
-  --wraparguments preserve \
-  --maxwidth 1
-
-# 8. Generate a v1/v2 compatible `init(from:)` and splice it into the model's class
+# 7. Generate a v1/v2 compatible `init(from:)` and splice it into the model's class
 #    body, where a `required` initializer is allowed.
 splice_generated_decoders() {
   local generated="$OUTPUT_DIR_CHAT/OpenAPIDecoders.generated.swift"
@@ -785,3 +761,10 @@ PY
 }
 sourcery --config "$REPO_ROOT/Sources/StreamChat/.openapi.sourcery.yml"
 splice_generated_decoders
+
+# 8. Wrap generated OpenAPI function declarations that exceed the maximum width.
+swiftformat "$OUTPUT_DIR_CHAT" \
+  --rules wrapArguments \
+  --wrapparameters before-first \
+  --wraparguments preserve \
+  --maxwidth 100

--- a/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/APIs/DefaultEndpoints.swift
@@ -37,10 +37,7 @@ enum EndpointPath: Codable {
     case unpinMessage(MessageId)
     case replies(MessageId)
     case addReaction(MessageId)
-    case deleteReaction(
-        MessageId,
-        MessageReactionType
-    )
+    case deleteReaction(MessageId, MessageReactionType)
     case messageAction(MessageId)
     case translateMessage(MessageId)
 
@@ -58,35 +55,19 @@ enum EndpointPath: Codable {
 
     case addUserGroupMembers(id: String)
     case blockUsers
-    case castPollVote(
-        messageId: String,
-        pollId: String
-    )
+    case castPollVote(messageId: String, pollId: String)
     case createDevice
     case createPoll
     case createPollOption(pollId: String)
     case createUserGroup
-    case deleteChannel(
-        type: String,
-        id: String
-    )
-    case deleteChannelFile(
-        type: String,
-        id: String
-    )
-    case deleteChannelImage(
-        type: String,
-        id: String
-    )
+    case deleteChannel(type: String, id: String)
+    case deleteChannelFile(type: String, id: String)
+    case deleteChannelImage(type: String, id: String)
     case deleteDevice
     case deleteFile
     case deleteImage
     case deletePoll(pollId: String)
-    case deletePollVote(
-        messageId: String,
-        pollId: String,
-        voteId: String
-    )
+    case deletePollVote(messageId: String, pollId: String, voteId: String)
     case deleteUserGroup(id: String)
     case getApp
     case getBlockedUsers
@@ -94,10 +75,7 @@ enum EndpointPath: Codable {
     case getReactions(id: String)
     case getUserGroup(id: String)
     case getUserLiveLocations
-    case hideChannel(
-        type: String,
-        id: String
-    )
+    case hideChannel(type: String, id: String)
     case listDevices
     case listUserGroups
     case markDelivered
@@ -109,34 +87,19 @@ enum EndpointPath: Codable {
     case removeUserGroupMembers(id: String)
     case searchRoles
     case searchUserGroups
-    case showChannel(
-        type: String,
-        id: String
-    )
-    case stopWatchingChannel(
-        type: String,
-        id: String
-    )
+    case showChannel(type: String, id: String)
+    case stopWatchingChannel(type: String, id: String)
     case unblockUsers
     case unmute
     case unmuteChannel
     case unreadCounts
     case updateLiveLocation
-    case updateMemberPartial(
-        type: String,
-        id: String
-    )
+    case updateMemberPartial(type: String, id: String)
     case updatePollPartial(pollId: String)
     case updatePushNotificationPreferences
     case updateUserGroup(id: String)
-    case uploadChannelFile(
-        type: String,
-        id: String
-    )
-    case uploadChannelImage(
-        type: String,
-        id: String
-    )
+    case uploadChannelFile(type: String, id: String)
+    case uploadChannelImage(type: String, id: String)
     case uploadFile
     case uploadImage
 
@@ -178,10 +141,7 @@ enum EndpointPath: Codable {
         case let .unpinMessage(messageId): return "messages/\(messageId)"
         case let .replies(messageId): return "messages/\(messageId)/replies"
         case let .addReaction(messageId): return "messages/\(messageId)/reaction"
-        case let .deleteReaction(
-            messageId,
-            reaction
-        ): return "messages/\(messageId)/reaction/\(reaction.rawValue)"
+        case let .deleteReaction(messageId, reaction): return "messages/\(messageId)/reaction/\(reaction.rawValue)"
         case let .messageAction(messageId): return "messages/\(messageId)/action"
         case let .translateMessage(messageId): return "messages/\(messageId)/translate"
 
@@ -199,10 +159,7 @@ enum EndpointPath: Codable {
             return "/api/v2/usergroups/\(APIHelper.escapedPathItem(id))/members"
         case .blockUsers:
             return "/api/v2/users/block"
-        case let .castPollVote(
-            messageId: messageId,
-            pollId: pollId
-        ):
+        case let .castPollVote(messageId: messageId, pollId: pollId):
             return "/api/v2/chat/messages/\(APIHelper.escapedPathItem(messageId))/polls/\(APIHelper.escapedPathItem(pollId))/vote"
         case .createDevice:
             return "/api/v2/devices"
@@ -212,20 +169,11 @@ enum EndpointPath: Codable {
             return "/api/v2/polls/\(APIHelper.escapedPathItem(pollId))/options"
         case .createUserGroup:
             return "/api/v2/usergroups"
-        case let .deleteChannel(
-            type: type,
-            id: id
-        ):
+        case let .deleteChannel(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))"
-        case let .deleteChannelFile(
-            type: type,
-            id: id
-        ):
+        case let .deleteChannelFile(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/file"
-        case let .deleteChannelImage(
-            type: type,
-            id: id
-        ):
+        case let .deleteChannelImage(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/image"
         case .deleteDevice:
             return "/api/v2/devices"
@@ -235,11 +183,7 @@ enum EndpointPath: Codable {
             return "/api/v2/uploads/image"
         case let .deletePoll(pollId: pollId):
             return "/api/v2/polls/\(APIHelper.escapedPathItem(pollId))"
-        case let .deletePollVote(
-            messageId: messageId,
-            pollId: pollId,
-            voteId: voteId
-        ):
+        case let .deletePollVote(messageId: messageId, pollId: pollId, voteId: voteId):
             return "/api/v2/chat/messages/\(APIHelper.escapedPathItem(messageId))/polls/\(APIHelper.escapedPathItem(pollId))/vote/\(APIHelper.escapedPathItem(voteId))"
         case let .deleteUserGroup(id: id):
             return "/api/v2/usergroups/\(APIHelper.escapedPathItem(id))"
@@ -255,10 +199,7 @@ enum EndpointPath: Codable {
             return "/api/v2/usergroups/\(APIHelper.escapedPathItem(id))"
         case .getUserLiveLocations:
             return "/api/v2/users/live_locations"
-        case let .hideChannel(
-            type: type,
-            id: id
-        ):
+        case let .hideChannel(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/hide"
         case .listDevices:
             return "/api/v2/devices"
@@ -282,15 +223,9 @@ enum EndpointPath: Codable {
             return "/api/v2/roles/search"
         case .searchUserGroups:
             return "/api/v2/usergroups/search"
-        case let .showChannel(
-            type: type,
-            id: id
-        ):
+        case let .showChannel(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/show"
-        case let .stopWatchingChannel(
-            type: type,
-            id: id
-        ):
+        case let .stopWatchingChannel(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/stop-watching"
         case .unblockUsers:
             return "/api/v2/users/unblock"
@@ -302,10 +237,7 @@ enum EndpointPath: Codable {
             return "/api/v2/chat/unread"
         case .updateLiveLocation:
             return "/api/v2/users/live_locations"
-        case let .updateMemberPartial(
-            type: type,
-            id: id
-        ):
+        case let .updateMemberPartial(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/member"
         case let .updatePollPartial(pollId: pollId):
             return "/api/v2/polls/\(APIHelper.escapedPathItem(pollId))"
@@ -313,15 +245,9 @@ enum EndpointPath: Codable {
             return "/api/v2/push_preferences"
         case let .updateUserGroup(id: id):
             return "/api/v2/usergroups/\(APIHelper.escapedPathItem(id))"
-        case let .uploadChannelFile(
-            type: type,
-            id: id
-        ):
+        case let .uploadChannelFile(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/file"
-        case let .uploadChannelImage(
-            type: type,
-            id: id
-        ):
+        case let .uploadChannelImage(type: type, id: id):
             return "/api/v2/chat/channels/\(APIHelper.escapedPathItem(type))/\(APIHelper.escapedPathItem(id))/image"
         case .uploadFile:
             return "/api/v2/uploads/file"
@@ -366,61 +292,25 @@ final class Endpoint<ResponseType: Decodable>: Codable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        path = try container.decode(
-            EndpointPath.self,
-            forKey: .path
-        )
-        method = try container.decode(
-            EndpointMethod.self,
-            forKey: .method
-        )
-        queryItems = try container.decodeIfPresent(
-            Data.self,
-            forKey: .queryItems
-        )
-        requiresConnectionId = try container.decode(
-            Bool.self,
-            forKey: .requiresConnectionId
-        )
-        requiresToken = try container.decode(
-            Bool.self,
-            forKey: .requiresToken
-        )
-        body = try container.decodeIfPresent(
-            Data.self,
-            forKey: .body
-        )
+        path = try container.decode(EndpointPath.self, forKey: .path)
+        method = try container.decode(EndpointMethod.self, forKey: .method)
+        queryItems = try container.decodeIfPresent(Data.self, forKey: .queryItems)
+        requiresConnectionId = try container.decode(Bool.self, forKey: .requiresConnectionId)
+        requiresToken = try container.decode(Bool.self, forKey: .requiresToken)
+        body = try container.decodeIfPresent(Data.self, forKey: .body)
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(
-            path,
-            forKey: .path
-        )
-        try container.encode(
-            method,
-            forKey: .method
-        )
+        try container.encode(path, forKey: .path)
+        try container.encode(method, forKey: .method)
         if let queryItems = try queryItems?.encodedAsData() {
-            try container.encode(
-                queryItems,
-                forKey: .queryItems
-            )
+            try container.encode(queryItems, forKey: .queryItems)
         }
-        try container.encode(
-            requiresConnectionId,
-            forKey: .requiresConnectionId
-        )
-        try container.encode(
-            requiresToken,
-            forKey: .requiresToken
-        )
+        try container.encode(requiresConnectionId, forKey: .requiresConnectionId)
+        try container.encode(requiresToken, forKey: .requiresToken)
         if let body = try body?.encodedAsData() {
-            try container.encode(
-                body,
-                forKey: .body
-            )
+            try container.encode(body, forKey: .body)
         }
     }
 }
@@ -457,10 +347,7 @@ extension Endpoint {
         )
     }
 
-    static func blockUsers(
-        blockUsersRequest: BlockUsersRequest,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<BlockUsersResponse> {
+    static func blockUsers(blockUsersRequest: BlockUsersRequest, requiresConnectionId: Bool = false) -> Endpoint<BlockUsersResponse> {
         return .init(
             path: .blockUsers,
             method: .post,
@@ -477,10 +364,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<PollVotePayloadResponse> {
         return .init(
-            path: .castPollVote(
-                messageId: messageId,
-                pollId: pollId
-            ),
+            path: .castPollVote(messageId: messageId, pollId: pollId),
             method: .post,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -548,10 +432,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<DeleteChannelResponse> {
         return .init(
-            path: .deleteChannel(
-                type: type,
-                id: id
-            ),
+            path: .deleteChannel(type: type, id: id),
             method: .delete,
             queryItems: APIHelper.mapValuesToQueryDictionary([
                 "hard_delete": hardDelete
@@ -568,10 +449,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<EmptyResponse> {
         return .init(
-            path: .deleteChannelFile(
-                type: type,
-                id: id
-            ),
+            path: .deleteChannelFile(type: type, id: id),
             method: .delete,
             queryItems: APIHelper.mapValuesToQueryDictionary([
                 "url": url
@@ -588,10 +466,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<EmptyResponse> {
         return .init(
-            path: .deleteChannelImage(
-                type: type,
-                id: id
-            ),
+            path: .deleteChannelImage(type: type, id: id),
             method: .delete,
             queryItems: APIHelper.mapValuesToQueryDictionary([
                 "url": url
@@ -601,10 +476,7 @@ extension Endpoint {
         )
     }
 
-    static func deleteDevice(
-        id: String,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<EmptyResponse> {
+    static func deleteDevice(id: String, requiresConnectionId: Bool = false) -> Endpoint<EmptyResponse> {
         return .init(
             path: .deleteDevice,
             method: .delete,
@@ -616,10 +488,7 @@ extension Endpoint {
         )
     }
 
-    static func deleteFile(
-        url: String?,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<EmptyResponse> {
+    static func deleteFile(url: String?, requiresConnectionId: Bool = false) -> Endpoint<EmptyResponse> {
         return .init(
             path: .deleteFile,
             method: .delete,
@@ -631,10 +500,7 @@ extension Endpoint {
         )
     }
 
-    static func deleteImage(
-        url: String?,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<EmptyResponse> {
+    static func deleteImage(url: String?, requiresConnectionId: Bool = false) -> Endpoint<EmptyResponse> {
         return .init(
             path: .deleteImage,
             method: .delete,
@@ -646,10 +512,7 @@ extension Endpoint {
         )
     }
 
-    static func deletePoll(
-        pollId: String,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<EmptyResponse> {
+    static func deletePoll(pollId: String, requiresConnectionId: Bool = false) -> Endpoint<EmptyResponse> {
         return .init(
             path: .deletePoll(pollId: pollId),
             method: .delete,
@@ -666,11 +529,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<PollVotePayloadResponse> {
         return .init(
-            path: .deletePollVote(
-                messageId: messageId,
-                pollId: pollId,
-                voteId: voteId
-            ),
+            path: .deletePollVote(messageId: messageId, pollId: pollId, voteId: voteId),
             method: .delete,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -678,11 +537,7 @@ extension Endpoint {
         )
     }
 
-    static func deleteUserGroup(
-        id: String,
-        teamId: String?,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<EmptyResponse> {
+    static func deleteUserGroup(id: String, teamId: String?, requiresConnectionId: Bool = false) -> Endpoint<EmptyResponse> {
         return .init(
             path: .deleteUserGroup(id: id),
             method: .delete,
@@ -714,10 +569,7 @@ extension Endpoint {
         )
     }
 
-    static func getOG(
-        url: String,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<GetOGResponse> {
+    static func getOG(url: String, requiresConnectionId: Bool = false) -> Endpoint<GetOGResponse> {
         return .init(
             path: .getOG,
             method: .get,
@@ -747,11 +599,7 @@ extension Endpoint {
         )
     }
 
-    static func getUserGroup(
-        id: String,
-        teamId: String?,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<UserGroupResponse> {
+    static func getUserGroup(id: String, teamId: String?, requiresConnectionId: Bool = false) -> Endpoint<UserGroupResponse> {
         return .init(
             path: .getUserGroup(id: id),
             method: .get,
@@ -780,10 +628,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<EmptyResponse> {
         return .init(
-            path: .hideChannel(
-                type: type,
-                id: id
-            ),
+            path: .hideChannel(type: type, id: id),
             method: .post,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -835,10 +680,7 @@ extension Endpoint {
         )
     }
 
-    static func mute(
-        muteRequest: MuteRequest,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<MuteResponse> {
+    static func mute(muteRequest: MuteRequest, requiresConnectionId: Bool = false) -> Endpoint<MuteResponse> {
         return .init(
             path: .mute,
             method: .post,
@@ -861,10 +703,7 @@ extension Endpoint {
         )
     }
 
-    static func queryMembers(
-        payload: QueryMembersPayload?,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<MembersResponse> {
+    static func queryMembers(payload: QueryMembersPayload?, requiresConnectionId: Bool = false) -> Endpoint<MembersResponse> {
         return .init(
             path: .queryMembers,
             method: .get,
@@ -967,16 +806,9 @@ extension Endpoint {
         )
     }
 
-    static func showChannel(
-        type: String,
-        id: String,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<EmptyResponse> {
+    static func showChannel(type: String, id: String, requiresConnectionId: Bool = false) -> Endpoint<EmptyResponse> {
         return .init(
-            path: .showChannel(
-                type: type,
-                id: id
-            ),
+            path: .showChannel(type: type, id: id),
             method: .post,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -984,16 +816,9 @@ extension Endpoint {
         )
     }
 
-    static func stopWatchingChannel(
-        type: String,
-        id: String,
-        requiresConnectionId: Bool = true
-    ) -> Endpoint<EmptyResponse> {
+    static func stopWatchingChannel(type: String, id: String, requiresConnectionId: Bool = true) -> Endpoint<EmptyResponse> {
         return .init(
-            path: .stopWatchingChannel(
-                type: type,
-                id: id
-            ),
+            path: .stopWatchingChannel(type: type, id: id),
             method: .post,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -1014,10 +839,7 @@ extension Endpoint {
         )
     }
 
-    static func unmute(
-        unmuteRequest: UnmuteRequest,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<UnmuteUsersResponse> {
+    static func unmute(unmuteRequest: UnmuteRequest, requiresConnectionId: Bool = false) -> Endpoint<UnmuteUsersResponse> {
         return .init(
             path: .unmute,
             method: .post,
@@ -1070,10 +892,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<UpdateMemberPartialResponse> {
         return .init(
-            path: .updateMemberPartial(
-                type: type,
-                id: id
-            ),
+            path: .updateMemberPartial(type: type, id: id),
             method: .patch,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -1129,10 +948,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<UploadChannelFileResponse> {
         return .init(
-            path: .uploadChannelFile(
-                type: type,
-                id: id
-            ),
+            path: .uploadChannelFile(type: type, id: id),
             method: .post,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -1147,10 +963,7 @@ extension Endpoint {
         requiresConnectionId: Bool = false
     ) -> Endpoint<UploadChannelResponse> {
         return .init(
-            path: .uploadChannelImage(
-                type: type,
-                id: id
-            ),
+            path: .uploadChannelImage(type: type, id: id),
             method: .post,
             queryItems: nil,
             requiresConnectionId: requiresConnectionId,
@@ -1158,10 +971,7 @@ extension Endpoint {
         )
     }
 
-    static func uploadFile(
-        multipartFormData: MultipartFormData,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<FileUploadResponse> {
+    static func uploadFile(multipartFormData: MultipartFormData, requiresConnectionId: Bool = false) -> Endpoint<FileUploadResponse> {
         return .init(
             path: .uploadFile,
             method: .post,
@@ -1171,10 +981,7 @@ extension Endpoint {
         )
     }
 
-    static func uploadImage(
-        multipartFormData: MultipartFormData,
-        requiresConnectionId: Bool = false
-    ) -> Endpoint<ImageUploadResponse> {
+    static func uploadImage(multipartFormData: MultipartFormData, requiresConnectionId: Bool = false) -> Endpoint<ImageUploadResponse> {
         return .init(
             path: .uploadImage,
             method: .post,

--- a/Sources/StreamChat/Generated/OpenAPI/models/AddUserGroupMembersRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AddUserGroupMembersRequest.swift
@@ -11,11 +11,7 @@ final class AddUserGroupMembersRequest: Sendable, Codable, JSONEncodable {
     let memberIds: [String]
     let teamId: String?
 
-    init(
-        asAdmin: Bool? = nil,
-        memberIds: [String],
-        teamId: String? = nil
-    ) {
+    init(asAdmin: Bool? = nil, memberIds: [String], teamId: String? = nil) {
         self.asAdmin = asAdmin
         self.memberIds = memberIds
         self.teamId = teamId

--- a/Sources/StreamChat/Generated/OpenAPI/models/AppSettings.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AppSettings.swift
@@ -43,10 +43,7 @@ public final class AppSettings: Sendable, Codable, JSONEncodable {
 }
 
 extension AppSettings: Hashable {
-    public static func == (
-        lhs: AppSettings,
-        rhs: AppSettings
-    ) -> Bool {
+    public static func == (lhs: AppSettings, rhs: AppSettings) -> Bool {
         lhs.asyncUrlEnrichEnabled == rhs.asyncUrlEnrichEnabled &&
             lhs.autoTranslationEnabled == rhs.autoTranslationEnabled &&
             lhs.fileUploadConfig == rhs.fileUploadConfig &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/AttachmentActionPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AttachmentActionPayload.swift
@@ -11,13 +11,7 @@ final class AttachmentActionPayload: Sendable, Codable, JSONEncodable {
     let type: String
     let value: String?
 
-    init(
-        name: String,
-        style: String? = nil,
-        text: String,
-        type: String,
-        value: String? = nil
-    ) {
+    init(name: String, style: String? = nil, text: String, type: String, value: String? = nil) {
         self.name = name
         self.style = style
         self.text = text

--- a/Sources/StreamChat/Generated/OpenAPI/models/AttachmentFieldPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/AttachmentFieldPayload.swift
@@ -9,11 +9,7 @@ final class AttachmentFieldPayload: Sendable, Codable, JSONEncodable {
     let title: String
     let value: String
 
-    init(
-        short: Bool,
-        title: String,
-        value: String
-    ) {
+    init(short: Bool, title: String, value: String) {
         self.short = short
         self.title = title
         self.value = value

--- a/Sources/StreamChat/Generated/OpenAPI/models/BlockUsersResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/BlockUsersResponse.swift
@@ -14,12 +14,7 @@ final class BlockUsersResponse: Sendable, Codable, JSONEncodable {
     /// Duration of the request in milliseconds
     let duration: String
 
-    init(
-        blockedByUserId: String,
-        blockedUserId: String,
-        createdAt: Date,
-        duration: String
-    ) {
+    init(blockedByUserId: String, blockedUserId: String, createdAt: Date, duration: String) {
         self.blockedByUserId = blockedByUserId
         self.blockedUserId = blockedUserId
         self.createdAt = createdAt

--- a/Sources/StreamChat/Generated/OpenAPI/models/ChannelDetailPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/ChannelDetailPayload.swift
@@ -157,8 +157,14 @@ final class ChannelDetailPayload: Sendable, Codable, JSONEncodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        autoTranslationEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoTranslationEnabled)
-        autoTranslationLanguage = try container.decodeIfPresent(String.self, forKey: .autoTranslationLanguage)
+        autoTranslationEnabled = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .autoTranslationEnabled
+        )
+        autoTranslationLanguage = try container.decodeIfPresent(
+            String.self,
+            forKey: .autoTranslationLanguage
+        )
         blocked = try container.decodeIfPresent(Bool.self, forKey: .blocked)
         cid = try container.decode(ChannelId.self, forKey: .cid)
         config = try container.decode(ChannelConfig.self, forKey: .config)
@@ -185,7 +191,10 @@ final class ChannelDetailPayload: Sendable, Codable, JSONEncodable {
         messageCount = try container.decodeIfPresent(Int.self, forKey: .messageCount)
         muteExpiresAt = try container.decodeIfPresent(Date.self, forKey: .muteExpiresAt)
         muted = try container.decodeIfPresent(Bool.self, forKey: .muted)
-        ownCapabilities = try container.decodeIfPresent([ChannelOwnCapability].self, forKey: .ownCapabilities)
+        ownCapabilities = try container.decodeIfPresent(
+            [ChannelOwnCapability].self,
+            forKey: .ownCapabilities
+        )
         team = try container.decodeIfPresent(String.self, forKey: .team)
         truncatedAt = try container.decodeIfPresent(Date.self, forKey: .truncatedAt)
         truncatedBy = try container.decodeIfPresent(UserPayload.self, forKey: .truncatedBy)

--- a/Sources/StreamChat/Generated/OpenAPI/models/CreatePollOptionRequestBody.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/CreatePollOptionRequestBody.swift
@@ -10,10 +10,7 @@ final class CreatePollOptionRequestBody: Sendable, Codable, JSONEncodable {
     /// Option text
     let text: String
 
-    init(
-        custom: [String: RawJSON]? = nil,
-        text: String
-    ) {
+    init(custom: [String: RawJSON]? = nil, text: String) {
         self.custom = custom
         self.text = text
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/DeliveredMessagePayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/DeliveredMessagePayload.swift
@@ -8,10 +8,7 @@ final class DeliveredMessagePayload: Sendable, Codable, JSONEncodable {
     let cid: String?
     let id: String?
 
-    init(
-        cid: String? = nil,
-        id: String? = nil
-    ) {
+    init(cid: String? = nil, id: String? = nil) {
         self.cid = cid
         self.id = id
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/Device.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/Device.swift
@@ -60,10 +60,7 @@ public final class Device: Sendable, Codable, JSONEncodable {
 }
 
 extension Device: Hashable {
-    public static func == (
-        lhs: Device,
-        rhs: Device
-    ) -> Bool {
+    public static func == (lhs: Device, rhs: Device) -> Bool {
         lhs.createdAt == rhs.createdAt &&
             lhs.disabled == rhs.disabled &&
             lhs.disabledReason == rhs.disabledReason &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/FileUploadResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/FileUploadResponse.swift
@@ -10,10 +10,7 @@ final class FileUploadResponse: Sendable, Codable, JSONEncodable {
     /// URL of the file thumbnail for supported file formats. Should be put to `thumb_url` attachment field
     let thumbUrl: String?
 
-    init(
-        file: String? = nil,
-        thumbUrl: String? = nil
-    ) {
+    init(file: String? = nil, thumbUrl: String? = nil) {
         self.file = file
         self.thumbUrl = thumbUrl
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GetApplicationResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GetApplicationResponse.swift
@@ -9,10 +9,7 @@ final class GetApplicationResponse: Sendable, Codable, JSONEncodable {
     /// Duration of the request in milliseconds
     let duration: String
 
-    init(
-        app: AppSettings,
-        duration: String
-    ) {
+    init(app: AppSettings, duration: String) {
         self.app = app
         self.duration = duration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GetBlockedUsersResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GetBlockedUsersResponse.swift
@@ -10,10 +10,7 @@ final class GetBlockedUsersResponse: Sendable, Codable, JSONEncodable {
     /// Duration of the request in milliseconds
     let duration: String
 
-    init(
-        blocks: [BlockedUserResponse],
-        duration: String
-    ) {
+    init(blocks: [BlockedUserResponse], duration: String) {
         self.blocks = blocks
         self.duration = duration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/GiphyImageData.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/GiphyImageData.swift
@@ -11,13 +11,7 @@ final class GiphyImageData: Sendable, Codable, JSONEncodable {
     let url: String
     let width: String
 
-    init(
-        frames: String,
-        height: String,
-        size: String,
-        url: String,
-        width: String
-    ) {
+    init(frames: String, height: String, size: String, url: String, width: String) {
         self.frames = frames
         self.height = height
         self.size = size

--- a/Sources/StreamChat/Generated/OpenAPI/models/ImageSize.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/ImageSize.swift
@@ -14,12 +14,7 @@ final class ImageSize: Sendable, Codable, JSONEncodable {
     /// Target image width
     let width: Int?
 
-    init(
-        crop: String? = nil,
-        height: Int? = nil,
-        resize: String? = nil,
-        width: Int? = nil
-    ) {
+    init(crop: String? = nil, height: Int? = nil, resize: String? = nil, width: Int? = nil) {
         self.crop = crop
         self.height = height
         self.resize = resize

--- a/Sources/StreamChat/Generated/OpenAPI/models/ListDevicesResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/ListDevicesResponse.swift
@@ -9,10 +9,7 @@ final class ListDevicesResponse: Sendable, Codable, JSONEncodable {
     let devices: [Device]
     let duration: String
 
-    init(
-        devices: [Device],
-        duration: String
-    ) {
+    init(devices: [Device], duration: String) {
         self.devices = devices
         self.duration = duration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/ListUserGroupsResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/ListUserGroupsResponse.swift
@@ -9,10 +9,7 @@ final class ListUserGroupsResponse: Sendable, Codable, JSONEncodable {
     /// List of user groups
     let userGroups: [UserGroup]
 
-    init(
-        duration: String,
-        userGroups: [UserGroup]
-    ) {
+    init(duration: String, userGroups: [UserGroup]) {
         self.duration = duration
         self.userGroups = userGroups
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/MemberPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/MemberPayload.swift
@@ -123,7 +123,10 @@ final class MemberPayload: Sendable, Codable, JSONEncodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         archivedAt = try container.decodeIfPresent(Date.self, forKey: .archivedAt)
         banExpires = try container.decodeIfPresent(Date.self, forKey: .banExpires)
-        banFromFutureChannels = try container.decodeIfPresent(Bool.self, forKey: .banFromFutureChannels)
+        banFromFutureChannels = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .banFromFutureChannels
+        )
         banned = try container.decodeIfPresent(Bool.self, forKey: .banned)
         channelRole = try container.decodeIfPresent(String.self, forKey: .channelRole)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
@@ -136,7 +139,10 @@ final class MemberPayload: Sendable, Codable, JSONEncodable {
         }
         deletedAt = try container.decodeIfPresent(Date.self, forKey: .deletedAt)
         deletedMessages = try container.decodeIfPresent([String].self, forKey: .deletedMessages)
-        futureChannelBanExpires = try container.decodeIfPresent(Date.self, forKey: .futureChannelBanExpires)
+        futureChannelBanExpires = try container.decodeIfPresent(
+            Date.self,
+            forKey: .futureChannelBanExpires
+        )
         inviteAcceptedAt = try container.decodeIfPresent(Date.self, forKey: .inviteAcceptedAt)
         inviteRejectedAt = try container.decodeIfPresent(Date.self, forKey: .inviteRejectedAt)
         invited = try container.decodeIfPresent(Bool.self, forKey: .invited)

--- a/Sources/StreamChat/Generated/OpenAPI/models/MembersResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/MembersResponse.swift
@@ -10,10 +10,7 @@ final class MembersResponse: Sendable, Codable, JSONEncodable {
     /// List of found members
     let members: [MemberPayload]
 
-    init(
-        duration: String,
-        members: [MemberPayload]
-    ) {
+    init(duration: String, members: [MemberPayload]) {
         self.duration = duration
         self.members = members
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/MuteChannelRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/MuteChannelRequest.swift
@@ -10,10 +10,7 @@ final class MuteChannelRequest: Sendable, Codable, JSONEncodable {
     /// Duration of mute in milliseconds
     let expiration: Int?
 
-    init(
-        channelCids: [String]? = nil,
-        expiration: Int? = nil
-    ) {
+    init(channelCids: [String]? = nil, expiration: Int? = nil) {
         self.channelCids = channelCids
         self.expiration = expiration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/MuteRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/MuteRequest.swift
@@ -10,10 +10,7 @@ final class MuteRequest: Sendable, Codable, JSONEncodable {
     /// Duration of mute in minutes
     let timeout: Int?
 
-    init(
-        targetIds: [String],
-        timeout: Int? = nil
-    ) {
+    init(targetIds: [String], timeout: Int? = nil) {
         self.targetIds = targetIds
         self.timeout = timeout
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/OwnUserResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/OwnUserResponse.swift
@@ -139,7 +139,10 @@ final class OwnUserResponse: Sendable, Codable, JSONEncodable {
         avgResponseTime = try container.decodeIfPresent(Int.self, forKey: .avgResponseTime)
         banned = try container.decodeIfPresent(Bool.self, forKey: .banned)
         blockedUserIds = try container.decodeIfPresent([String].self, forKey: .blockedUserIds)
-        channelMutes = try container.decodeIfPresent([MutedChannelPayload].self, forKey: .channelMutes)
+        channelMutes = try container.decodeIfPresent(
+            [MutedChannelPayload].self,
+            forKey: .channelMutes
+        )
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         if let decoded = try container.decodeIfPresent([String: RawJSON].self, forKey: .custom) {
             custom = decoded
@@ -156,18 +159,33 @@ final class OwnUserResponse: Sendable, Codable, JSONEncodable {
         invisible = try container.decodeIfPresent(Bool.self, forKey: .invisible)
         language = try container.decodeIfPresent(String.self, forKey: .language)
         lastActive = try container.decodeIfPresent(Date.self, forKey: .lastActive)
-        latestHiddenChannels = try container.decodeIfPresent([String].self, forKey: .latestHiddenChannels)
+        latestHiddenChannels = try container.decodeIfPresent(
+            [String].self,
+            forKey: .latestHiddenChannels
+        )
         mutes = try container.decodeIfPresent([MutedUserPayload].self, forKey: .mutes)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         online = try container.decode(Bool.self, forKey: .online)
-        privacySettings = try container.decodeIfPresent(UserPrivacySettings.self, forKey: .privacySettings)
-        pushPreferences = try container.decodeIfPresent(PushPreference.self, forKey: .pushPreferences)
-        revokeTokensIssuedBefore = try container.decodeIfPresent(Date.self, forKey: .revokeTokensIssuedBefore)
+        privacySettings = try container.decodeIfPresent(
+            UserPrivacySettings.self,
+            forKey: .privacySettings
+        )
+        pushPreferences = try container.decodeIfPresent(
+            PushPreference.self,
+            forKey: .pushPreferences
+        )
+        revokeTokensIssuedBefore = try container.decodeIfPresent(
+            Date.self,
+            forKey: .revokeTokensIssuedBefore
+        )
         role = try container.decode(String.self, forKey: .role)
         teams = try container.decodeIfPresent([String].self, forKey: .teams)
         teamsRole = try container.decodeIfPresent([String: String].self, forKey: .teamsRole)
         totalUnreadCount = try container.decodeIfPresent(Int.self, forKey: .totalUnreadCount)
-        totalUnreadCountByTeam = try container.decodeIfPresent([String: Int].self, forKey: .totalUnreadCountByTeam)
+        totalUnreadCountByTeam = try container.decodeIfPresent(
+            [String: Int].self,
+            forKey: .totalUnreadCountByTeam
+        )
         unreadChannels = try container.decodeIfPresent(Int.self, forKey: .unreadChannels)
         unreadThreads = try container.decodeIfPresent(Int.self, forKey: .unreadThreads)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)

--- a/Sources/StreamChat/Generated/OpenAPI/models/PollOptionPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PollOptionPayload.swift
@@ -9,11 +9,7 @@ final class PollOptionPayload: Sendable, Codable, JSONEncodable {
     let id: String
     let text: String
 
-    init(
-        custom: [String: RawJSON]? = nil,
-        id: String,
-        text: String
-    ) {
+    init(custom: [String: RawJSON]? = nil, id: String, text: String) {
         self.custom = custom
         self.id = id
         self.text = text

--- a/Sources/StreamChat/Generated/OpenAPI/models/PollOptionRequestBody.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PollOptionRequestBody.swift
@@ -8,10 +8,7 @@ final class PollOptionRequestBody: Sendable, Codable, JSONEncodable {
     let custom: [String: RawJSON]?
     let text: String?
 
-    init(
-        custom: [String: RawJSON]? = nil,
-        text: String? = nil
-    ) {
+    init(custom: [String: RawJSON]? = nil, text: String? = nil) {
         self.custom = custom
         self.text = text
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/PollOptionResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PollOptionResponse.swift
@@ -9,10 +9,7 @@ final class PollOptionResponse: Sendable, Codable, JSONEncodable {
     let duration: String
     let pollOption: PollOptionPayload
 
-    init(
-        duration: String,
-        pollOption: PollOptionPayload
-    ) {
+    init(duration: String, pollOption: PollOptionPayload) {
         self.duration = duration
         self.pollOption = pollOption
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/PollPayloadResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PollPayloadResponse.swift
@@ -9,10 +9,7 @@ final class PollPayloadResponse: Sendable, Codable, JSONEncodable {
     let duration: String
     let poll: PollPayload
 
-    init(
-        duration: String,
-        poll: PollPayload
-    ) {
+    init(duration: String, poll: PollPayload) {
         self.duration = duration
         self.poll = poll
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/PollVoteListResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PollVoteListResponse.swift
@@ -12,12 +12,7 @@ final class PollVoteListResponse: Sendable, Codable, JSONEncodable {
     /// Poll votes
     let votes: [PollVotePayload?]
 
-    init(
-        duration: String,
-        next: String? = nil,
-        prev: String? = nil,
-        votes: [PollVotePayload?]
-    ) {
+    init(duration: String, next: String? = nil, prev: String? = nil, votes: [PollVotePayload?]) {
         self.duration = duration
         self.next = next
         self.prev = prev

--- a/Sources/StreamChat/Generated/OpenAPI/models/PollVotePayloadResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PollVotePayloadResponse.swift
@@ -10,11 +10,7 @@ final class PollVotePayloadResponse: Sendable, Codable, JSONEncodable {
     let poll: PollPayload?
     let vote: PollVotePayload?
 
-    init(
-        duration: String,
-        poll: PollPayload? = nil,
-        vote: PollVotePayload? = nil
-    ) {
+    init(duration: String, poll: PollPayload? = nil, vote: PollVotePayload? = nil) {
         self.duration = duration
         self.poll = poll
         self.vote = vote

--- a/Sources/StreamChat/Generated/OpenAPI/models/PushPreference.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PushPreference.swift
@@ -9,10 +9,7 @@ public final class PushPreference: Sendable, Codable, JSONEncodable {
     public var level: PushPreferenceLevel { _level ?? .all }
     public let disabledUntil: Date?
 
-    init(
-        level: PushPreferenceLevel? = nil,
-        disabledUntil: Date? = nil
-    ) {
+    init(level: PushPreferenceLevel? = nil, disabledUntil: Date? = nil) {
         self._level = level
         self.disabledUntil = disabledUntil
     }
@@ -24,10 +21,7 @@ public final class PushPreference: Sendable, Codable, JSONEncodable {
 }
 
 extension PushPreference: Hashable {
-    public static func == (
-        lhs: PushPreference,
-        rhs: PushPreference
-    ) -> Bool {
+    public static func == (lhs: PushPreference, rhs: PushPreference) -> Bool {
         lhs.level == rhs.level &&
             lhs.disabledUntil == rhs.disabledUntil
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/PushPreferenceInput.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/PushPreferenceInput.swift
@@ -60,10 +60,7 @@ final class PushPreferenceInput: Sendable, Codable, JSONEncodable {
 }
 
 extension PushPreferenceInput: Hashable {
-    static func == (
-        lhs: PushPreferenceInput,
-        rhs: PushPreferenceInput
-    ) -> Bool {
+    static func == (lhs: PushPreferenceInput, rhs: PushPreferenceInput) -> Bool {
         lhs.channelCid == rhs.channelCid &&
             lhs.chatLevel == rhs.chatLevel &&
             lhs.disabledUntil == rhs.disabledUntil &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/QueryMembersPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/QueryMembersPayload.swift
@@ -45,33 +45,12 @@ final class QueryMembersPayload: Sendable, Encodable, JSONEncodable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(
-            filterConditions,
-            forKey: .filterConditions
-        )
-        try container.encodeIfPresent(
-            id,
-            forKey: .id
-        )
-        try container.encodeIfPresent(
-            limit,
-            forKey: .limit
-        )
-        try container.encodeIfPresent(
-            members,
-            forKey: .members
-        )
-        try container.encodeIfPresent(
-            offset,
-            forKey: .offset
-        )
-        try container.encodeIfPresent(
-            sort,
-            forKey: .sort
-        )
-        try container.encode(
-            type,
-            forKey: .type
-        )
+        try container.encode(filterConditions, forKey: .filterConditions)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(limit, forKey: .limit)
+        try container.encodeIfPresent(members, forKey: .members)
+        try container.encodeIfPresent(offset, forKey: .offset)
+        try container.encodeIfPresent(sort, forKey: .sort)
+        try container.encode(type, forKey: .type)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/QueryPollVotesRequestBody.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/QueryPollVotesRequestBody.swift
@@ -38,26 +38,11 @@ final class QueryPollVotesRequestBody: Sendable, Encodable, JSONEncodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if let filter {
-            try container.encode(
-                filter,
-                forKey: .filter
-            )
+            try container.encode(filter, forKey: .filter)
         }
-        try container.encodeIfPresent(
-            limit,
-            forKey: .limit
-        )
-        try container.encodeIfPresent(
-            next,
-            forKey: .next
-        )
-        try container.encodeIfPresent(
-            prev,
-            forKey: .prev
-        )
-        try container.encodeIfPresent(
-            sort,
-            forKey: .sort
-        )
+        try container.encodeIfPresent(limit, forKey: .limit)
+        try container.encodeIfPresent(next, forKey: .next)
+        try container.encodeIfPresent(prev, forKey: .prev)
+        try container.encodeIfPresent(sort, forKey: .sort)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/QueryReactionsRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/QueryReactionsRequest.swift
@@ -38,26 +38,11 @@ final class QueryReactionsRequest: Sendable, Encodable, JSONEncodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if let filter {
-            try container.encode(
-                filter,
-                forKey: .filter
-            )
+            try container.encode(filter, forKey: .filter)
         }
-        try container.encodeIfPresent(
-            limit,
-            forKey: .limit
-        )
-        try container.encodeIfPresent(
-            next,
-            forKey: .next
-        )
-        try container.encodeIfPresent(
-            prev,
-            forKey: .prev
-        )
-        try container.encodeIfPresent(
-            sort,
-            forKey: .sort
-        )
+        try container.encodeIfPresent(limit, forKey: .limit)
+        try container.encodeIfPresent(next, forKey: .next)
+        try container.encodeIfPresent(prev, forKey: .prev)
+        try container.encodeIfPresent(sort, forKey: .sort)
     }
 }

--- a/Sources/StreamChat/Generated/OpenAPI/models/RemoveUserGroupMembersRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/RemoveUserGroupMembersRequest.swift
@@ -9,10 +9,7 @@ final class RemoveUserGroupMembersRequest: Sendable, Codable, JSONEncodable {
     let memberIds: [String]
     let teamId: String?
 
-    init(
-        memberIds: [String],
-        teamId: String? = nil
-    ) {
+    init(memberIds: [String], teamId: String? = nil) {
         self.memberIds = memberIds
         self.teamId = teamId
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/Role.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/Role.swift
@@ -40,10 +40,7 @@ public final class Role: Sendable, Codable, JSONEncodable {
 }
 
 extension Role: Hashable {
-    public static func == (
-        lhs: Role,
-        rhs: Role
-    ) -> Bool {
+    public static func == (lhs: Role, rhs: Role) -> Bool {
         lhs.createdAt == rhs.createdAt &&
             lhs.custom == rhs.custom &&
             lhs.name == rhs.name &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/SearchRolesResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/SearchRolesResponse.swift
@@ -9,10 +9,7 @@ final class SearchRolesResponse: Sendable, Codable, JSONEncodable {
     /// Matching roles, sorted ascending by name
     let roles: [Role]
 
-    init(
-        duration: String,
-        roles: [Role]
-    ) {
+    init(duration: String, roles: [Role]) {
         self.duration = duration
         self.roles = roles
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/SharedLocation.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/SharedLocation.swift
@@ -51,10 +51,7 @@ public final class SharedLocation: Sendable, Codable, JSONEncodable {
 }
 
 extension SharedLocation: Hashable {
-    public static func == (
-        lhs: SharedLocation,
-        rhs: SharedLocation
-    ) -> Bool {
+    public static func == (lhs: SharedLocation, rhs: SharedLocation) -> Bool {
         lhs.channelCid == rhs.channelCid &&
             lhs.createdAt == rhs.createdAt &&
             lhs.createdByDeviceId == rhs.createdByDeviceId &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/SortParamRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/SortParamRequest.swift
@@ -12,11 +12,7 @@ final class SortParamRequest: Sendable, Codable, JSONEncodable {
     /// Type of field to sort by. Empty string or omitted means string type (default). One of: number, boolean
     let type: String?
 
-    init(
-        direction: Int? = nil,
-        field: String? = nil,
-        type: String? = nil
-    ) {
+    init(direction: Int? = nil, field: String? = nil, type: String? = nil) {
         self.direction = direction
         self.field = field
         self.type = type

--- a/Sources/StreamChat/Generated/OpenAPI/models/UnmuteChannelRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UnmuteChannelRequest.swift
@@ -10,10 +10,7 @@ final class UnmuteChannelRequest: Sendable, Codable, JSONEncodable {
     /// Duration of mute in milliseconds
     let expiration: Int?
 
-    init(
-        channelCids: [String]? = nil,
-        expiration: Int? = nil
-    ) {
+    init(channelCids: [String]? = nil, expiration: Int? = nil) {
         self.channelCids = channelCids
         self.expiration = expiration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UnreadChannel.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UnreadChannel.swift
@@ -9,11 +9,7 @@ public final class UnreadChannel: Sendable, Codable, JSONEncodable {
     public let lastRead: Date?
     public let unreadCount: Int
 
-    init(
-        channelId: ChannelId,
-        lastRead: Date? = nil,
-        unreadCount: Int
-    ) {
+    init(channelId: ChannelId, lastRead: Date? = nil, unreadCount: Int) {
         self.channelId = channelId
         self.lastRead = lastRead
         self.unreadCount = unreadCount

--- a/Sources/StreamChat/Generated/OpenAPI/models/UnreadChannelByType.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UnreadChannelByType.swift
@@ -9,11 +9,7 @@ public final class UnreadChannelByType: Sendable, Codable, JSONEncodable {
     public let channelType: ChannelType
     public let unreadCount: Int
 
-    init(
-        channelCount: Int,
-        channelType: ChannelType,
-        unreadCount: Int
-    ) {
+    init(channelCount: Int, channelType: ChannelType, unreadCount: Int) {
         self.channelCount = channelCount
         self.channelType = channelType
         self.unreadCount = unreadCount

--- a/Sources/StreamChat/Generated/OpenAPI/models/UpdateLiveLocationRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UpdateLiveLocationRequest.swift
@@ -14,12 +14,7 @@ final class UpdateLiveLocationRequest: Sendable, Codable, JSONEncodable {
     /// Live location ID
     let messageId: String
 
-    init(
-        endAt: Date? = nil,
-        latitude: Double? = nil,
-        longitude: Double? = nil,
-        messageId: String
-    ) {
+    init(endAt: Date? = nil, latitude: Double? = nil, longitude: Double? = nil, messageId: String) {
         self.endAt = endAt
         self.latitude = latitude
         self.longitude = longitude

--- a/Sources/StreamChat/Generated/OpenAPI/models/UpdateMemberPartialRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UpdateMemberPartialRequest.swift
@@ -8,10 +8,7 @@ final class UpdateMemberPartialRequest: Sendable, Codable, JSONEncodable {
     let set: [String: RawJSON]?
     let unset: [String]?
 
-    init(
-        set: [String: RawJSON]? = nil,
-        unset: [String]? = nil
-    ) {
+    init(set: [String: RawJSON]? = nil, unset: [String]? = nil) {
         self.set = set
         self.unset = unset
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UpdateMemberPartialResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UpdateMemberPartialResponse.swift
@@ -9,10 +9,7 @@ final class UpdateMemberPartialResponse: Sendable, Codable, JSONEncodable {
     /// Duration of the request in milliseconds
     let duration: String
 
-    init(
-        channelMember: MemberPayload? = nil,
-        duration: String
-    ) {
+    init(channelMember: MemberPayload? = nil, duration: String) {
         self.channelMember = channelMember
         self.duration = duration
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UpdatePollPartialRequestBody.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UpdatePollPartialRequestBody.swift
@@ -10,10 +10,7 @@ final class UpdatePollPartialRequestBody: Sendable, Codable, JSONEncodable {
     /// Array of field names to unset
     let unset: [String]?
 
-    init(
-        set: [String: RawJSON]? = nil,
-        unset: [String]? = nil
-    ) {
+    init(set: [String: RawJSON]? = nil, unset: [String]? = nil) {
         self.set = set
         self.unset = unset
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UpdateUserGroupRequest.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UpdateUserGroupRequest.swift
@@ -11,11 +11,7 @@ final class UpdateUserGroupRequest: Sendable, Codable, JSONEncodable {
     let name: String?
     let teamId: String?
 
-    init(
-        description: String? = nil,
-        name: String? = nil,
-        teamId: String? = nil
-    ) {
+    init(description: String? = nil, name: String? = nil, teamId: String? = nil) {
         self.description = description
         self.name = name
         self.teamId = teamId

--- a/Sources/StreamChat/Generated/OpenAPI/models/UploadConfig.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UploadConfig.swift
@@ -35,10 +35,7 @@ public final class UploadConfig: Sendable, Codable, JSONEncodable {
 }
 
 extension UploadConfig: Hashable {
-    public static func == (
-        lhs: UploadConfig,
-        rhs: UploadConfig
-    ) -> Bool {
+    public static func == (lhs: UploadConfig, rhs: UploadConfig) -> Bool {
         lhs.allowedFileExtensions == rhs.allowedFileExtensions &&
             lhs.allowedMimeTypes == rhs.allowedMimeTypes &&
             lhs.blockedFileExtensions == rhs.blockedFileExtensions &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/UserGroup.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UserGroup.swift
@@ -48,10 +48,7 @@ public final class UserGroup: Sendable, Codable, JSONEncodable {
 }
 
 extension UserGroup: Hashable {
-    public static func == (
-        lhs: UserGroup,
-        rhs: UserGroup
-    ) -> Bool {
+    public static func == (lhs: UserGroup, rhs: UserGroup) -> Bool {
         lhs.createdAt == rhs.createdAt &&
             lhs.createdBy == rhs.createdBy &&
             lhs.description == rhs.description &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/UserGroupMember.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UserGroupMember.swift
@@ -10,12 +10,7 @@ public final class UserGroupMember: Sendable, Codable, JSONEncodable {
     public let isAdmin: Bool
     public let userId: String
 
-    init(
-        createdAt: Date,
-        groupId: String,
-        isAdmin: Bool,
-        userId: String
-    ) {
+    init(createdAt: Date, groupId: String, isAdmin: Bool, userId: String) {
         self.createdAt = createdAt
         self.groupId = groupId
         self.isAdmin = isAdmin
@@ -31,10 +26,7 @@ public final class UserGroupMember: Sendable, Codable, JSONEncodable {
 }
 
 extension UserGroupMember: Hashable {
-    public static func == (
-        lhs: UserGroupMember,
-        rhs: UserGroupMember
-    ) -> Bool {
+    public static func == (lhs: UserGroupMember, rhs: UserGroupMember) -> Bool {
         lhs.createdAt == rhs.createdAt &&
             lhs.groupId == rhs.groupId &&
             lhs.isAdmin == rhs.isAdmin &&

--- a/Sources/StreamChat/Generated/OpenAPI/models/UserGroupResponse.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UserGroupResponse.swift
@@ -8,10 +8,7 @@ final class UserGroupResponse: Sendable, Codable, JSONEncodable {
     let duration: String
     let userGroup: UserGroup?
 
-    init(
-        duration: String,
-        userGroup: UserGroup? = nil
-    ) {
+    init(duration: String, userGroup: UserGroup? = nil) {
         self.duration = duration
         self.userGroup = userGroup
     }

--- a/Sources/StreamChat/Generated/OpenAPI/models/UserPayload.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/UserPayload.swift
@@ -120,7 +120,10 @@ final class UserPayload: Sendable, Codable, JSONEncodable {
         lastActive = try container.decodeIfPresent(Date.self, forKey: .lastActive)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         online = try container.decode(Bool.self, forKey: .online)
-        revokeTokensIssuedBefore = try container.decodeIfPresent(Date.self, forKey: .revokeTokensIssuedBefore)
+        revokeTokensIssuedBefore = try container.decodeIfPresent(
+            Date.self,
+            forKey: .revokeTokensIssuedBefore
+        )
         role = try container.decode(String.self, forKey: .role)
         teams = try container.decodeIfPresent([String].self, forKey: .teams)
         teamsRole = try container.decodeIfPresent([String: String].self, forKey: .teamsRole)

--- a/Sources/StreamChat/Generated/OpenAPI/models/VoteDataRequestBody.swift
+++ b/Sources/StreamChat/Generated/OpenAPI/models/VoteDataRequestBody.swift
@@ -8,10 +8,7 @@ final class VoteDataRequestBody: Sendable, Codable, JSONEncodable {
     let answerText: String?
     let optionId: String?
 
-    init(
-        answerText: String? = nil,
-        optionId: String? = nil
-    ) {
+    init(answerText: String? = nil, optionId: String? = nil) {
         self.answerText = answerText
         self.optionId = optionId
     }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1952](https://linear.app/stream/issue/IOS-1952)

### 🎯 Goal

Reformat generated code because the line limit made it very ugly

### 📝 Summary

* Reformat
* Cleanup unused remove
* Cleanup not needed unfinalize step

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated API code cleanup by removing obsolete property references and resolving dangling expressions.
  * Ensured upload response duration fields are removed consistently.
  * Improved formatting of generated decoder code for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->