### PR TITLE
[v4] Fix rare crashes in `DataController.state`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix rare crashes in `DataController.state` [#4248](https://github.com/GetStream/stream-chat-swift/pull/4248)
 
 # [4.102.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.102.0)
 _July 23, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🐞 Fixed
-- Fix rare crashes in `DataController.state` [#4248](https://github.com/GetStream/stream-chat-swift/pull/4248)
+- Fix rare crashes in `DataController.state` [#4251](https://github.com/GetStream/stream-chat-swift/pull/4251)
 
 # [4.102.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.102.0)
 _July 23, 2026_

--- a/Sources/StreamChat/Controllers/DataController.swift
+++ b/Sources/StreamChat/Controllers/DataController.swift
@@ -20,9 +20,13 @@ public class DataController: Controller {
         case remoteDataFetchFailed(ClientError)
     }
 
+    @Atomic private var _state: State = .initialized
+
     /// The current state of the controller.
-    public internal(set) var state: State = .initialized {
-        didSet {
+    public internal(set) var state: State {
+        get { _state }
+        set {
+            _state = newValue
             callback {
                 self.stateMulticastDelegate.invoke { $0.controller(self, didChangeState: self.state) }
             }

--- a/Tests/StreamChatTests/DataController_Tests.swift
+++ b/Tests/StreamChatTests/DataController_Tests.swift
@@ -57,4 +57,20 @@ final class DataController_Tests: XCTestCase {
         controller.state = .localDataFetchFailed(ClientError(""))
         XCTAssertFalse(controller.canBeRecovered)
     }
+
+    func test_state_whenAccessedConcurrently_doesNotCrash() {
+        let controller = DataController()
+        let iterations = 1000
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            if index.isMultiple(of: 2) {
+                controller.state = .remoteDataFetchFailed(ClientError("Failed \(index)"))
+            } else {
+                _ = controller.state
+                _ = controller.canBeRecovered
+            }
+        }
+
+        XCTAssertTrue(controller.canBeRecovered)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1985](https://linear.app/stream/issue/IOS-1985)

### 🎯 Goal

Make `DataController.state` thread safe on the v4 branch.

### 📝 Summary

Backport of #4248 to v4: add Atomic to guard internal state

### 🛠 Implementation

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
