### PR TITLE
Fix rare crashes in `DataController.state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix rare crashes in `DataController.state` [#4248](https://github.com/GetStream/stream-chat-swift/pull/4248)
 
 # [5.10.0](https://github.com/GetStream/stream-chat-swift/releases/tag/5.10.0)
 _August 27, 2026_

--- a/Sources/StreamChat/Controllers/DataController.swift
+++ b/Sources/StreamChat/Controllers/DataController.swift
@@ -20,9 +20,13 @@ public class DataController: Controller, @unchecked Sendable {
         case remoteDataFetchFailed(ClientError)
     }
 
+    @Atomic private var _state: State = .initialized
+
     /// The current state of the controller.
-    public internal(set) var state: State = .initialized {
-        didSet {
+    public internal(set) var state: State {
+        get { _state }
+        set {
+            _state = newValue
             callback {
                 self.stateMulticastDelegate.invoke { $0.controller(self, didChangeState: self.state) }
             }

--- a/Tests/StreamChatTests/DataController_Tests.swift
+++ b/Tests/StreamChatTests/DataController_Tests.swift
@@ -55,4 +55,20 @@ final class DataController_Tests: XCTestCase {
         controller.state = .localDataFetchFailed(ClientError(""))
         XCTAssertFalse(controller.canBeRecovered)
     }
+
+    func test_state_whenAccessedConcurrently_doesNotCrash() {
+        let controller = DataController()
+        let iterations = 1000
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            if index.isMultiple(of: 2) {
+                controller.state = .remoteDataFetchFailed(ClientError("Failed \(index)"))
+            } else {
+                _ = controller.state
+                _ = controller.canBeRecovered
+            }
+        }
+
+        XCTAssertTrue(controller.canBeRecovered)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1985](https://linear.app/stream/issue/IOS-1985)

### 🎯 Goal

Make `DataController.state` thread safe

### 📝 Summary

Add Atomic to guard internal state (easy for cherry-picking to v4)

### 🛠 Implementation

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rare crashes that could occur when accessing controller state concurrently.
  * Improved reliability when updating and reading recovery-related state.

* **Tests**
  * Added coverage for concurrent state access and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->