### PR TITLE
Remove invalid @retroactive Equatable in StreamChatTestTools

### DIFF
--- a/TestTools/StreamChatTestTools/Extensions/AnyEncodable+Equatable.swift
+++ b/TestTools/StreamChatTestTools/Extensions/AnyEncodable+Equatable.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import StreamChat
 
-extension AnyEncodable: @retroactive Equatable {
+extension AnyEncodable: Equatable {
     public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
         do {
             let encoder = JSONEncoder.default

--- a/TestTools/StreamChatTestTools/Extensions/ChannelListQuery+Equatable.swift
+++ b/TestTools/StreamChatTestTools/Extensions/ChannelListQuery+Equatable.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import StreamChat
 
-extension ChannelListQuery: @retroactive Equatable {
+extension ChannelListQuery: Equatable {
     public static func == (lhs: ChannelListQuery, rhs: ChannelListQuery) -> Bool {
         lhs.filter == rhs.filter &&
             lhs.messagesLimit == rhs.messagesLimit &&

--- a/TestTools/StreamChatTestTools/Extensions/CleanUpTypingEvent+Equatable.swift
+++ b/TestTools/StreamChatTestTools/Extensions/CleanUpTypingEvent+Equatable.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import StreamChat
 
-extension CleanUpTypingEvent: @retroactive Equatable {
+extension CleanUpTypingEvent: Equatable {
     public static func == (lhs: CleanUpTypingEvent, rhs: CleanUpTypingEvent) -> Bool {
         lhs.cid == rhs.cid && lhs.userId == rhs.userId
     }

--- a/TestTools/StreamChatTestTools/Extensions/EndpoinPath+Equatable.swift
+++ b/TestTools/StreamChatTestTools/Extensions/EndpoinPath+Equatable.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import StreamChat
 
-extension EndpointPath: @retroactive Equatable {
+extension EndpointPath: Equatable {
     public static func == (_ lhs: EndpointPath, _ rhs: EndpointPath) -> Bool {
         switch (lhs, rhs) {
         case (.connect, .connect): return true

--- a/TestTools/StreamChatTestTools/Extensions/Unique/TypingEventDTO+Unique.swift
+++ b/TestTools/StreamChatTestTools/Extensions/Unique/TypingEventDTO+Unique.swift
@@ -43,7 +43,7 @@ extension TypingEventDTO {
     }
 }
 
-extension TypingEventDTO: @retroactive Equatable {
+extension TypingEventDTO: Equatable {
     public static func == (lhs: TypingEventDTO, rhs: TypingEventDTO) -> Bool {
         lhs.isTyping == rhs.isTyping && lhs.cid == rhs.cid && lhs.user.id == rhs.user.id
     }

--- a/TestTools/StreamChatTestTools/Extensions/WebSocketEngineError+Equatable.swift
+++ b/TestTools/StreamChatTestTools/Extensions/WebSocketEngineError+Equatable.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import StreamChat
 
-extension WebSocketEngineError: @retroactive Equatable {
+extension WebSocketEngineError: Equatable {
     public static func == (lhs: WebSocketEngineError, rhs: WebSocketEngineError) -> Bool {
         String(describing: lhs) == String(describing: rhs)
     }

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/Attachments/AnyAttachmentPayload_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/Attachments/AnyAttachmentPayload_Mock.swift
@@ -38,7 +38,7 @@ public extension AnyAttachmentPayload {
     }
 }
 
-extension AnyAttachmentPayload: @retroactive Equatable {
+extension AnyAttachmentPayload: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         let lhsData = try! JSONEncoder.default.encode(lhs.payload.asAnyEncodable)
         let lhsJSON = try! JSONDecoder.default.decode(RawJSON.self, from: lhsData)

--- a/TestTools/StreamChatTestTools/TestData/FilterTestScope.swift
+++ b/TestTools/StreamChatTestTools/TestData/FilterTestScope.swift
@@ -19,7 +19,7 @@ extension FilterKey where Scope == FilterTestScope {
     static var testKeyArrayDouble: FilterKey<Scope, Double> { "test_key_ArrayDouble" }
 }
 
-extension Filter: @retroactive Equatable {
+extension Filter: Equatable {
     public static func == (lhs: Filter<Scope>, rhs: Filter<Scope>) -> Bool {
         String(describing: lhs) == String(describing: rhs)
     }


### PR DESCRIPTION
### 🔗 Issue Links

- Blocks SwiftUI: https://github.com/GetStream/stream-chat-swiftui/pull/1590
- Introduced by [#4253](https://github.com/GetStream/stream-chat-swift/pull/4253)

### 🎯 Goal

`StreamChatTestTools` Equatable extensions use `@retroactive` on types imported with `@testable import StreamChat`. That attribute is invalid in this setup and fails SPM clients (SwiftUI) on Xcode 16.1 with `'retroactive' attribute does not apply; 'Equatable' is declared in this module`.

### 📝 Summary

- Remove `@retroactive` from Equatable extensions in `StreamChatTestTools` so they match the `@testable import StreamChat` module relationship.

### 🛠 Implementation

These files all `@testable import StreamChat`. With `@testable`, the compiler treats the StreamChat types as same-module for retroactive-conformance checking, so `@retroactive` is rejected. The conformances themselves are unchanged; only the invalid attribute is removed.

### 🎨 Showcase

N/A — test-only compile fix.

### 🧪 Manual Testing Notes

N/A. Covered by compiling StreamChatTestTools via SPM (SwiftUI smoke checks).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes (n/a - test tools only)
- [x] Changelog is updated with new localization keys (n/a - no new strings)
- [x] New code is covered by unit tests (n/a - compile fix)
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test utilities and mock models to use standard equality conformance declarations.
  - Preserved existing equality behavior while removing retroactive conformance annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->